### PR TITLE
Fix journal/dirent robustness and clone warnings

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -2,8 +2,8 @@
 	"servers": {
 		"mcp-shell-server": {
 			"type": "stdio",
-			"command": "mcp-shell-server",
-			"args": []
+			"command": "npx",
+			"args": ["-y", "@mako10k/mcp-shell-server@latest"]
 		}
 	},
 	"inputs": []

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,7 +17,32 @@
 "editor.detectIndentation": false,
 "chat.mcp.serverSampling": {
         "kafs/.vscode/mcp.json: mcp-shell-server": {
-                "allowedDuringChat": true
+                "allowedDuringChat": true,
+                "allowedModels": [
+                        "copilot/gpt-5.2-codex",
+                        "copilot/auto",
+                        "copilot/claude-haiku-4.5",
+                        "copilot/claude-opus-41",
+                        "copilot/claude-opus-4.5",
+                        "copilot/claude-opus-4.6",
+                        "copilot/claude-sonnet-4",
+                        "copilot/claude-sonnet-4.5",
+                        "copilot/gemini-2.5-pro",
+                        "copilot/gemini-3-flash-preview",
+                        "copilot/gemini-3-pro-preview",
+                        "copilot/gpt-4.1",
+                        "copilot/gpt-4o",
+                        "copilot/gpt-5",
+                        "copilot/gpt-5-mini",
+                        "copilot/gpt-5-codex",
+                        "copilot/gpt-5.1",
+                        "copilot/gpt-5.1-codex",
+                        "copilot/gpt-5.1-codex-max",
+                        "copilot/gpt-5.1-codex-mini",
+                        "copilot/gpt-5.2",
+                        "copilot/grok-code-fast-1",
+                        "copilot/oswe-vscode-prime"
+                ]
         }
 }
 }

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -27,15 +27,15 @@
 ### Individual Tests
 
 ```bash
-./scripts/test-git-operations.sh  # Test 1: Git workflow reproduction
-./test-hooks-direct.sh            # Test 2: Hook functions verification
-./test-fresh-image-git-fsck.sh    # Test 3: Complete scenario
+./scripts/test-git-operations.sh        # Test 1: Git workflow reproduction
+./scripts/test-hooks-direct.sh          # Test 2: Hook functions verification
+./scripts/test-fresh-image-git-fsck.sh  # Test 3: Complete scenario
 ```
 
 ### Master Test Runner
 
 ```bash
-./scripts/run-all-tests.sh        # Run all 3 tests sequentially
+./scripts/run-all-tests.sh              # Run all 3 tests sequentially
 ```
 
 ## Test Results
@@ -121,10 +121,10 @@ Generates: `TEST_EXECUTION_RESULTS.txt`
 ./scripts/test-git-operations.sh
 
 # Test 2: Hook functions
-./test-hooks-direct.sh
+./scripts/test-hooks-direct.sh
 
 # Test 3: Fresh image + git + fsck
-./test-fresh-image-git-fsck.sh
+./scripts/test-fresh-image-git-fsck.sh
 ```
 
 ### Check Test Logs

--- a/scripts/test-fresh-image-git-fsck.sh
+++ b/scripts/test-fresh-image-git-fsck.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+set -e
+
+IMG="fresh-git-repro.img"
+MNT="mnt-fresh-git"
+LOG="fresh-git-repro.log"
+KAFS="./src/kafs"
+
+echo "=== KAFS Fresh Image Git+fsck Test ==="
+echo "Time: $(date)"
+echo ""
+
+# Cleanup
+rm -rf "$IMG" "$MNT" "$LOG" 2>/dev/null || true
+mkdir -p "$MNT"
+
+# Create fresh KAFS filesystem image
+echo "1. Creating fresh KAFS filesystem image..."
+SIZE=$((100 * 1024 * 1024))
+truncate -s "$SIZE" "$IMG"
+./src/mkfs.kafs "$IMG" > /dev/null 2>&1
+echo "✓ Image created: $IMG (100MB)"
+
+echo ""
+echo "2. Mounting KAFS filesystem..."
+
+export KAFS_DEBUG=1
+export KAFS_IMAGE="$IMG"
+
+"$KAFS" "$MNT" -f -s > "$LOG" 2>&1 &
+KAFS_PID=$!
+echo "KAFS PID: $KAFS_PID"
+
+# Wait for mount
+MOUNTED=0
+for i in {1..100}; do
+    if grep -q "$MNT" /proc/mounts 2>/dev/null; then
+        MOUNTED=1
+        echo "✓ Mounted"
+        break
+    fi
+    sleep 0.1
+done
+
+if [ $MOUNTED -eq 0 ]; then
+    echo "✗ Mount failed"
+    [ -f "$LOG" ] && echo "Log:" && cat "$LOG"
+    exit 1
+fi
+
+sleep 1
+chmod 777 "$MNT"
+
+echo ""
+echo "3. Git init/add/commit/fsck operations..."
+
+cd "$MNT"
+git init 2>&1 | head -5
+echo "✓ git init done"
+
+echo ""
+# Create files
+printf "Hello World" > file1.txt
+printf "More content" > file2.txt
+mkdir -p subdir
+printf "Nested file" > subdir/file3.txt
+
+git add file1.txt file2.txt subdir/file3.txt
+echo "✓ git add done"
+
+git -c user.email="test@test.com" -c user.name="Test User" commit -m "Initial commit" 2>&1 | head -10
+echo "✓ git commit done"
+
+echo ""
+# Git fsck on mounted repo
+git fsck --full 2>&1 | head -20
+
+echo ""
+cd - > /dev/null
+
+echo "4. Unmounting..."
+
+fusermount3 -u "$MNT" 2>/dev/null || umount "$MNT" 2>/dev/null || true
+sleep 1
+kill $KAFS_PID 2>/dev/null || true
+wait $KAFS_PID 2>/dev/null || true
+
+echo "✓ Unmounted"
+
+echo ""
+echo "5. Running fsck.kafs..."
+./src/fsck.kafs "$IMG" 2>&1 | tail -20
+
+echo ""
+echo "=== Log Analysis ==="
+echo ""
+
+if [ ! -f "$LOG" ]; then
+    echo "ERROR: Log file not found!"
+    exit 1
+fi
+
+LOGLINES=$(wc -l < "$LOG")
+echo "KAFS Debug Log file: $LOG"
+echo "Total lines: $LOGLINES"
+
+echo ""
+echo "=== Checking for EIO/SHA1/EOF errors ==="
+echo ""
+
+ERROR_COUNT=0
+
+echo "--- EIO errors ---"
+EIO_COUNT=$(grep -i "EIO\|I/O error" "$LOG" 2>/dev/null | wc -l)
+echo "EIO/I/O error count: $EIO_COUNT"
+[ $EIO_COUNT -gt 0 ] && ERROR_COUNT=$((ERROR_COUNT + 1))
+
+echo ""
+echo "--- SHA1 corruption errors ---"
+SHA1_COUNT=$(grep -i "sha1\|hash\|corrupt" "$LOG" 2>/dev/null | wc -l)
+echo "SHA1/hash/corruption errors: $SHA1_COUNT"
+[ $SHA1_COUNT -gt 0 ] && ERROR_COUNT=$((ERROR_COUNT + 1))
+
+echo ""
+echo "--- EOF errors (kafs_blk_read) ---"
+EOF_COUNT=$(grep "kafs_blk_read.*EOF\|unexpected EOF" "$LOG" 2>/dev/null | wc -l)
+echo "EOF error count: $EOF_COUNT"
+[ $EOF_COUNT -gt 0 ] && ERROR_COUNT=$((ERROR_COUNT + 1))
+
+echo ""
+echo "--- fsync/flush related errors ---"
+FSYNC_COUNT=$(grep "fsync\|flush\|release" "$LOG" 2>/dev/null | grep -i "error\|failed" | wc -l)
+echo "fsync/flush/release errors: $FSYNC_COUNT"
+[ $FSYNC_COUNT -gt 0 ] && ERROR_COUNT=$((ERROR_COUNT + 1))
+
+echo ""
+echo "=== Test Result ==="
+if [ $ERROR_COUNT -eq 0 ]; then
+    echo "✓ SUCCESS: No EIO/SHA1/EOF errors detected in fresh image scenario"
+    exit 0
+else
+    echo "✗ FAILURE: Detected $ERROR_COUNT error categories"
+    echo ""
+    echo "=== Last 50 lines of KAFS Debug Log ==="
+    tail -50 "$LOG"
+    exit 1
+fi

--- a/scripts/test-hooks-direct.sh
+++ b/scripts/test-hooks-direct.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+set -e
+
+IMG="hook-test.img"
+MNT="mnt-hook-test"
+LOG="hook-test.log"
+KAFS="./src/kafs"
+
+echo "=== KAFS Hook Functions Direct Test ==="
+echo "Time: $(date)"
+echo ""
+
+# Cleanup
+rm -rf "$IMG" "$MNT" "$LOG" 2>/dev/null || true
+mkdir -p "$MNT"
+
+# Create fresh KAFS filesystem image
+echo "1. Creating fresh KAFS filesystem image..."
+SIZE=$((50 * 1024 * 1024))
+truncate -s "$SIZE" "$IMG"
+./src/mkfs.kafs "$IMG" > /dev/null 2>&1
+echo "✓ Image created: $IMG (50MB)"
+
+echo ""
+echo "2. Mounting KAFS filesystem..."
+
+export KAFS_DEBUG=1
+export KAFS_IMAGE="$IMG"
+
+"$KAFS" "$MNT" -f -s > "$LOG" 2>&1 &
+KAFS_PID=$!
+echo "KAFS PID: $KAFS_PID"
+
+# Wait for mount
+MOUNTED=0
+for i in {1..100}; do
+    if grep -q "$MNT" /proc/mounts 2>/dev/null; then
+        MOUNTED=1
+        echo "✓ Mounted"
+        break
+    fi
+    sleep 0.1
+done
+
+if [ $MOUNTED -eq 0 ]; then
+    echo "✗ Mount failed"
+    [ -f "$LOG" ] && echo "Log:" && cat "$LOG"
+    exit 1
+fi
+
+sleep 1
+chmod 777 "$MNT"
+
+echo ""
+echo "3. Exercising hooks (flush/fsync/release/fsyncdir)..."
+
+cd "$MNT"
+
+# fsync on write
+DD_OUT="fsync-file.bin"
+dd if=/dev/zero of="$DD_OUT" bs=4096 count=8 conv=fsync status=none
+
+# Small file write + sync
+printf "hello" > small.txt
+sync
+
+# Directory ops
+mkdir -p dir1
+printf "nested" > dir1/nested.txt
+mv dir1/nested.txt dir1/renamed.txt
+rm -f small.txt
+rm -f dir1/renamed.txt
+rmdir dir1
+
+# opendir/readdir paths
+ls -la > /dev/null
+
+cd - > /dev/null
+
+echo "✓ Hook exercise done"
+
+echo ""
+echo "4. Unmounting..."
+
+fusermount3 -u "$MNT" 2>/dev/null || umount "$MNT" 2>/dev/null || true
+sleep 1
+kill $KAFS_PID 2>/dev/null || true
+wait $KAFS_PID 2>/dev/null || true
+
+echo "✓ Unmounted"
+
+echo ""
+echo "5. Running fsck.kafs..."
+./src/fsck.kafs "$IMG" 2>&1 | tail -20
+
+echo ""
+echo "=== Log Analysis ==="
+echo ""
+
+if [ ! -f "$LOG" ]; then
+    echo "ERROR: Log file not found!"
+    exit 1
+fi
+
+LOGLINES=$(wc -l < "$LOG")
+echo "KAFS Debug Log file: $LOG"
+echo "Total lines: $LOGLINES"
+
+echo ""
+echo "=== Checking for EIO/SHA1/EOF errors ==="
+echo ""
+
+ERROR_COUNT=0
+
+echo "--- EIO errors ---"
+EIO_COUNT=$(grep -i "EIO\|I/O error" "$LOG" 2>/dev/null | wc -l)
+echo "EIO/I/O error count: $EIO_COUNT"
+[ $EIO_COUNT -gt 0 ] && ERROR_COUNT=$((ERROR_COUNT + 1))
+
+echo ""
+echo "--- SHA1 corruption errors ---"
+SHA1_COUNT=$(grep -i "sha1\|hash\|corrupt" "$LOG" 2>/dev/null | wc -l)
+echo "SHA1/hash/corruption errors: $SHA1_COUNT"
+[ $SHA1_COUNT -gt 0 ] && ERROR_COUNT=$((ERROR_COUNT + 1))
+
+echo ""
+echo "--- EOF errors (kafs_blk_read) ---"
+EOF_COUNT=$(grep "kafs_blk_read.*EOF\|unexpected EOF" "$LOG" 2>/dev/null | wc -l)
+echo "EOF error count: $EOF_COUNT"
+[ $EOF_COUNT -gt 0 ] && ERROR_COUNT=$((ERROR_COUNT + 1))
+
+echo ""
+echo "--- fsync/flush related errors ---"
+FSYNC_COUNT=$(grep "fsync\|flush\|release" "$LOG" 2>/dev/null | grep -i "error\|failed" | wc -l)
+echo "fsync/flush/release errors: $FSYNC_COUNT"
+[ $FSYNC_COUNT -gt 0 ] && ERROR_COUNT=$((ERROR_COUNT + 1))
+
+echo ""
+echo "=== Test Result ==="
+if [ $ERROR_COUNT -eq 0 ]; then
+    echo "✓ SUCCESS: No EIO/SHA1/EOF errors detected during hook exercise"
+    exit 0
+else
+    echo "✗ FAILURE: Detected $ERROR_COUNT error categories"
+    echo ""
+    echo "=== Last 50 lines of KAFS Debug Log ==="
+    tail -50 "$LOG"
+    exit 1
+fi

--- a/src/kafsctl.c
+++ b/src/kafsctl.c
@@ -128,7 +128,8 @@ static const char *to_kafs_path(const char *mnt_abs, const char *p, char out[KAF
   return out;
 }
 
-static const char *to_mount_rel_path(const char *mnt_abs, const char *p, char out[KAFS_IOCTL_PATH_MAX])
+static const char *to_mount_rel_path(const char *mnt_abs, const char *p,
+                                     char out[KAFS_IOCTL_PATH_MAX])
 {
   if (!p || !*p)
     return NULL;


### PR DESCRIPTION
## Summary
- handle truncated dirent tails as EOF with warnings
- centralize journal CRC32 helpers and reduce duplicate sidecar/in-image logic
- add direct hook and fresh-image test scripts and update docs

## Testing
- ./scripts/format.sh
- ./scripts/static-checks.sh
- make -C src
- ./scripts/run-all-tests.sh