### PR TITLE
fix: initialize journal header for fresh mkfs images

### DIFF
--- a/src/mkfs_kafs.c
+++ b/src/mkfs_kafs.c
@@ -4,6 +4,7 @@
 #include "kafs_block.h"
 #include "kafs_inode.h"
 #include "kafs_hash.h"
+#include "kafs_journal.h"
 
 #include <ctype.h>
 #include <errno.h>
@@ -410,6 +411,31 @@ int main(int argc, char **argv)
   ctx.c_hrl_index = (void *)((char *)ctx.c_superblock + layout.hrl_index_off);
   ctx.c_hrl_bucket_cnt = layout.hrl_bucket_cnt;
   (void)kafs_hrl_format(&ctx);
+
+  // Journal header 初期化（fresh image が fsck --fast-check を通る前提）
+  {
+    size_t hsz = kj_header_size();
+    if (journal_bytes > hsz)
+    {
+      kj_header_t jh;
+      memset(&jh, 0, sizeof(jh));
+      jh.magic = KJ_MAGIC;
+      jh.version = KJ_VER;
+      jh.flags = 0;
+      jh.area_size = (uint64_t)journal_bytes - (uint64_t)hsz;
+      jh.write_off = 0;
+      jh.seq = 0;
+      jh.reserved0 = 0;
+      jh.header_crc = 0;
+      jh.header_crc = kj_crc32(&jh, sizeof(jh));
+
+      char *jhdr_ptr = (char *)ctx.c_superblock + layout.journal_off;
+      char *base3 = (char *)ctx.c_superblock;
+      char *end3 = base3 + mapsize;
+      assert(jhdr_ptr >= base3 && jhdr_ptr + sizeof(jh) <= end3);
+      memcpy(jhdr_ptr, &jh, sizeof(jh));
+    }
+  }
 
   munmap(ctx.c_superblock, mapsize);
   close(ctx.c_fd);


### PR DESCRIPTION
## Summary
- initialize in-image journal header during `mkfs.kafs` formatting
- make fresh images pass `fsck.kafs --fast-check` journal validation

## Linked Issue
- closes #17

## Root Cause
`mkfs.kafs` wrote journal region metadata into the superblock but did not initialize the on-image journal header (`kj_header_t`), so `fsck.kafs --fast-check` saw zeroed values and reported:
- bad magic
- bad version
- area_size mismatch
- header CRC mismatch

## Changes
- `src/mkfs_kafs.c`
  - include `kafs_journal.h`
  - write a fresh `kj_header_t` at `layout.journal_off` with:
    - `magic=KJ_MAGIC`
    - `version=KJ_VER`
    - `area_size=journal_bytes-kj_header_size()`
    - `write_off=0`, `seq=0`
    - valid `header_crc`

## Validation (Gate)
- reproduction before fix: `fsck.kafs --fast-check` exit `3` with journal header errors
- after fix:
  - `make`: PASS
  - `mkfs.kafs /tmp/kafs-issue17-fixed.img -s 128M`: PASS
  - `fsck.kafs --fast-check /tmp/kafs-issue17-fixed.img`: PASS (`Journal check: OK`, exit `0`)
  - `make check TESTS=kafsresize`: PASS
  - `./scripts/format.sh`: PASS
  - `./scripts/lint.sh`: PASS
  - `./scripts/clones.sh`: PASS
  - `./scripts/complexity.sh`: PASS

## Review
- Gatekeeper approval requested per repository rule for significant changes.
