### PR TITLE
feat: improve bg dedup non-HRL convergence (phase 1/2)

### DIFF
--- a/src/kafs.c
+++ b/src/kafs.c
@@ -133,6 +133,9 @@ static inline void kafs_stat_record_pwrite_iblk_write_latency(kafs_context_t *ct
 #define KAFS_BG_DEDUP_BLOCK_BUDGET_PRESSURE 32u
 #define KAFS_BG_DEDUP_SCAN_WINDOW_DEFAULT 64u
 #define KAFS_BG_DEDUP_SCAN_WINDOW_PRESSURE 256u
+#define KAFS_BG_DEDUP_SWEEP_IDX_CAP_DEFAULT 256u
+#define KAFS_BG_DEDUP_SWEEP_IDX_CAP_PRESSURE 1024u
+#define KAFS_BG_DEDUP_SWEEP_BUCKETS 2048u
 
 #define KAFS_BG_DEDUP_MODE_COLD 1u
 #define KAFS_BG_DEDUP_MODE_ADAPTIVE 2u
@@ -1135,6 +1138,57 @@ static kafs_blkcnt_t kafs_bg_recent_find_dup_blo(struct kafs_context *ctx, uint6
   return KAFS_BLO_NONE;
 }
 
+static kafs_blkcnt_t kafs_bg_sweep_find_dup_blo(struct kafs_context *ctx, uint64_t fast,
+                                                kafs_blkcnt_t self_blo, const void *buf,
+                                                const uint32_t *bucket_heads,
+                                                const uint64_t *entry_fast,
+                                                const uint32_t *entry_blo,
+                                                const uint32_t *entry_next)
+{
+  if (!ctx || !buf || !bucket_heads || !entry_fast || !entry_blo || !entry_next)
+    return KAFS_BLO_NONE;
+
+  kafs_blksize_t bs = kafs_sb_blksize_get(ctx->c_superblock);
+  char tmp[bs];
+  uint32_t bucket = (uint32_t)(fast & (KAFS_BG_DEDUP_SWEEP_BUCKETS - 1u));
+  uint32_t idx = bucket_heads[bucket];
+  while (idx != UINT32_MAX)
+  {
+    if (entry_fast[idx] == fast)
+    {
+      kafs_blkcnt_t cand = (kafs_blkcnt_t)entry_blo[idx];
+      if (cand != KAFS_BLO_NONE && cand != self_blo)
+      {
+        if (kafs_blk_read(ctx, cand, tmp) == 0 && memcmp(tmp, buf, bs) == 0)
+          return cand;
+      }
+    }
+    idx = entry_next[idx];
+  }
+  return KAFS_BLO_NONE;
+}
+
+static void kafs_bg_sweep_note(uint64_t fast, kafs_blkcnt_t blo, uint32_t cap,
+                               uint32_t *entry_count, uint32_t *bucket_heads, uint64_t *entry_fast,
+                               uint32_t *entry_blo, uint32_t *entry_next)
+{
+  if (!entry_count || !bucket_heads || !entry_fast || !entry_blo || !entry_next)
+    return;
+  if (blo == KAFS_BLO_NONE)
+    return;
+  if (*entry_count >= cap)
+    return;
+
+  uint32_t idx = *entry_count;
+  (*entry_count)++;
+
+  uint32_t bucket = (uint32_t)(fast & (KAFS_BG_DEDUP_SWEEP_BUCKETS - 1u));
+  entry_fast[idx] = fast;
+  entry_blo[idx] = (uint32_t)blo;
+  entry_next[idx] = bucket_heads[bucket];
+  bucket_heads[bucket] = idx;
+}
+
 static int kafs_bg_advance_cursor(struct kafs_context *ctx, kafs_inocnt_t inocnt,
                                   uint32_t next_iblk)
 {
@@ -1198,7 +1252,16 @@ static void kafs_bg_dedup_step(struct kafs_context *ctx, int pressure_mode)
       pressure_mode ? KAFS_BG_DEDUP_BLOCK_BUDGET_PRESSURE : KAFS_BG_DEDUP_BLOCK_BUDGET_DEFAULT;
   uint32_t scan_window =
       pressure_mode ? KAFS_BG_DEDUP_SCAN_WINDOW_PRESSURE : KAFS_BG_DEDUP_SCAN_WINDOW_DEFAULT;
+  uint32_t sweep_cap =
+      pressure_mode ? KAFS_BG_DEDUP_SWEEP_IDX_CAP_PRESSURE : KAFS_BG_DEDUP_SWEEP_IDX_CAP_DEFAULT;
   uint32_t scanned_blocks_this_step = 0;
+  uint32_t sweep_bucket_heads[KAFS_BG_DEDUP_SWEEP_BUCKETS];
+  uint64_t sweep_entry_fast[KAFS_BG_DEDUP_SWEEP_IDX_CAP_PRESSURE];
+  uint32_t sweep_entry_blo[KAFS_BG_DEDUP_SWEEP_IDX_CAP_PRESSURE];
+  uint32_t sweep_entry_next[KAFS_BG_DEDUP_SWEEP_IDX_CAP_PRESSURE];
+  uint32_t sweep_entry_count = 0;
+  for (uint32_t i = 0; i < KAFS_BG_DEDUP_SWEEP_BUCKETS; ++i)
+    sweep_bucket_heads[i] = UINT32_MAX;
 
   for (kafs_inocnt_t scanned = 0; scanned < inocnt; ++scanned)
   {
@@ -1284,9 +1347,15 @@ static void kafs_bg_dedup_step(struct kafs_context *ctx, int pressure_mode)
       }
 
       uint64_t fast = kafs_bg_hash64(buf, bs);
-      kafs_blkcnt_t dup_direct = kafs_bg_recent_find_dup_blo(ctx, fast, old_blo, buf);
+      kafs_blkcnt_t dup_direct =
+          kafs_bg_sweep_find_dup_blo(ctx, fast, old_blo, buf, sweep_bucket_heads, sweep_entry_fast,
+                                     sweep_entry_blo, sweep_entry_next);
+      if (dup_direct == KAFS_BLO_NONE)
+        dup_direct = kafs_bg_recent_find_dup_blo(ctx, fast, old_blo, buf);
       if (dup_direct == KAFS_BLO_NONE)
         dup_direct = kafs_bg_index_find_dup_blo(ctx, fast, old_blo, buf);
+      kafs_bg_sweep_note(fast, old_blo, sweep_cap, &sweep_entry_count, sweep_bucket_heads,
+                         sweep_entry_fast, sweep_entry_blo, sweep_entry_next);
       kafs_bg_recent_note(ctx, fast, old_blo);
       kafs_bg_index_note(ctx, fast, old_blo);
       if (dup_direct == KAFS_BLO_NONE)


### PR DESCRIPTION
## 概要
Issue #25 の実装着手として、BG dedup の非HRL重複収束を改善する Phase 1/2 を導入しました。

Closes #25

## 変更内容
- Phase 1
  - BG dedup 1ステップあたりの処理予算を導入
  - 走査ウィンドウを拡張（先頭固定幅の緩和）
  - 重複未検出時の即時 return を抑制し、予算内で探索継続
- Phase 2
  - ステップ単位の一時 reverse index を追加
  - fast hash バケット内比較で非HRL候補探索を追加
  - 既存 recent/index 探索の前段に sweep-local 探索を接続

## 影響範囲
- src/kafs.c

## 検証結果
- make -j4: PASS
- ./scripts/clones.sh: PASS（既存クローン3件、増加なし）
- ./scripts/static-checks.sh: PASS
  - format: PASS
  - lint: PASS
  - clones: PASS
  - deadcode: 既存 warning のみ
  - complexity: lizard 未導入メッセージ（既存）

## リスクと補足
- BG探索量が増えるため CPU 使用率は上がる可能性があります。
- 既存ロック順序は維持（inode ロック中の既存処理範囲内で追加探索）。
- 追加メモリはステップ内一時配列のみです。
