### PR TITLE
ci: make cppcheck deadcode optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
+    inputs:
+      run_deadcode:
+        description: Run optional deadcode (cppcheck) step
+        required: false
+        default: 'false'
 
 jobs:
   build-and-check:
@@ -44,6 +50,7 @@ jobs:
         run: ./scripts/clones.sh
 
       - name: Dead code (cppcheck)
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_deadcode == 'true' }}
         run: ./scripts/deadcode.sh
 
       - name: Complexity (lizard)


### PR DESCRIPTION
## Summary
- make `Dead code (cppcheck)` step optional in CI
- keep the step available via manual workflow dispatch input `run_deadcode=true`
- avoid long-running deadcode checks on normal push/pull_request CI

## Details
- add `workflow_dispatch` trigger with `run_deadcode` input (default: false)
- gate deadcode step with:
  - `github.event_name == 'workflow_dispatch'`
  - `github.event.inputs.run_deadcode == 'true'`

## Impact
- normal PR CI latency is reduced
- deadcode/cppcheck can still be run on demand
