### PR TITLE
feat: salvage crash diagnostics from closed PR #6

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -48,6 +48,12 @@ design and policy notes.
 
 ## Documentation Files
 
+### Operations
+
+| File | Purpose |
+|------|---------|
+| [crash-diagnostics.md](crash-diagnostics.md) | Crash diagnostics output and core dump collection guide |
+
 ### Primary Documentation
 
 | File | Size | Purpose | Read Time |

--- a/docs/crash-diagnostics.md
+++ b/docs/crash-diagnostics.md
@@ -1,0 +1,96 @@
+# Crash Diagnostics and Core Dump Guide
+
+## Purpose
+
+This document describes how KAFS emits crash diagnostics and how to collect core dumps for post-mortem analysis.
+
+## What Is Enabled in KAFS
+
+The following binaries install crash diagnostics at startup:
+
+- `kafs`
+- `kafs-back`
+
+On fatal signals (`SIGSEGV`, `SIGABRT`, `SIGBUS`, `SIGILL`, `SIGFPE`), they do the following:
+
+1. Print a fatal signal line to `stderr`.
+2. Print a stack backtrace to `stderr` (Linux).
+3. Re-raise the signal with default handler so OS-level core dump flow runs.
+
+Additionally on Linux startup:
+
+- Attempts to keep process dumpable (`PR_SET_DUMPABLE=1`).
+- Tries to uncap `RLIMIT_CORE` when soft limit is zero and hard limit allows it.
+- Writes `0x3f` to `/proc/self/coredump_filter` to keep richer mappings in core dumps.
+
+## Quick Verification (Optional)
+
+A minimal smoke run should show both of these:
+
+- Stderr log lines like `caught fatal signal ...` and `stack backtrace ...`.
+- A system core handling event (either a core file or a core-handler capture).
+
+Observed in this environment:
+
+- `stderr` backtrace output: confirmed.
+- `core_pattern`: `|/wsl-capture-crash %t %E %p %s`.
+- Result: no `core*` file in working directory because core is piped to external handler.
+
+## How to Collect Core Dumps
+
+First inspect `/proc/sys/kernel/core_pattern`.
+
+### Case A: Direct core files (no leading `|`)
+
+- Core files are written according to `core_pattern` path template.
+- Ensure shell soft limit is non-zero (`ulimit -c unlimited`).
+- Collect the core path and analyze with `gdb`.
+
+### Case B: Piped handler (`core_pattern` starts with `|`)
+
+- Core is forwarded to a handler process, so `./core` is typically not created.
+- Use platform handler tooling/logs to retrieve the dump.
+- On systemd environments this is usually `coredumpctl`.
+- On WSL-like environments, vendor-specific crash capture tools may own the dump.
+
+## WSL Practical Retrieval Steps
+
+This workspace currently reports:
+
+- `core_pattern`: `|/wsl-capture-crash %t %E %p %s`
+
+In this mode, WSL forwards the crash to `CaptureCrash`, and dump files are typically written on the Windows side. In this environment, dumps are present under:
+
+- `/mnt/c/Users/<windows-user>/AppData/Local/Temp/wsl-crashes/`
+
+Example filename pattern:
+
+- `wsl-crash-<ts>-<pid>-_<path>_<exe>-<signal>.dmp`
+
+Suggested workflow:
+
+1. Reproduce the crash and keep `stderr` output.
+2. Confirm capture in journal logs (look for `CaptureCrash`):
+   - `journalctl --no-pager -n 200 | rg -i "CaptureCrash|wsl-capture|signal"`
+3. Find newest WSL crash dump:
+   - `ls -lt /mnt/c/Users/$USER/AppData/Local/Temp/wsl-crashes/*.dmp | head`
+4. Narrow by executable name if needed:
+   - `ls -lt /mnt/c/Users/$USER/AppData/Local/Temp/wsl-crashes/*.dmp | rg "kafs|kafs-back|kafs-front"`
+
+If `$USER` does not match your Windows account name, replace it with the actual Windows profile directory name.
+
+## Recommended Incident Bundle
+
+When reporting a crash, include all of:
+
+- Binary name and build revision.
+- Full `stderr` crash output (signal + backtrace).
+- `core_pattern` value.
+- Core dump reference (file path or handler-side identifier).
+- Reproduction steps and relevant input image/workload.
+- For WSL: matching `CaptureCrash` journal lines and the selected `.dmp` filename.
+
+## Notes
+
+- If permissions prevent changing core limits, the diagnostics still emit stack traces to `stderr`.
+- `backtrace_symbols_fd` output quality depends on symbol availability (debug symbols improve readability).

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -10,6 +10,7 @@
 #include "kafs_mmap_io.h"
 #include "kafs_rpc.h"
 #include "kafs_core.h"
+#include "kafs_crash_diag.h"
 
 #define KAFS_DIRECT_SIZE (sizeof(((struct kafs_sinode *)NULL)->i_blkreftbl))
 
@@ -7561,41 +7562,10 @@ static int kafs_migrate_v2_image(const char *image_path, int assume_yes)
   return 0;
 }
 
-static void kafs_signal_handler(int sig)
-{
-  const char *name = strsignal(sig);
-  kafs_log(KAFS_LOG_ERR, "kafs: caught signal %d (%s)\n", sig, name ? name : "?");
-#ifdef __linux__
-  void *bt[64];
-  int n = backtrace(bt, (int)(sizeof(bt) / sizeof(bt[0])));
-  char **syms = backtrace_symbols(bt, n);
-  if (syms)
-  {
-    for (int i = 0; i < n; ++i)
-      kafs_log(KAFS_LOG_ERR, "  bt[%02d]=%s\n", i, syms[i]);
-  }
-#endif
-  signal(sig, SIG_DFL);
-  raise(sig);
-}
-
-static void kafs_install_crash_handlers(void)
-{
-  struct sigaction sa;
-  memset(&sa, 0, sizeof(sa));
-  sa.sa_handler = kafs_signal_handler;
-  sigemptyset(&sa.sa_mask);
-  sigaction(SIGSEGV, &sa, NULL);
-  sigaction(SIGABRT, &sa, NULL);
-  sigaction(SIGBUS, &sa, NULL);
-  sigaction(SIGILL, &sa, NULL);
-  sigaction(SIGFPE, &sa, NULL);
-}
-
 #ifndef KAFS_NO_MAIN
 int main(int argc, char **argv)
 {
-  kafs_install_crash_handlers();
+  kafs_crash_diag_install("kafs");
   // 画像ファイル指定を受け取る: --image <path> または --image=<path>、環境変数 KAFS_IMAGE
   const char *image_path = getenv("KAFS_IMAGE");
   kafs_bool_t auto_migrate_v2 = KAFS_FALSE;

--- a/src/kafs_back.c
+++ b/src/kafs_back.c
@@ -1,5 +1,6 @@
 #include "kafs_rpc.h"
 #include "kafs_cli_opts.h"
+#include "kafs_crash_diag.h"
 #ifdef KAFS_BACK_ENABLE_IMAGE
 #include "kafs_core.h"
 #endif
@@ -72,6 +73,8 @@ static int kafs_back_apply_mode_result(int mrc, int *result)
 
 int main(int argc, char **argv)
 {
+  kafs_crash_diag_install("kafs-back");
+
   const char *fd_env = getenv("KAFS_HOTPLUG_BACK_FD");
   const char *uds_path = getenv("KAFS_HOTPLUG_UDS");
 #ifdef KAFS_BACK_ENABLE_IMAGE

--- a/src/kafs_crash_diag.h
+++ b/src/kafs_crash_diag.h
@@ -1,0 +1,80 @@
+#ifndef KAFS_CRASH_DIAG_H
+#define KAFS_CRASH_DIAG_H
+
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#ifdef __linux__
+#include <execinfo.h>
+#include <sys/prctl.h>
+#include <sys/resource.h>
+#endif
+
+static const char *kafs_crash_diag_prog_name = "kafs";
+
+static void kafs_crash_diag_handler(int sig)
+{
+  const char *name = strsignal(sig);
+  fprintf(stderr, "%s: caught fatal signal %d (%s)\n", kafs_crash_diag_prog_name, sig,
+          name ? name : "?");
+#ifdef __linux__
+  void *bt[64];
+  int n = backtrace(bt, (int)(sizeof(bt) / sizeof(bt[0])));
+  if (n > 0)
+  {
+    fprintf(stderr, "%s: stack backtrace (%d frames):\n", kafs_crash_diag_prog_name, n);
+    backtrace_symbols_fd(bt, n, STDERR_FILENO);
+  }
+#endif
+
+  signal(sig, SIG_DFL);
+  raise(sig);
+}
+
+static void kafs_crash_diag_prepare_core_dump(const char *prog_name)
+{
+#ifdef __linux__
+  struct rlimit lim;
+  if (getrlimit(RLIMIT_CORE, &lim) == 0)
+  {
+    if (lim.rlim_cur == 0 && lim.rlim_max > 0)
+      (void)setrlimit(RLIMIT_CORE, &lim);
+  }
+
+  (void)prctl(PR_SET_DUMPABLE, 1, 0, 0, 0);
+
+  FILE *f = fopen("/proc/self/coredump_filter", "w");
+  if (f)
+  {
+    /* Include anonymous/private/shared mappings for richer post-mortem dumps. */
+    (void)fputs("0x3f\n", f);
+    (void)fclose(f);
+  }
+#else
+  (void)prog_name;
+#endif
+}
+
+static void kafs_crash_diag_install(const char *prog_name)
+{
+  if (prog_name && *prog_name)
+    kafs_crash_diag_prog_name = prog_name;
+
+  kafs_crash_diag_prepare_core_dump(prog_name);
+
+  struct sigaction sa;
+  memset(&sa, 0, sizeof(sa));
+  sa.sa_handler = kafs_crash_diag_handler;
+  sigemptyset(&sa.sa_mask);
+
+  (void)sigaction(SIGSEGV, &sa, NULL);
+  (void)sigaction(SIGABRT, &sa, NULL);
+  (void)sigaction(SIGBUS, &sa, NULL);
+  (void)sigaction(SIGILL, &sa, NULL);
+  (void)sigaction(SIGFPE, &sa, NULL);
+}
+
+#endif


### PR DESCRIPTION
## Summary
- close oversized/conflicting PR #6 and salvage only the necessary crash-diagnostics changes
- add shared crash diagnostics helper used by `kafs` and `kafs-back`
- add crash diagnostics / core dump guide documentation

## Included changes (minimal)
- add `src/kafs_crash_diag.h`
- wire crash diagnostics install at startup in:
  - `src/kafs.c`
  - `src/kafs_back.c`
- add docs:
  - `docs/crash-diagnostics.md`
  - `docs/INDEX.md` link entry

## Validation
- PASS: `make -j4`
- PASS: `make -j4 check` (9 passed / 11 skipped)
- PASS: `./scripts/clones.sh` (existing baseline clones only)
- PASS: `./scripts/static-checks.sh` (deadcode shows existing warnings only)

## Notes
- intentionally did not pull broad hotplug/front delegation changes from PR #6
- this PR is scoped to crash diagnostics salvage only
