### PR TITLE
fix: prevent HRL leaks after directory unlink shrink

### DIFF
--- a/src/kafs.c
+++ b/src/kafs.c
@@ -2706,7 +2706,10 @@ static int kafs_ino_iblk_write(struct kafs_context *ctx, kafs_sinode_t *inoent, 
   assert(buf != NULL);
   assert(inoent != NULL);
   assert(kafs_ino_get_usage(inoent));
-  if (ctx->c_pendinglog_enabled && ctx->c_pending_worker_running)
+  // Directory metadata is frequently rewritten and can cross the inline/block-backed boundary.
+  // Keep that path synchronous so shrink-to-inline and unlink do not race with pendinglog writes.
+  if (ctx->c_pendinglog_enabled && ctx->c_pending_worker_running &&
+      !S_ISDIR(kafs_ino_mode_get(inoent)))
   {
     kafs_blkcnt_t temp_blo = KAFS_BLO_NONE;
     KAFS_CALL(kafs_blk_alloc, ctx, &temp_blo);

--- a/tests/tests_open_unlink_visibility.c
+++ b/tests/tests_open_unlink_visibility.c
@@ -97,6 +97,15 @@ static int run_cmd(char *const argv[])
     return -errno;
   return (WIFEXITED(st) && WEXITSTATUS(st) == 0) ? 0 : -1;
 }
+
+static const char *pick_fsck_bin(void)
+{
+  const char *p = getenv("KAFS_TEST_FSCK");
+  if (p && *p)
+    return p;
+  return "./fsck.kafs";
+}
+
 static int is_still_mounted(const char *mnt) { return is_mounted_fuse(mnt); }
 
 static void stop_kafs(const char *mnt, pid_t pid)
@@ -198,6 +207,58 @@ int main(void)
   }
 
   stop_kafs(mnt, srv);
+
+  const char *img2 = "dir-unlink-leak.img";
+  const char *mnt2 = "mnt-dir-unlink";
+  if (kafs_test_mkimg_with_hrl(img2, 128u * 1024u * 1024u, 12, 4096, &ctx, &mapsize) != 0)
+    return 77;
+  munmap(ctx.c_superblock, mapsize);
+  close(ctx.c_fd);
+
+  srv = spawn_kafs(img2, mnt2);
+  if (srv <= 0)
+    return 77;
+
+  for (int i = 1; i <= 8; ++i)
+  {
+    snprintf(p, sizeof(p), "%s/f%d", mnt2, i);
+    int fd = open(p, O_CREAT | O_TRUNC | O_WRONLY, 0644);
+    if (fd < 0)
+    {
+      tlogf("create tiny file failed: %s", strerror(errno));
+      stop_kafs(mnt2, srv);
+      return 1;
+    }
+    if (write(fd, "x", 1) != 1)
+    {
+      tlogf("write tiny file failed: %s", strerror(errno));
+      close(fd);
+      stop_kafs(mnt2, srv);
+      return 1;
+    }
+    close(fd);
+  }
+
+  for (int i = 1; i <= 8; ++i)
+  {
+    snprintf(p, sizeof(p), "%s/f%d", mnt2, i);
+    if (unlink(p) != 0)
+    {
+      tlogf("unlink tiny file failed: %s", strerror(errno));
+      stop_kafs(mnt2, srv);
+      return 1;
+    }
+  }
+
+  stop_kafs(mnt2, srv);
+
+  char *fsck_argv[] = {(char *)pick_fsck_bin(), "--check-hrl-blo-refcounts", (char *)img2, NULL};
+  if (run_cmd(fsck_argv) != 0)
+  {
+    tlogf("hrl refcount check failed after deleting 8 tiny files");
+    return 1;
+  }
+
   tlogf("open_unlink_visibility OK");
   return 0;
 }


### PR DESCRIPTION
## Summary
- avoid async pendinglog writes for directory inode blocks
- add a regression case for deleting 8 tiny files and checking HRL refcounts with fsck
- keep the existing open-unlink visibility coverage in the same test binary

## Root cause
Directory metadata writes can cross the inline/block-backed boundary during unlink-heavy shrink paths. Keeping directory inode block writes synchronous avoids leaving stale HRL references behind that reproduced as `live_entries=2 mismatches=2`.

## Validation
- `make -j4`
- `make -C tests open_unlink_visibility -j4`
- `KAFS_TEST_KAFS=/home/mako10k/kafs/src/kafs KAFS_TEST_FSCK=/home/mako10k/kafs/src/fsck.kafs ./tests/open_unlink_visibility`
- `./scripts/clones.sh`
- `./scripts/static-checks.sh`

Fixes #32
