### PR TITLE
refactor: centralize feature-test macros

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,8 @@ AC_INIT([kafs],[0.2.3],[mako10k@mk10.org])
 AC_CONFIG_SRCDIR([src/kafs.c])
 AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE([foreign])
+AC_USE_SYSTEM_EXTENSIONS
+AC_SYS_LARGEFILE
 PKG_CHECK_MODULES([KAFS], [fuse3])
 
 AC_ARG_ENABLE([lto],

--- a/scripts/bootstrap-check.sh
+++ b/scripts/bootstrap-check.sh
@@ -82,7 +82,7 @@ CFG_CFLAGS=""
 CFG_LDFLAGS=""
 if [[ "$USE_ASAN" == "1" ]]; then
   echo "[cfg] enabling AddressSanitizer"
-  CFG_CFLAGS="-Wall -Werror -g -O0 -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -fsanitize=address"
+  CFG_CFLAGS="-Wall -Werror -g -O0 -fsanitize=address"
   CFG_LDFLAGS="-fsanitize=address"
 fi
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -8,7 +8,7 @@ if command -v pkg-config >/dev/null 2>&1 && pkg-config --exists fuse3; then
 else
   FUSE_CFLAGS="-I/usr/include/fuse3"
 fi
-CFLAGS_COMMON=( -Wall -Wextra -Werror -Wno-unused-function -Wno-unused-parameter -std=c11 -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -I./src ${FUSE_CFLAGS} )
+CFLAGS_COMMON=( -Wall -Wextra -Werror -Wno-unused-function -Wno-unused-parameter -std=c11 -include ./src/kafs_config.h -I./src ${FUSE_CFLAGS} )
 SRC=( src/*.c )
 if [[ ${#SRC[@]} -eq 0 ]]; then echo "No C sources"; exit 0; fi
 # Compile each source to ensure warnings are caught; no link to avoid multiple mains

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,3 +1,5 @@
+AM_CPPFLAGS = -include $(srcdir)/kafs_config.h
+
 bin_PROGRAMS = kafs mkfs.kafs fsck.kafs kafs-info kafsdump kafsimage kafsresize kafsctl kafs-front kafs-back
 
 # add per-target flags; silence unused-function as headers provide many static helpers
@@ -48,6 +50,6 @@ kafs_back_SOURCES = kafs_back.c kafs_rpc.c kafs.c kafs_hrl.c kafs_locks.c kafs_j
 kafs_back_CFLAGS = $(KAFS_CFLAGS) -Wno-unused-function -Wno-unused-parameter -DKAFS_NO_MAIN
 kafs_back_LDADD = $(KAFS_LIBS)
 
-noinst_HEADERS = kafs_block.h kafs_context.h kafs_dirent.h kafs_inode.h kafs_superblock.h kafs.h kafs_ioctl.h kafs_journal.h kafs_rpc.h kafs_core.h
+noinst_HEADERS = kafs_block.h kafs_config.h kafs_context.h kafs_dirent.h kafs_inode.h kafs_superblock.h kafs.h kafs_ioctl.h kafs_journal.h kafs_rpc.h kafs_core.h
 
-CFLAGS = -Wall -Werror -g -O2 -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -Wno-unused-function -Wno-unused-parameter
+CFLAGS = -Wall -Werror -g -O2 -Wno-unused-function -Wno-unused-parameter

--- a/src/kafs.h
+++ b/src/kafs.h
@@ -1,8 +1,6 @@
 #pragma once
 #define FUSE_USE_VERSION 30
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
+#include "kafs_config.h"
 
 #include <inttypes.h>
 #include <time.h>

--- a/src/kafs_block.h
+++ b/src/kafs_block.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "kafs_config.h"
 #include "kafs.h"
 #include "kafs_context.h"
 #include "kafs_superblock.h"

--- a/src/kafs_cli_opts.h
+++ b/src/kafs_cli_opts.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "kafs_config.h"
 #include <string.h>
 
 typedef void (*kafs_usage_fn_t)(const char *prog);

--- a/src/kafs_config.h
+++ b/src/kafs_config.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#else
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE 1
+#endif
+
+#ifndef _FILE_OFFSET_BITS
+#define _FILE_OFFSET_BITS 64
+#endif
+#endif

--- a/src/kafs_context.h
+++ b/src/kafs_context.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "kafs_config.h"
 #include "kafs.h"
 #include "kafs_superblock.h"
 #include "kafs_inode.h"

--- a/src/kafs_core.h
+++ b/src/kafs_core.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "kafs_config.h"
 #include "kafs_context.h"
 
 #include <sys/types.h>

--- a/src/kafs_crash_diag.h
+++ b/src/kafs_crash_diag.h
@@ -1,6 +1,7 @@
 #ifndef KAFS_CRASH_DIAG_H
 #define KAFS_CRASH_DIAG_H
 
+#include "kafs_config.h"
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/kafs_dirent.h
+++ b/src/kafs_dirent.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "kafs_config.h"
 #include "kafs.h"
 
 #include <string.h>

--- a/src/kafs_hotplug.h
+++ b/src/kafs_hotplug.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "kafs_config.h"
 #include <stdint.h>
 
 #define KAFS_HOTPLUG_ENV_KEY_MAX 64

--- a/src/kafs_inode.h
+++ b/src/kafs_inode.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "kafs_config.h"
 #include "kafs.h"
 #include <errno.h>
 

--- a/src/kafs_ioctl.h
+++ b/src/kafs_ioctl.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "kafs_config.h"
 #include <stdint.h>
 #include <sys/ioctl.h>
 #include "kafs_hotplug.h"

--- a/src/kafs_journal.h
+++ b/src/kafs_journal.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "kafs_config.h"
 #include <stdint.h>
 #include <stdarg.h>
 #include <stddef.h>

--- a/src/kafs_mmap_io.h
+++ b/src/kafs_mmap_io.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "kafs_config.h"
 #include "kafs.h"
 #include "kafs_context.h"
 #include "kafs_superblock.h"

--- a/src/kafs_rpc.h
+++ b/src/kafs_rpc.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "kafs_config.h"
 #include <stdint.h>
 #include <sys/stat.h>
 #include "kafs_hotplug.h"

--- a/src/kafs_superblock.h
+++ b/src/kafs_superblock.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "kafs_config.h"
 #include "kafs.h"
 #include <assert.h>
 #include <stdio.h>

--- a/src/kafs_tool_util.h
+++ b/src/kafs_tool_util.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "kafs_config.h"
 #include <ctype.h>
 #include <errno.h>
 #include <stdint.h>

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -3,10 +3,10 @@ AUTOMAKE_OPTIONS = serial-tests subdir-objects
 # Keep these tests self-contained and avoid polluting the repo tree: each test
 # enters a fresh workdir under ${TMPDIR:-/tmp} at startup.
 
-AM_CPPFLAGS = -I$(top_srcdir)/src -I$(srcdir)
+AM_CPPFLAGS = -include $(top_srcdir)/src/kafs_config.h -I$(top_srcdir)/src -I$(srcdir)
 
 # Match src/ build flags for consistent warnings/debug.
-CFLAGS = -Wall -Werror -g -O0 -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 \
+CFLAGS = -Wall -Werror -g -O0 \
 	-Wno-unused-function -Wno-unused-parameter
 
 noinst_HEADERS = test_utils.h


### PR DESCRIPTION
## Summary
- add autotools-managed system extension and large-file defines in configure.ac
- centralize fallback feature-test macros in src/kafs_config.h
- remove duplicated macro defines from build and helper script entry points

## Validation
- make -j4
- make check
- ./scripts/static-checks.sh

Closes #34