### PR TITLE
perf: reduce migrate cutover transfer guidance

### DIFF
--- a/man/kafsresize.8
+++ b/man/kafsresize.8
@@ -26,6 +26,15 @@ It also supports creating a migration target image with new geometry
 .B --migrate-create
 for cutover workflows.
 
+When
+.B --src-mount
+and
+.B --dst-mount
+are provided, the suggested cutover workflow prints an initial seed
+copy plus a final rsync command using
+.B --inplace --no-whole-file
+to reduce re-transfer and rewrite volume before the final switch.
+
 Current v0 implementation is conservative and supports growth only within
 preallocated headroom:
 
@@ -78,10 +87,11 @@ Optional HRL entry ratio forwarded to
 Valid range is greater than 0 and less than or equal to 1.0.
 .TP
 .B --src-mount PATH
-Optional source mount path; printed in suggested rsync command.
+Optional source mount path; printed in suggested rsync commands.
 .TP
 .B --dst-mount PATH
-Optional destination mount path; printed in suggested mount/rsync commands.
+Optional destination mount path; printed in suggested mount/rsync commands,
+including a final low-transfer rsync step.
 .TP
 .B --yes
 Skip confirmation prompt for

--- a/src/kafsresize.c
+++ b/src/kafsresize.c
@@ -84,6 +84,38 @@ static int run_command(const char *prog, char *const argv[])
   return 1;
 }
 
+static void print_migrate_next_steps(const char *dst_image, const char *src_mount,
+                                     const char *dst_mount)
+{
+  printf("\nnext steps (manual cutover):\n");
+  if (dst_mount && *dst_mount)
+  {
+    printf("  1) sudo mkdir -p %s\n", dst_mount);
+    printf("  2) sudo kafs %s %s\n", dst_image, dst_mount);
+    if (src_mount && *src_mount)
+    {
+      printf("  3) initial seed copy:\n");
+      printf("     sudo rsync -aHAX --numeric-ids --delete %s/ %s/\n", src_mount, dst_mount);
+      printf("  4) final low-transfer sync before cutover:\n");
+      printf("     sudo rsync -aHAX --numeric-ids --delete --inplace --no-whole-file %s/ %s/\n",
+             src_mount, dst_mount);
+      printf("  5) verify then switch mountpoint\n");
+    }
+    else
+    {
+      printf("  3) copy data from source mount to %s\n", dst_mount);
+      printf("  4) re-run a low-transfer rsync before cutover if source changed\n");
+      printf("  5) verify then switch mountpoint\n");
+    }
+  }
+  else
+  {
+    printf("  - mount destination image and copy data from source filesystem\n");
+    printf(
+        "  - before cutover, re-run rsync with --inplace --no-whole-file to minimize transfer\n");
+  }
+}
+
 static void bitmap_clear_range(uint8_t *bm, uint32_t from_blo, uint32_t to_blo)
 {
   for (uint32_t b = from_blo; b < to_blo; ++b)
@@ -418,26 +450,7 @@ static int cmd_migrate_create(const char *dst_image, uint64_t size_bytes, uint32
   if (hrl_entry_ratio > 0.0)
     printf("  hrl_entry_ratio: %.6f\n", hrl_entry_ratio);
 
-  printf("\nnext steps (manual cutover):\n");
-  if (dst_mount && *dst_mount)
-  {
-    printf("  1) sudo mkdir -p %s\n", dst_mount);
-    printf("  2) sudo kafs %s %s\n", dst_image, dst_mount);
-    if (src_mount && *src_mount)
-    {
-      printf("  3) sudo rsync -aHAX --numeric-ids --delete %s/ %s/\n", src_mount, dst_mount);
-      printf("  4) verify then switch mountpoint\n");
-    }
-    else
-    {
-      printf("  3) copy data from source mount to %s\n", dst_mount);
-      printf("  4) verify then switch mountpoint\n");
-    }
-  }
-  else
-  {
-    printf("  - mount destination image and copy data from source filesystem\n");
-  }
+  print_migrate_next_steps(dst_image, src_mount, dst_mount);
 
   return 0;
 }

--- a/tests/tests_kafsresize.c
+++ b/tests/tests_kafsresize.c
@@ -80,6 +80,58 @@ static int run_cmd_status_with_stdin(char *const argv[], const char *stdin_data)
   return 255;
 }
 
+static int run_cmd_capture_stdout(char *const argv[], char *stdout_buf, size_t stdout_buf_sz)
+{
+  int pipefd[2];
+  if (pipe(pipefd) != 0)
+    return -errno;
+
+  pid_t pid = fork();
+  if (pid < 0)
+  {
+    int saved = errno;
+    close(pipefd[0]);
+    close(pipefd[1]);
+    return -saved;
+  }
+  if (pid == 0)
+  {
+    close(pipefd[0]);
+    if (dup2(pipefd[1], STDOUT_FILENO) < 0)
+      _exit(127);
+    close(pipefd[1]);
+    execvp(argv[0], argv);
+    _exit(127);
+  }
+
+  close(pipefd[1]);
+  size_t used = 0;
+  while (stdout_buf && used + 1 < stdout_buf_sz)
+  {
+    ssize_t n = read(pipefd[0], stdout_buf + used, stdout_buf_sz - used - 1);
+    if (n < 0)
+    {
+      int saved = errno;
+      close(pipefd[0]);
+      (void)waitpid(pid, NULL, 0);
+      return -saved;
+    }
+    if (n == 0)
+      break;
+    used += (size_t)n;
+  }
+  if (stdout_buf && stdout_buf_sz > 0)
+    stdout_buf[used] = '\0';
+  close(pipefd[0]);
+
+  int st = 0;
+  if (waitpid(pid, &st, 0) < 0)
+    return -errno;
+  if (WIFEXITED(st))
+    return WEXITSTATUS(st);
+  return 255;
+}
+
 static int to_abs_path(const char *in, char *out, size_t out_sz)
 {
   if (!in || !*in || !out || out_sz == 0)
@@ -326,6 +378,62 @@ int main(void)
   if (run_cmd_status(resize_over_argv) == 0)
   {
     fprintf(stderr, "resize unexpectedly succeeded over headroom limit\n");
+    return 1;
+  }
+
+  const char *dst_img = "migrate-dst.img";
+  int dst_fd = open(dst_img, O_RDWR | O_CREAT | O_TRUNC, 0600);
+  if (dst_fd < 0)
+  {
+    fprintf(stderr, "failed to create migrate dst image\n");
+    return 1;
+  }
+  if (ftruncate(dst_fd, 64 * 1024 * 1024) != 0)
+  {
+    fprintf(stderr, "failed to size migrate dst image\n");
+    close(dst_fd);
+    return 1;
+  }
+  close(dst_fd);
+
+  char migrate_stdout[4096];
+  char *migrate_create_argv[] = {(char *)resize_abs,
+                                 (char *)"--migrate-create",
+                                 (char *)"--dst-image",
+                                 (char *)dst_img,
+                                 (char *)"--force",
+                                 (char *)"--inodes",
+                                 (char *)"4096",
+                                 (char *)"--src-mount",
+                                 (char *)"/srcmnt",
+                                 (char *)"--dst-mount",
+                                 (char *)"/dstmnt",
+                                 (char *)"--yes",
+                                 NULL};
+  if (run_cmd_capture_stdout(migrate_create_argv, migrate_stdout, sizeof(migrate_stdout)) != 0)
+  {
+    fprintf(stderr, "migrate-create failed\n");
+    return 1;
+  }
+
+  kafs_ssuperblock_t migrate_sb = {0};
+  if (read_superblock(dst_img, &migrate_sb) != 0)
+  {
+    fprintf(stderr, "failed to read migrate-create superblock\n");
+    return 1;
+  }
+  if (kafs_sb_magic_get(&migrate_sb) != KAFS_MAGIC ||
+      kafs_sb_format_version_get(&migrate_sb) != KAFS_FORMAT_VERSION ||
+      kafs_sb_inocnt_get(&migrate_sb) != 4096)
+  {
+    fprintf(stderr, "unexpected migrate-create image format\n");
+    return 1;
+  }
+  if (!strstr(migrate_stdout, "initial seed copy:") ||
+      !strstr(migrate_stdout, "--inplace --no-whole-file") ||
+      !strstr(migrate_stdout, "sudo rsync -aHAX --numeric-ids --delete /srcmnt/ /dstmnt/"))
+  {
+    fprintf(stderr, "migrate-create output missing low-transfer rsync guidance\n");
     return 1;
   }
 


### PR DESCRIPTION
## Summary
- teach kafsresize --migrate-create to print a two-step cutover flow with an initial seed copy and a final low-transfer rsync
- cover the new guidance in tests by capturing stdout from migrate-create and validating the generated image
- document the low-transfer cutover recommendation in the kafsresize man page

## Testing
- make -j4
- make check
- ./scripts/clones.sh
- ./scripts/static-checks.sh

Closes #22