### PR TITLE
release: prepare v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## v0.2.3 - 2026-03-04
-- `fsck.kafs` に統合モード `full` / `balanced` / `fast` を追加。
-- 低レベル修復オプションとしてジャーナル再生と未参照データブロックの punch-hole を追加。
-- `fsck.kafs` の journal リンク不足を修正し、静的解析指摘（条件式/ポインタ演算/const など）へ対応。
-- RPC/CLI/block/back-end の重複コードを削減し、クローン抑止と静的チェックの運用ルールを強化。
+## v0.3.0 - 2026-03-14
+- `kafsdump`, `kafsimage`, `kafsresize`, 拡張 `fsck.kafs` を含むオフライン運用ツール群を強化。
+- `fsck.kafs` に統合モード `full` / `balanced` / `fast`、ジャーナル再生、inode block-count 修復、未参照/空きデータブロック punch-hole を追加。
+- idle background dedup のスキャン制御、テレメトリ、HRL rescue 指標、`fsstat`/`stats` 可視化を追加。
+- logical delete tombstone と background GC を導入し、`kafsctl stats` / `kafs-info` / `fsck.kafs` で tombstone を扱えるようにした。
+- `mkfs.kafs` の上書き確認、クラッシュ診断、bash completion、clone/static/lock policy の品質ゲートを強化。
 
 ## v0.2.2 - 2026-03-01
 - pending 非同期処理の競合対策を強化（inode epoch 楽観ガード導入、stale pending の適用抑止）。

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ KAFS is a FUSE-based filesystem backed by a single image file with a journal and
 optional deduplication features. This repository contains the filesystem
 implementation, tools, and tests.
 
-## Release Highlights (v0.2.3)
+## Release Highlights (v0.3.0)
 
-- Added integrated `fsck.kafs` modes: `full`, `balanced`, and `fast`
-- Added low-level fsck options: journal replay and unreferenced-block punch-hole
-- Fixed `fsck.kafs` journal link dependency and addressed static-analysis findings
-- Reduced code duplication across RPC/CLI/block/back-end paths and tightened quality gates
+- Expanded the offline tooling suite with `kafsdump`, `kafsimage`, `kafsresize`, and richer `fsck.kafs` repair flows
+- Added idle background dedup scanning, telemetry, and HRL rescue observability in runtime stats
+- Introduced logical-delete tombstones with background GC and tombstone visibility in `kafsctl stats` and `kafs-info`
+- Tightened operational safety with `mkfs.kafs` overwrite confirmation, crash diagnostics, and stronger clone/static/lock gates
 
 ## Features
 

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.71])
-AC_INIT([kafs],[0.2.3],[mako10k@mk10.org])
+AC_INIT([kafs],[0.3.0],[mako10k@mk10.org])
 AC_CONFIG_SRCDIR([src/kafs.c])
 AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE([foreign])

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -32,6 +32,7 @@ design and policy notes.
 - [phase2-validation-20260228.md](phase2-validation-20260228.md)
 - [phase3-validation-20260228.md](phase3-validation-20260228.md)
 - [release-announcement-v0.2.1.md](release-announcement-v0.2.1.md)
+- [release-announcement-v0.3.0.md](release-announcement-v0.3.0.md)
 - [discussion-post-v0.2.1-final.md](discussion-post-v0.2.1-final.md)
 - [static-checks.md](static-checks.md)
 - [tools-suite.md](tools-suite.md)

--- a/docs/release-announcement-v0.3.0.md
+++ b/docs/release-announcement-v0.3.0.md
@@ -1,0 +1,63 @@
+# Release Announcement (v0.3.0)
+
+## Short summary
+
+- `v0.3.0` をリリースしました。
+- オフライン運用ツール群、background dedup、logical delete tombstone の一連の機能をまとめたマイルストーンリリースです。
+- 運用性だけでなく、観測性・修復性・品質ゲートも強化しました。
+
+## What changed since v0.2.2
+
+対象差分（`v0.2.2..HEAD`）:
+
+- `src/kafs.c`, `src/kafsctl.c`, `src/fsck_kafs.c`
+- `src/kafsdump.c`, `src/kafsimage.c`, `src/kafsresize.c`, `src/kafs_info.c`
+- `tests/tests_kafsresize.c`, `tests/tests_open_unlink_visibility.c`, `tests/tests_journal_boundary.c`
+- `README.md`, `man/*.1`, `man/*.8`, `CHANGELOG.md`
+
+主な変更:
+
+- `fsck.kafs` に統合モードと低レベル修復オプションを追加
+- `kafsdump`, `kafsimage`, `kafsresize` によるオフライン保守フローを拡充
+- idle background dedup の制御・可視化・HRL rescue 指標を追加
+- logical delete tombstone と background GC を追加し、統計・info・fsck に反映
+- `mkfs.kafs` の上書き確認、クラッシュ診断、completion、CI/clone/static gate を強化
+
+## Links
+
+- v0.2.2: https://github.com/mako10k/kafs/releases/tag/v0.2.2
+- v0.3.0: https://github.com/mako10k/kafs/releases/tag/v0.3.0
+
+---
+
+## Slack template (JP)
+
+KAFS `v0.3.0` をリリースしました。
+
+- `fsck.kafs`, `kafsdump`, `kafsimage`, `kafsresize` を中心にオフライン運用ツール群を強化
+- idle background dedup の制御と observability を追加
+- logical delete tombstone と background GC を導入し、`kafsctl stats` / `kafs-info` / `fsck.kafs` に反映
+- `mkfs.kafs` の上書き確認、クラッシュ診断、品質ゲートも強化
+
+詳細: https://github.com/mako10k/kafs/releases/tag/v0.3.0
+
+## GitHub Discussion template (JP)
+
+### KAFS v0.3.0 をリリースしました
+
+`v0.3.0` は、オフライン修復・イメージ操作・統計可視化・logical delete 運用までをまとめたマイルストーンリリースです。単一の機能追加ではなく、保守運用フロー全体を前進させる更新になっています。
+
+#### 変更点
+
+- `fsck.kafs`: 統合モード、journal replay、inode block-count repair、punch-hole 系オプションを追加
+- `kafsdump` / `kafsimage` / `kafsresize`: オフライン点検・出力・移行フローを拡充
+- background dedup: idle scan 制御、テレメトリ、HRL rescue 指標を追加
+- tombstone GC: logical delete tombstone、background GC、stats/info/fsck 連携を追加
+- operation hardening: `mkfs.kafs` overwrite confirmation、crash diagnostics、completion、品質ゲートを強化
+
+#### 互換性
+
+- 既存の single-image ベース運用を前提としたまま、保守ツールと観測性を拡張しています
+- 🟨 新機能が広範囲にまたがるため、既存運用へ適用する際は `fsck.kafs` とオフラインツール群の手順差分を先に確認するのが安全です
+
+Release: https://github.com/mako10k/kafs/releases/tag/v0.3.0

--- a/man/fsck.kafs.8
+++ b/man/fsck.kafs.8
@@ -1,5 +1,5 @@
 '.\" -*- nroff -*-
-.TH FSCK.KAFS 8 "2026-03-04" "kafs 0.2.3" "System Administration"
+.TH FSCK.KAFS 8 "2026-03-14" "kafs 0.3.0" "System Administration"
 .SH NAME
 fsck.kafs \- check and repair specific KAFS consistency layers
 .SH SYNOPSIS

--- a/man/kafs-back.8
+++ b/man/kafs-back.8
@@ -1,5 +1,5 @@
 '.\" -*- nroff -*-
-.TH KAFS-BACK 8 "2026-03-09" "kafs 0.2.3" "System Administration"
+.TH KAFS-BACK 8 "2026-03-14" "kafs 0.3.0" "System Administration"
 .SH NAME
 kafs-back \- hotplug back process speaking KAFS RPC
 .SH SYNOPSIS

--- a/man/kafs-front.8
+++ b/man/kafs-front.8
@@ -1,5 +1,5 @@
 '.\" -*- nroff -*-
-.TH KAFS-FRONT 8 "2026-03-09" "kafs 0.2.3" "System Administration"
+.TH KAFS-FRONT 8 "2026-03-14" "kafs 0.3.0" "System Administration"
 .SH NAME
 kafs-front \- hotplug front supervisor for kafs-back process
 .SH SYNOPSIS

--- a/man/kafs-info.8
+++ b/man/kafs-info.8
@@ -1,5 +1,5 @@
 '.\" -*- nroff -*-
-.TH KAFS-INFO 8 "2026-03-09" "kafs 0.2.3" "System Administration"
+.TH KAFS-INFO 8 "2026-03-14" "kafs 0.3.0" "System Administration"
 .SH NAME
 kafs-info \- print basic superblock and HRL summary from an offline KAFS image
 .SH SYNOPSIS

--- a/man/kafs.1
+++ b/man/kafs.1
@@ -1,5 +1,5 @@
 '.\" -*- nroff -*-
-.TH KAFS 1 "2026-03-04" "kafs 0.2.3" "User Commands"
+.TH KAFS 1 "2026-03-14" "kafs 0.3.0" "User Commands"
 .SH NAME
 kafs \- FUSE-based KAFS filesystem
 .SH SYNOPSIS

--- a/man/kafsctl.1
+++ b/man/kafsctl.1
@@ -1,5 +1,5 @@
 '.\" -*- nroff -*-
-.TH KAFSCTL 1 "2026-03-09" "kafs 0.2.3" "User Commands"
+.TH KAFSCTL 1 "2026-03-14" "kafs 0.3.0" "User Commands"
 .SH NAME
 kafsctl \- runtime control and maintenance utility for mounted KAFS
 .SH SYNOPSIS

--- a/man/kafsdump.8
+++ b/man/kafsdump.8
@@ -1,5 +1,5 @@
 '.\" -*- nroff -*-
-.TH KAFSDUMP 8 "2026-03-04" "kafs 0.2.3" "System Administration"
+.TH KAFSDUMP 8 "2026-03-14" "kafs 0.3.0" "System Administration"
 .SH NAME
 kafsdump \- inspect offline KAFS image metadata without mutation
 .SH SYNOPSIS

--- a/man/kafsimage.8
+++ b/man/kafsimage.8
@@ -1,5 +1,5 @@
 '.\" -*- nroff -*-
-.TH KAFSIMAGE 8 "2026-03-04" "kafs 0.2.3" "System Administration"
+.TH KAFSIMAGE 8 "2026-03-14" "kafs 0.3.0" "System Administration"
 .SH NAME
 kafsimage \- export offline KAFS image data in metadata-only mode
 .SH SYNOPSIS

--- a/man/kafsresize.8
+++ b/man/kafsresize.8
@@ -1,5 +1,5 @@
 '.\" -*- nroff -*-
-.TH KAFSRESIZE 8 "2026-03-04" "kafs 0.2.3" "System Administration"
+.TH KAFSRESIZE 8 "2026-03-14" "kafs 0.3.0" "System Administration"
 .SH NAME
 kafsresize \- grow offline KAFS image logical block range (grow-only)
 .SH SYNOPSIS

--- a/man/mkfs.kafs.8
+++ b/man/mkfs.kafs.8
@@ -1,5 +1,5 @@
 '.\" -*- nroff -*-
-.TH MKFS.KAFS 8 "2026-03-04" "kafs 0.2.3" "System Administration"
+.TH MKFS.KAFS 8 "2026-03-14" "kafs 0.3.0" "System Administration"
 .SH NAME
 mkfs.kafs \- create a KAFS filesystem image
 .SH SYNOPSIS


### PR DESCRIPTION
## Summary
- bump version metadata to `v0.3.0`
- refresh CHANGELOG/README release highlights to match the actual release scope
- sync man page headers and add the v0.3.0 release announcement doc

## Testing
- make -j4
- make -j4 check
- ./scripts/clones.sh
- ./scripts/static-checks.sh
- ./scripts/format.sh check
