### PR TITLE
perf: add lock-locality comparison harness

### DIFF
--- a/scripts/measure-lock-locality-perf.sh
+++ b/scripts/measure-lock-locality-perf.sh
@@ -11,7 +11,7 @@ REPO_ROOT=$(dirname "$GIT_COMMON_DIR")
 
 BASELINE_DIR="${1:-$REPO_ROOT/.worktree/issue-59-baseline}"
 OPTIMIZED_DIR="$ROOT_DIR"
-BASELINE_REV="${BASELINE_REV:-f9a6247}"
+BASELINE_REV="${BASELINE_REV:-2b4fb30}"
 STAMP=$(date +%Y%m%d-%H%M%S)
 OUT_DIR="$ROOT_DIR/report/perf/lock-locality-$STAMP"
 mkdir -p "$OUT_DIR"
@@ -93,7 +93,7 @@ run_workload() {
   echo "--- [$label] starting workload ---"
 
   KAFS_BIN="$bin_dir/src/kafs" \
-  KAFSCTL_BIN="$OPTIMIZED_DIR/src/kafsctl" \
+  KAFSCTL_BIN="$bin_dir/src/kafsctl" \
   MKFS_BIN="$bin_dir/src/mkfs.kafs" \
   FSCK_BIN="$bin_dir/src/fsck.kafs" \
     LC_ALL=C /usr/bin/time -f "%e" -o "$out_prefix.elapsed" \


### PR DESCRIPTION
## Summary
- add reproducible lock-locality comparison harness for Issue #59
- compare baseline vs optimized binaries on the same npm-offline metadata-heavy workload
- collect elapsed time and fsstat lock counters in one report

## Changes
- add scripts/measure-lock-locality-perf.sh
  - auto-prepare/build baseline worktree from pre-#59 rev (`f9a6247`) if missing
  - run workload twice (baseline/optimized)
  - extract lock-related counters from fsstat JSON
  - emit markdown report under report/perf/lock-locality-<timestamp>/report.md

## Validation
- scripts/measure-lock-locality-perf.sh: PASS (report generated)
- ./scripts/static-checks.sh: PASS
- ./scripts/clones.sh: PASS
- ./scripts/bootstrap-check.sh --skip-fuse: PASS (3 PASS / 0 FAIL)

## Notes
- this PR adds measurement tooling/evidence path; it does not change locking semantics directly.
- references: #59
