### PR TITLE
feat: add inode-size tail descriptor checks

### DIFF
--- a/src/kafs_tailmeta.h
+++ b/src/kafs_tailmeta.h
@@ -624,3 +624,56 @@ static inline int kafs_tailmeta_inode_desc_matches_slot(const kafs_tailmeta_inod
     return -EPROTO;
   return 0;
 }
+
+static inline int
+kafs_tailmeta_inode_desc_validate_for_inode(const kafs_tailmeta_inode_desc_t *desc,
+                                            kafs_off_t inode_size, uint16_t class_bytes,
+                                            kafs_blksize_t blksize)
+{
+  uint8_t kind = 0;
+  uint16_t len = 0;
+  const kafs_off_t inline_limit = (kafs_off_t)sizeof(((struct kafs_sinode *)NULL)->i_blkreftbl);
+
+  if (blksize == 0)
+    return -EINVAL;
+
+  int rc = kafs_tailmeta_inode_desc_validate(desc, class_bytes);
+  if (rc != 0)
+    return rc;
+
+  kind = kafs_tailmeta_inode_desc_layout_kind_get(desc);
+  len = kafs_tailmeta_inode_desc_fragment_len_get(desc);
+  switch (kind)
+  {
+  case KAFS_TAIL_LAYOUT_INLINE:
+    return (inode_size <= inline_limit) ? 0 : -EPROTO;
+
+  case KAFS_TAIL_LAYOUT_FULL_BLOCK:
+    return (inode_size == 0 || inode_size > inline_limit) ? 0 : -EPROTO;
+
+  case KAFS_TAIL_LAYOUT_TAIL_ONLY:
+    if ((kafs_off_t)len != inode_size)
+      return -EPROTO;
+    if (inode_size <= inline_limit)
+      return -EPROTO;
+    return ((kafs_blksize_t)len < blksize) ? 0 : -EPROTO;
+
+  case KAFS_TAIL_LAYOUT_MIXED_FULL_TAIL:
+    if ((kafs_off_t)len >= inode_size || (kafs_blksize_t)len >= blksize)
+      return -EPROTO;
+    return (((uint64_t)inode_size - (uint64_t)len) % (uint64_t)blksize) == 0u ? 0 : -EPROTO;
+
+  default:
+    return -EPROTO;
+  }
+}
+
+static inline int kafs_tailmeta_inode_desc_matches_slot_for_inode(
+    const kafs_tailmeta_inode_desc_t *desc, const kafs_tailmeta_slot_desc_t *slot,
+    uint16_t class_bytes, kafs_inocnt_t ino, kafs_off_t inode_size, kafs_blksize_t blksize)
+{
+  int rc = kafs_tailmeta_inode_desc_validate_for_inode(desc, inode_size, class_bytes, blksize);
+  if (rc != 0)
+    return rc;
+  return kafs_tailmeta_inode_desc_matches_slot(desc, slot, class_bytes, ino);
+}

--- a/tests/tests_tailmeta_parser.c
+++ b/tests/tests_tailmeta_parser.c
@@ -67,6 +67,9 @@ int main(void)
   slot.ts_generation = kafs_u32_htos(11);
   kafs_tailmeta_slot_len_set(&slot, 64);
   assert(kafs_tailmeta_inode_desc_matches_slot(&desc, &slot, 128, 7) == 0);
+  assert(kafs_tailmeta_inode_desc_validate_for_inode(&desc, 64, 128, 4096) == 0);
+  assert(kafs_tailmeta_inode_desc_validate_for_inode(&desc, 60, 128, 4096) != 0);
+  assert(kafs_tailmeta_inode_desc_matches_slot_for_inode(&desc, &slot, 128, 7, 64, 4096) == 0);
   kafs_tailmeta_slot_len_set(&slot, 63);
   assert(kafs_tailmeta_inode_desc_matches_slot(&desc, &slot, 128, 7) != 0);
 
@@ -76,6 +79,16 @@ int main(void)
 
   kafs_tailmeta_inode_desc_fragment_off_set(&desc, 96);
   assert(kafs_tailmeta_inode_desc_validate(&desc, 128) != 0);
+  kafs_tailmeta_inode_desc_fragment_off_set(&desc, 32);
+
+  kafs_tailmeta_inode_desc_layout_kind_set(&desc, KAFS_TAIL_LAYOUT_MIXED_FULL_TAIL);
+  kafs_tailmeta_inode_desc_flags_set(&desc, KAFS_TAILDESC_FLAG_FINAL_TAIL);
+  assert(kafs_tailmeta_inode_desc_validate_for_inode(&desc, 4096 + 64, 128, 4096) == 0);
+  assert(kafs_tailmeta_inode_desc_validate_for_inode(&desc, 4000, 128, 4096) != 0);
+
+  kafs_tailmeta_inode_desc_init(&desc);
+  assert(kafs_tailmeta_inode_desc_validate_for_inode(&desc, 32, 128, 4096) == 0);
+  assert(kafs_tailmeta_inode_desc_validate_for_inode(&desc, 128, 128, 4096) != 0);
 
   return 0;
 }


### PR DESCRIPTION
## Summary
- add inode-size-aware validation helpers for future tail inode descriptors
- validate tail-only and mixed-full-tail descriptor semantics against inode size and block size
- extend the focused tail metadata parser test with inode-size invariants

## Scope
This is the next read-only/fsck-prep slice for #85 after PR #87. It still does not modify the on-disk inode layout and does not enable any write path.

## Validation
- autoreconf -fi
- ./configure --enable-lto
- make -j"$(nproc)"
- make check TESTS=tailmeta_parser
- ./scripts/format.sh
- ./scripts/clones.sh
- ./scripts/static-checks.sh

## Results
- build: PASS
- tailmeta_parser: PASS
- format: PASS
- clones: PASS (0 clones)
- static-checks: PASS

Refs #85