### PR TITLE
feat: add tail descriptor report checks

### DIFF
--- a/src/kafs_tailmeta.h
+++ b/src/kafs_tailmeta.h
@@ -24,6 +24,13 @@
   (KAFS_TAILDESC_FLAG_PACKED_SMALL_FILE | KAFS_TAILDESC_FLAG_FINAL_TAIL |                          \
    KAFS_TAILDESC_FLAG_NEEDS_FSCK_REVIEW)
 
+#define KAFS_TAILCHECK_INVALID_DESC (1u << 0)
+#define KAFS_TAILCHECK_INVALID_SLOT (1u << 1)
+#define KAFS_TAILCHECK_INVALID_INODE_SIZE (1u << 2)
+#define KAFS_TAILCHECK_OWNER_MISMATCH (1u << 3)
+#define KAFS_TAILCHECK_LENGTH_MISMATCH (1u << 4)
+#define KAFS_TAILCHECK_GENERATION_MISMATCH (1u << 5)
+
 struct kafs_stailmeta_region_hdr
 {
   kafs_su32_t tr_magic;
@@ -676,4 +683,35 @@ static inline int kafs_tailmeta_inode_desc_matches_slot_for_inode(
   if (rc != 0)
     return rc;
   return kafs_tailmeta_inode_desc_matches_slot(desc, slot, class_bytes, ino);
+}
+
+static inline uint32_t kafs_tailmeta_inode_desc_report_flags(
+    const kafs_tailmeta_inode_desc_t *desc, const kafs_tailmeta_slot_desc_t *slot,
+    uint16_t class_bytes, kafs_inocnt_t ino, kafs_off_t inode_size, kafs_blksize_t blksize)
+{
+  uint32_t flags = 0;
+  int rc = kafs_tailmeta_inode_desc_validate(desc, class_bytes);
+  if (rc != 0)
+    flags |= KAFS_TAILCHECK_INVALID_DESC;
+
+  rc = kafs_tailmeta_slot_validate(slot, class_bytes);
+  if (rc != 0)
+    flags |= KAFS_TAILCHECK_INVALID_SLOT;
+
+  rc = kafs_tailmeta_inode_desc_validate_for_inode(desc, inode_size, class_bytes, blksize);
+  if (rc != 0)
+    flags |= KAFS_TAILCHECK_INVALID_INODE_SIZE;
+
+  if ((flags & (KAFS_TAILCHECK_INVALID_DESC | KAFS_TAILCHECK_INVALID_SLOT)) != 0)
+    return flags;
+  if (!kafs_tailmeta_inode_desc_uses_tail_storage(desc))
+    return flags | KAFS_TAILCHECK_INVALID_DESC;
+
+  if (kafs_tailmeta_slot_owner_ino_get(slot) != ino)
+    flags |= KAFS_TAILCHECK_OWNER_MISMATCH;
+  if (kafs_tailmeta_slot_len_get(slot) != kafs_tailmeta_inode_desc_fragment_len_get(desc))
+    flags |= KAFS_TAILCHECK_LENGTH_MISMATCH;
+  if (kafs_u32_stoh(slot->ts_generation) != kafs_tailmeta_inode_desc_generation_get(desc))
+    flags |= KAFS_TAILCHECK_GENERATION_MISMATCH;
+  return flags;
 }

--- a/tests/tests_tailmeta_parser.c
+++ b/tests/tests_tailmeta_parser.c
@@ -67,15 +67,26 @@ int main(void)
   slot.ts_generation = kafs_u32_htos(11);
   kafs_tailmeta_slot_len_set(&slot, 64);
   assert(kafs_tailmeta_inode_desc_matches_slot(&desc, &slot, 128, 7) == 0);
+    assert(kafs_tailmeta_inode_desc_report_flags(&desc, &slot, 128, 7, 64, 4096) == 0);
   assert(kafs_tailmeta_inode_desc_validate_for_inode(&desc, 64, 128, 4096) == 0);
   assert(kafs_tailmeta_inode_desc_validate_for_inode(&desc, 60, 128, 4096) != 0);
   assert(kafs_tailmeta_inode_desc_matches_slot_for_inode(&desc, &slot, 128, 7, 64, 4096) == 0);
   kafs_tailmeta_slot_len_set(&slot, 63);
   assert(kafs_tailmeta_inode_desc_matches_slot(&desc, &slot, 128, 7) != 0);
+    assert((kafs_tailmeta_inode_desc_report_flags(&desc, &slot, 128, 7, 64, 4096) &
+      KAFS_TAILCHECK_LENGTH_MISMATCH) != 0);
 
   kafs_tailmeta_slot_len_set(&slot, 64);
   slot.ts_generation = kafs_u32_htos(12);
   assert(kafs_tailmeta_inode_desc_matches_slot(&desc, &slot, 128, 7) != 0);
+    assert((kafs_tailmeta_inode_desc_report_flags(&desc, &slot, 128, 7, 64, 4096) &
+      KAFS_TAILCHECK_GENERATION_MISMATCH) != 0);
+
+    slot.ts_generation = kafs_u32_htos(11);
+    kafs_tailmeta_slot_owner_ino_set(&slot, 8);
+    assert((kafs_tailmeta_inode_desc_report_flags(&desc, &slot, 128, 7, 64, 4096) &
+      KAFS_TAILCHECK_OWNER_MISMATCH) != 0);
+    kafs_tailmeta_slot_owner_ino_set(&slot, 7);
 
   kafs_tailmeta_inode_desc_fragment_off_set(&desc, 96);
   assert(kafs_tailmeta_inode_desc_validate(&desc, 128) != 0);
@@ -85,6 +96,8 @@ int main(void)
   kafs_tailmeta_inode_desc_flags_set(&desc, KAFS_TAILDESC_FLAG_FINAL_TAIL);
   assert(kafs_tailmeta_inode_desc_validate_for_inode(&desc, 4096 + 64, 128, 4096) == 0);
   assert(kafs_tailmeta_inode_desc_validate_for_inode(&desc, 4000, 128, 4096) != 0);
+    assert((kafs_tailmeta_inode_desc_report_flags(&desc, &slot, 128, 7, 4000, 4096) &
+      KAFS_TAILCHECK_INVALID_INODE_SIZE) != 0);
 
   kafs_tailmeta_inode_desc_init(&desc);
   assert(kafs_tailmeta_inode_desc_validate_for_inode(&desc, 32, 128, 4096) == 0);


### PR DESCRIPTION
## Summary
- add report-only mismatch flags for future tail inode descriptor validation
- classify descriptor, slot, inode-size, owner, length, and generation mismatches
- extend the focused tail metadata parser test to cover report-only reasons

## Scope
This is the next fsck-prep slice for #85 after PR #88. It still does not change the on-disk inode layout and keeps the work in shared helpers/tests so fsck wiring can consume it next.

## Validation
- autoreconf -fi
- ./configure --enable-lto
- make -j"$(nproc)"
- make check TESTS=tailmeta_parser
- ./scripts/format.sh
- ./scripts/clones.sh
- ./scripts/static-checks.sh

## Results
- build: PASS
- tailmeta_parser: PASS
- format: PASS
- clones: PASS (0 clones)
- static-checks: PASS

Refs #85