### PR TITLE
feat: add future inode-v5 layout scaffold

### DIFF
--- a/src/kafs.h
+++ b/src/kafs.h
@@ -153,6 +153,7 @@ typedef uint_fast32_t kafs_hrid_t;
 // --- 定数（新フォーマット用） ---
 #define KAFS_MAGIC 0x4B414653u /* 'KAFS' */
 #define KAFS_FORMAT_VERSION 4u /* v4: versioned dirent header/records */
+#define KAFS_FORMAT_VERSION_V5 5u
 #define KAFS_FORMAT_VERSION_V3 3u
 #define KAFS_FORMAT_VERSION_V2 2u
 #define KAFS_HASH_FAST_XXH64 1u

--- a/src/kafs_inode.h
+++ b/src/kafs_inode.h
@@ -1,12 +1,33 @@
 #pragma once
 #include "kafs_config.h"
 #include "kafs.h"
+#include <assert.h>
 #include <errno.h>
 
 /// 存在しないことを表す inode 番号
 #define KAFS_INO_NONE 0
 /// ルートディレクトリの inode 番号
 #define KAFS_INO_ROOTDIR 1
+
+#define KAFS_INODE_BLOCKREF_SLOTS 15u
+#define KAFS_INODE_DIRECT_BYTES 60u
+#define KAFS_INODE_TAILDESC_V5_BYTES 16u
+#define KAFS_INODE_V4_BYTES 114u
+#define KAFS_INODE_V5_BYTES (KAFS_INODE_V4_BYTES + KAFS_INODE_TAILDESC_V5_BYTES)
+
+/// @brief 将来の v5 inode 内 tail descriptor 予約領域
+struct kafs_sinode_taildesc_v5
+{
+  uint8_t it_layout_kind;
+  uint8_t it_flags;
+  uint16_t it_fragment_len;
+  kafs_sblkcnt_t it_container_blo;
+  uint16_t it_fragment_off;
+  kafs_su32_t it_generation;
+  uint16_t it_reserved0;
+} __attribute__((packed));
+
+typedef struct kafs_sinode_taildesc_v5 kafs_sinode_taildesc_v5_t;
 
 /// @brief inode 情報
 struct kafs_sinode
@@ -34,10 +55,40 @@ struct kafs_sinode
   /// @brief デバイス番号
   kafs_sdev_t i_rdev;
   /// @brief ブロックデータ
-  kafs_sblkcnt_t i_blkreftbl[15];
+  kafs_sblkcnt_t i_blkreftbl[KAFS_INODE_BLOCKREF_SLOTS];
 } __attribute__((packed));
 
 typedef struct kafs_sinode kafs_sinode_t;
+
+/// @brief 将来の v5 inode 情報
+struct kafs_sinode_v5
+{
+  kafs_smode_t i_mode;
+  kafs_suid_t i_uid;
+  kafs_soff_t i_size;
+  kafs_stime_t i_atime;
+  kafs_stime_t i_ctime;
+  kafs_stime_t i_mtime;
+  kafs_stime_t i_dtime;
+  kafs_sgid_t i_gid;
+  kafs_slinkcnt_t i_linkcnt;
+  kafs_sblkcnt_t i_blocks;
+  kafs_sdev_t i_rdev;
+  kafs_sblkcnt_t i_blkreftbl[KAFS_INODE_BLOCKREF_SLOTS];
+  kafs_sinode_taildesc_v5_t i_taildesc;
+} __attribute__((packed));
+
+typedef struct kafs_sinode_v5 kafs_sinode_v5_t;
+
+_Static_assert(sizeof(kafs_sinode_taildesc_v5_t) == KAFS_INODE_TAILDESC_V5_BYTES,
+               "kafs_sinode_taildesc_v5_t must be 16 bytes");
+_Static_assert(sizeof(((struct kafs_sinode *)NULL)->i_blkreftbl) == KAFS_INODE_DIRECT_BYTES,
+               "kafs_sinode direct payload must remain 60 bytes");
+_Static_assert(sizeof(kafs_sinode_t) == KAFS_INODE_V4_BYTES,
+               "kafs_sinode must remain 114 bytes in v4");
+_Static_assert(sizeof(((struct kafs_sinode_v5 *)NULL)->i_blkreftbl) == KAFS_INODE_DIRECT_BYTES,
+               "kafs_sinode_v5 direct payload must preserve 60 bytes");
+_Static_assert(sizeof(kafs_sinode_v5_t) == KAFS_INODE_V5_BYTES, "kafs_sinode_v5 must be 130 bytes");
 
 static kafs_mode_t kafs_ino_mode_get(const kafs_sinode_t *inoent)
 {


### PR DESCRIPTION
## Summary
- add a reserved v5 format version constant
- define a packed future inode-v5 tail descriptor shape
- add compile-time assertions that preserve the 60-byte inline payload while growing inode size to 130 bytes

## Validation
- autoreconf -fi
- ./configure --enable-lto
- make -j"$(nproc)"
- make check TESTS=tailmeta_parser
- ./scripts/format.sh fix
- ./scripts/clones.sh
- ./scripts/static-checks.sh

## Notes
- active runtime behavior remains v4
- no write path or format bump activation yet