### PR TITLE
refactor: use inode inline-byte helper in tailmeta

### DIFF
--- a/src/kafs_tailmeta.h
+++ b/src/kafs_tailmeta.h
@@ -630,7 +630,7 @@ kafs_tailmeta_inode_desc_validate_for_inode(const kafs_tailmeta_inode_desc_t *de
 {
   uint8_t kind = 0;
   uint16_t len = 0;
-  const kafs_off_t inline_limit = (kafs_off_t)sizeof(((struct kafs_sinode *)NULL)->i_blkreftbl);
+  const kafs_off_t inline_limit = (kafs_off_t)kafs_inode_inline_bytes();
 
   if (blksize == 0)
     return -EINVAL;


### PR DESCRIPTION
## Summary
- replace the raw inline payload size expression in tailmeta inode validation with the shared inode inline-byte helper
- keep tailmeta inode-size validation aligned with the centralized inode geometry helpers

## Impact
- no runtime behavior change intended
- reduces one remaining raw inline-boundary assumption in tailmeta validation

## Testing
- autoreconf -fi
- ./configure --enable-lto
- make -j"$(nproc)"
- make check -j"$(nproc)"
- ./scripts/format.sh
- ./scripts/clones.sh
- ./scripts/static-checks.sh
