### PR TITLE
refactor: share inline boundary helper

### DIFF
--- a/src/fsck_kafs.c
+++ b/src/fsck_kafs.c
@@ -494,7 +494,7 @@ static int orphan_reclaim(kafs_context_t *ctx, int do_fix, struct orphan_stats *
 
     // Free all referenced blocks (direct + indirect tables) best-effort.
     // NOTE: For "direct" small files, data is in inode and there are no blocks to free.
-    if (kafs_ino_size_get(e) > (kafs_off_t)sizeof(e->i_blkreftbl))
+    if (kafs_ino_size_get(e) > (kafs_off_t)kafs_inode_inline_bytes())
     {
       // Direct data blocks
       for (uint32_t i = 0; i < 12; ++i)
@@ -800,7 +800,7 @@ static void hrl_scan_expected_inode_refs(struct hrl_scan_ctx *sctx, kafs_inocnt_
       continue;
     if (S_ISDIR(kafs_ino_mode_get(e)))
       continue;
-    if (kafs_ino_size_get(e) <= (kafs_off_t)sizeof(e->i_blkreftbl))
+    if (kafs_ino_size_get(e) <= (kafs_off_t)kafs_inode_inline_bytes())
       continue;
 
     for (uint32_t i = 0; i < 12; ++i)
@@ -1158,7 +1158,7 @@ static int check_or_repair_inode_block_counts(kafs_context_t *ctx, int do_fix,
     uint64_t expected = 0;
     struct inode_blocks_scan_ctx sctx = {ctx, r_blkcnt, l2, blksize, refs_pb, 0};
 
-    if (kafs_ino_size_get(e) > (kafs_off_t)sizeof(e->i_blkreftbl))
+    if (kafs_ino_size_get(e) > (kafs_off_t)kafs_inode_inline_bytes())
     {
       for (uint32_t i = 0; i < 12; ++i)
         inode_blocks_count_data_ref(&sctx, kafs_blkcnt_stoh(e->i_blkreftbl[i]), &expected);

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -3688,9 +3688,10 @@ static ssize_t kafs_pwrite(struct kafs_context *ctx, kafs_sinode_t *inoent, cons
   }
 
   size_t size_written = 0;
+  const size_t inline_limit = kafs_inode_inline_bytes();
 
   // 60バイト以下は直接
-  if (filesize <= sizeof(inoent->i_blkreftbl))
+  if (filesize <= inline_limit)
   {
     memcpy((void *)inoent->i_blkreftbl + offset, buf, size);
     return size;

--- a/src/kafs_hrl.c
+++ b/src/kafs_hrl.c
@@ -141,7 +141,7 @@ static int hrl_write_blo(kafs_context_t *ctx, kafs_blkcnt_t blo, const void *buf
       kafs_mode_t mode = kafs_ino_mode_get(inoent);
       if (!S_ISDIR(mode))
         continue;
-      if (kafs_ino_size_get(inoent) <= sizeof(inoent->i_blkreftbl))
+      if (kafs_ino_size_get(inoent) <= (kafs_off_t)kafs_inode_inline_bytes())
         continue;
       kafs_blkcnt_t cur_ref = kafs_blkcnt_stoh(inoent->i_blkreftbl[0]);
       if (cur_ref != blo)


### PR DESCRIPTION
## Summary
- replace remaining raw inline-payload boundary comparisons with the shared inode inline-byte helper
- update core write path, fsck block/ref scans, and HRL dir-block scan to reference the centralized boundary helper

## Impact
- no runtime behavior change intended
- reduces remaining duplicated inline-threshold assumptions outside inode/tailmeta helpers

## Testing
- autoreconf -fi
- ./configure --enable-lto
- make -j"$(nproc)"
- make check -j"$(nproc)"
- ./scripts/format.sh
- ./scripts/clones.sh
- ./scripts/static-checks.sh
