### PR TITLE
refactor: share inline size predicates

### DIFF
--- a/src/fsck_kafs.c
+++ b/src/fsck_kafs.c
@@ -494,7 +494,7 @@ static int orphan_reclaim(kafs_context_t *ctx, int do_fix, struct orphan_stats *
 
     // Free all referenced blocks (direct + indirect tables) best-effort.
     // NOTE: For "direct" small files, data is in inode and there are no blocks to free.
-    if (kafs_ino_size_get(e) > (kafs_off_t)kafs_inode_inline_bytes())
+    if (kafs_inode_size_uses_blocks(kafs_ino_size_get(e)))
     {
       // Direct data blocks
       for (uint32_t i = 0; i < 12; ++i)
@@ -800,7 +800,7 @@ static void hrl_scan_expected_inode_refs(struct hrl_scan_ctx *sctx, kafs_inocnt_
       continue;
     if (S_ISDIR(kafs_ino_mode_get(e)))
       continue;
-    if (kafs_ino_size_get(e) <= (kafs_off_t)kafs_inode_inline_bytes())
+    if (kafs_inode_size_is_inline(kafs_ino_size_get(e)))
       continue;
 
     for (uint32_t i = 0; i < 12; ++i)
@@ -1158,7 +1158,7 @@ static int check_or_repair_inode_block_counts(kafs_context_t *ctx, int do_fix,
     uint64_t expected = 0;
     struct inode_blocks_scan_ctx sctx = {ctx, r_blkcnt, l2, blksize, refs_pb, 0};
 
-    if (kafs_ino_size_get(e) > (kafs_off_t)kafs_inode_inline_bytes())
+    if (kafs_inode_size_uses_blocks(kafs_ino_size_get(e)))
     {
       for (uint32_t i = 0; i < 12; ++i)
         inode_blocks_count_data_ref(&sctx, kafs_blkcnt_stoh(e->i_blkreftbl[i]), &expected);

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -3688,10 +3688,8 @@ static ssize_t kafs_pwrite(struct kafs_context *ctx, kafs_sinode_t *inoent, cons
   }
 
   size_t size_written = 0;
-  const size_t inline_limit = kafs_inode_inline_bytes();
-
   // 60バイト以下は直接
-  if (filesize <= inline_limit)
+  if (kafs_inode_size_is_inline((kafs_off_t)filesize))
   {
     memcpy((void *)inoent->i_blkreftbl + offset, buf, size);
     return size;

--- a/src/kafs_hrl.c
+++ b/src/kafs_hrl.c
@@ -141,7 +141,7 @@ static int hrl_write_blo(kafs_context_t *ctx, kafs_blkcnt_t blo, const void *buf
       kafs_mode_t mode = kafs_ino_mode_get(inoent);
       if (!S_ISDIR(mode))
         continue;
-      if (kafs_ino_size_get(inoent) <= (kafs_off_t)kafs_inode_inline_bytes())
+      if (kafs_inode_size_is_inline(kafs_ino_size_get(inoent)))
         continue;
       kafs_blkcnt_t cur_ref = kafs_blkcnt_stoh(inoent->i_blkreftbl[0]);
       if (cur_ref != blo)

--- a/src/kafs_inode.h
+++ b/src/kafs_inode.h
@@ -103,6 +103,16 @@ _Static_assert(sizeof(kafs_sinode_v5_t) == KAFS_INODE_V5_BYTES, "kafs_sinode_v5 
 
 static inline size_t kafs_inode_inline_bytes(void) { return KAFS_INODE_DIRECT_BYTES; }
 
+static inline int kafs_inode_size_is_inline(kafs_off_t inode_size)
+{
+  return inode_size <= (kafs_off_t)kafs_inode_inline_bytes();
+}
+
+static inline int kafs_inode_size_uses_blocks(kafs_off_t inode_size)
+{
+  return inode_size > (kafs_off_t)kafs_inode_inline_bytes();
+}
+
 static inline size_t kafs_inode_bytes_for_format(uint32_t format_version)
 {
   switch (format_version)

--- a/src/kafs_tailmeta.h
+++ b/src/kafs_tailmeta.h
@@ -630,7 +630,6 @@ kafs_tailmeta_inode_desc_validate_for_inode(const kafs_tailmeta_inode_desc_t *de
 {
   uint8_t kind = 0;
   uint16_t len = 0;
-  const kafs_off_t inline_limit = (kafs_off_t)kafs_inode_inline_bytes();
 
   if (blksize == 0)
     return -EINVAL;
@@ -644,15 +643,15 @@ kafs_tailmeta_inode_desc_validate_for_inode(const kafs_tailmeta_inode_desc_t *de
   switch (kind)
   {
   case KAFS_TAIL_LAYOUT_INLINE:
-    return (inode_size <= inline_limit) ? 0 : -EPROTO;
+    return kafs_inode_size_is_inline(inode_size) ? 0 : -EPROTO;
 
   case KAFS_TAIL_LAYOUT_FULL_BLOCK:
-    return (inode_size == 0 || inode_size > inline_limit) ? 0 : -EPROTO;
+    return (inode_size == 0 || kafs_inode_size_uses_blocks(inode_size)) ? 0 : -EPROTO;
 
   case KAFS_TAIL_LAYOUT_TAIL_ONLY:
     if ((kafs_off_t)len != inode_size)
       return -EPROTO;
-    if (inode_size <= inline_limit)
+    if (kafs_inode_size_is_inline(inode_size))
       return -EPROTO;
     return ((kafs_blksize_t)len < blksize) ? 0 : -EPROTO;
 


### PR DESCRIPTION
## Summary
- add shared inode-size predicates for inline-vs-block-backed decisions
- switch remaining inline-boundary comparisons in core write, fsck, HRL, and tailmeta validation to those predicates

## Impact
- no runtime behavior change intended
- keeps inline storage decision logic centralized alongside inode geometry helpers

## Testing
- autoreconf -fi
- ./configure --enable-lto
- make -j"$(nproc)"
- make check -j"$(nproc)"
- ./scripts/format.sh
- ./scripts/clones.sh
- ./scripts/static-checks.sh
