### PR TITLE
refactor: add tail descriptor conversion helpers

### DIFF
--- a/src/kafs_tailmeta.h
+++ b/src/kafs_tailmeta.h
@@ -416,6 +416,24 @@ static inline void kafs_tailmeta_inode_desc_init(kafs_tailmeta_inode_desc_t *des
   kafs_tailmeta_inode_desc_layout_kind_set(desc, KAFS_TAIL_LAYOUT_INLINE);
 }
 
+static inline void
+kafs_tailmeta_inode_desc_from_inode_taildesc(kafs_tailmeta_inode_desc_t *desc,
+                                             const kafs_sinode_taildesc_v5_t *taildesc)
+{
+  assert(desc != NULL);
+  assert(taildesc != NULL);
+  memcpy(desc, taildesc, sizeof(*desc));
+}
+
+static inline void
+kafs_tailmeta_inode_desc_to_inode_taildesc(kafs_sinode_taildesc_v5_t *taildesc,
+                                           const kafs_tailmeta_inode_desc_t *desc)
+{
+  assert(taildesc != NULL);
+  assert(desc != NULL);
+  memcpy(taildesc, desc, sizeof(*taildesc));
+}
+
 static inline int kafs_tailmeta_inode_desc_uses_tail_storage(const kafs_tailmeta_inode_desc_t *desc)
 {
   uint8_t kind = kafs_tailmeta_inode_desc_layout_kind_get(desc);


### PR DESCRIPTION
## Summary
- add helper functions to copy between future inode tail descriptors and tailmeta inode descriptors
- use the existing size/offset equivalence guarantees to centralize descriptor conversion at one call site

## Impact
- no runtime behavior change intended
- makes the inode-taildesc and tailmeta-descriptor shape sharing explicit beyond static asserts alone

## Testing
- autoreconf -fi
- ./configure --enable-lto
- make -j"$(nproc)"
- make check -j"$(nproc)"
- ./scripts/format.sh
- ./scripts/clones.sh
- ./scripts/static-checks.sh
