### PR TITLE
docs: note shared tail descriptor shape

### DIFF
--- a/docs/tail-packing-format-sketch.md
+++ b/docs/tail-packing-format-sketch.md
@@ -541,6 +541,10 @@ first-cut recommendation としては、A を採るなら 130 bytes より 128 b
 
 この形なら descriptor 合計は 14 bytes であり、114-byte v4 inode に追加しても 128 bytes に収まる。
 
+実装 scaffold でも、この 14-byte 形は inode 内 tail descriptor と tailmeta parser/fsck 用 inode descriptor で同じ field 配置を共有する前提にしておくのがよい。
+
+少なくとも first-cut では、両者を別 meaning に分岐させず、helper 経由で相互変換できる同形 descriptor として扱う方が drift を防ぎやすい。
+
 この方針では、初回導入では予約領域を無理に inode 内へ残さず、将来拡張が必要になった時点で外部 descriptor table 案を再検討する方が筋がよい。
 
 ### Why This Shape


### PR DESCRIPTION
## Summary
- document that the first-cut 14-byte descriptor shape is intended to stay identical between the inode tail descriptor scaffold and the tailmeta inode descriptor scaffold
- note that the two forms should be treated as helper-convertible views of the same shape to reduce drift

## Impact
- docs only
- clarifies the implementation direction that recent #84 refactors are converging on

## Testing
- not run (docs only)
