### PR TITLE
refactor: add inode taildesc v5 helpers

### DIFF
--- a/src/kafs_inode.h
+++ b/src/kafs_inode.h
@@ -3,6 +3,7 @@
 #include "kafs.h"
 #include <assert.h>
 #include <errno.h>
+#include <string.h>
 
 /// 存在しないことを表す inode 番号
 #define KAFS_INO_NONE 0
@@ -100,6 +101,88 @@ _Static_assert(sizeof(kafs_sinode_t) == KAFS_INODE_V4_BYTES,
 _Static_assert(sizeof(((struct kafs_sinode_v5 *)NULL)->i_blkreftbl) == KAFS_INODE_DIRECT_BYTES,
                "kafs_sinode_v5 direct payload must preserve 60 bytes");
 _Static_assert(sizeof(kafs_sinode_v5_t) == KAFS_INODE_V5_BYTES, "kafs_sinode_v5 must be 128 bytes");
+
+static inline uint8_t
+kafs_ino_taildesc_v5_layout_kind_get(const kafs_sinode_taildesc_v5_t *taildesc)
+{
+  return taildesc->it_layout_kind;
+}
+
+static inline void kafs_ino_taildesc_v5_layout_kind_set(kafs_sinode_taildesc_v5_t *taildesc,
+                                                        uint8_t v)
+{
+  taildesc->it_layout_kind = v;
+}
+
+static inline uint8_t kafs_ino_taildesc_v5_flags_get(const kafs_sinode_taildesc_v5_t *taildesc)
+{
+  return taildesc->it_flags;
+}
+
+static inline void kafs_ino_taildesc_v5_flags_set(kafs_sinode_taildesc_v5_t *taildesc, uint8_t v)
+{
+  taildesc->it_flags = v;
+}
+
+static inline uint16_t
+kafs_ino_taildesc_v5_fragment_len_get(const kafs_sinode_taildesc_v5_t *taildesc)
+{
+  return le16toh(taildesc->it_fragment_len);
+}
+
+static inline void kafs_ino_taildesc_v5_fragment_len_set(kafs_sinode_taildesc_v5_t *taildesc,
+                                                         uint16_t v)
+{
+  taildesc->it_fragment_len = htole16(v);
+}
+
+static inline kafs_blkcnt_t
+kafs_ino_taildesc_v5_container_blo_get(const kafs_sinode_taildesc_v5_t *taildesc)
+{
+  return kafs_blkcnt_stoh(taildesc->it_container_blo);
+}
+
+static inline void kafs_ino_taildesc_v5_container_blo_set(kafs_sinode_taildesc_v5_t *taildesc,
+                                                          kafs_blkcnt_t v)
+{
+  taildesc->it_container_blo = kafs_blkcnt_htos(v);
+}
+
+static inline uint16_t
+kafs_ino_taildesc_v5_fragment_off_get(const kafs_sinode_taildesc_v5_t *taildesc)
+{
+  return le16toh(taildesc->it_fragment_off);
+}
+
+static inline void kafs_ino_taildesc_v5_fragment_off_set(kafs_sinode_taildesc_v5_t *taildesc,
+                                                         uint16_t v)
+{
+  taildesc->it_fragment_off = htole16(v);
+}
+
+static inline uint32_t
+kafs_ino_taildesc_v5_generation_get(const kafs_sinode_taildesc_v5_t *taildesc)
+{
+  return kafs_u32_stoh(taildesc->it_generation);
+}
+
+static inline void kafs_ino_taildesc_v5_generation_set(kafs_sinode_taildesc_v5_t *taildesc,
+                                                       uint32_t v)
+{
+  taildesc->it_generation = kafs_u32_htos(v);
+}
+
+static inline void kafs_ino_taildesc_v5_init(kafs_sinode_taildesc_v5_t *taildesc)
+{
+  memset(taildesc, 0, sizeof(*taildesc));
+  kafs_ino_taildesc_v5_layout_kind_set(taildesc, KAFS_TAIL_LAYOUT_INLINE);
+}
+
+static inline int kafs_ino_taildesc_v5_uses_tail_storage(const kafs_sinode_taildesc_v5_t *taildesc)
+{
+  uint8_t kind = kafs_ino_taildesc_v5_layout_kind_get(taildesc);
+  return kind == KAFS_TAIL_LAYOUT_TAIL_ONLY || kind == KAFS_TAIL_LAYOUT_MIXED_FULL_TAIL;
+}
 
 static inline size_t kafs_inode_inline_bytes(void) { return KAFS_INODE_DIRECT_BYTES; }
 

--- a/tests/tests_tailmeta_parser.c
+++ b/tests/tests_tailmeta_parser.c
@@ -67,20 +67,28 @@ int main(void)
                 kafs_sinode_taildesc_v5_t inode_taildesc_roundtrip;
                 kafs_tailmeta_inode_desc_t desc_from_inode;
 
-                memset(&inode_taildesc, 0, sizeof(inode_taildesc));
-                inode_taildesc.it_layout_kind = KAFS_TAIL_LAYOUT_TAIL_ONLY;
-                inode_taildesc.it_flags = KAFS_TAILDESC_FLAG_PACKED_SMALL_FILE;
-                inode_taildesc.it_fragment_len = htole16(64);
-                inode_taildesc.it_container_blo = kafs_blkcnt_htos(9);
-                inode_taildesc.it_fragment_off = htole16(32);
-                inode_taildesc.it_generation = kafs_u32_htos(11);
+                kafs_ino_taildesc_v5_init(&inode_taildesc);
+                kafs_ino_taildesc_v5_layout_kind_set(&inode_taildesc, KAFS_TAIL_LAYOUT_TAIL_ONLY);
+                kafs_ino_taildesc_v5_flags_set(&inode_taildesc, KAFS_TAILDESC_FLAG_PACKED_SMALL_FILE);
+                kafs_ino_taildesc_v5_fragment_len_set(&inode_taildesc, 64);
+                kafs_ino_taildesc_v5_container_blo_set(&inode_taildesc, 9);
+                kafs_ino_taildesc_v5_fragment_off_set(&inode_taildesc, 32);
+                kafs_ino_taildesc_v5_generation_set(&inode_taildesc, 11);
+                assert(kafs_ino_taildesc_v5_uses_tail_storage(&inode_taildesc));
 
                 kafs_tailmeta_inode_desc_from_inode_taildesc(&desc_from_inode, &inode_taildesc);
                 assert(memcmp(&desc_from_inode, &desc, sizeof(desc)) == 0);
 
-                memset(&inode_taildesc_roundtrip, 0, sizeof(inode_taildesc_roundtrip));
+                kafs_ino_taildesc_v5_init(&inode_taildesc_roundtrip);
                 kafs_tailmeta_inode_desc_to_inode_taildesc(&inode_taildesc_roundtrip, &desc_from_inode);
                 assert(memcmp(&inode_taildesc_roundtrip, &inode_taildesc, sizeof(inode_taildesc)) == 0);
+                assert(kafs_ino_taildesc_v5_layout_kind_get(&inode_taildesc_roundtrip) == KAFS_TAIL_LAYOUT_TAIL_ONLY);
+                assert(kafs_ino_taildesc_v5_flags_get(&inode_taildesc_roundtrip) ==
+                                         KAFS_TAILDESC_FLAG_PACKED_SMALL_FILE);
+                assert(kafs_ino_taildesc_v5_fragment_len_get(&inode_taildesc_roundtrip) == 64);
+                assert(kafs_ino_taildesc_v5_container_blo_get(&inode_taildesc_roundtrip) == 9);
+                assert(kafs_ino_taildesc_v5_fragment_off_get(&inode_taildesc_roundtrip) == 32);
+                assert(kafs_ino_taildesc_v5_generation_get(&inode_taildesc_roundtrip) == 11);
         }
 
   memset(&slot, 0, sizeof(slot));


### PR DESCRIPTION
## Summary
- add accessor, setter, init, and usage helpers for the future v5 inode tail descriptor scaffold
- switch the tailmeta conversion round-trip test to use the inode-side helper API
- keep the helper surface aligned with the existing tailmeta-side descriptor helpers

## Testing
- autoreconf -fi
- ./configure --enable-lto
- make -j"12"
- make check -j"12"
- ./scripts/format.sh
- ./scripts/clones.sh
- ./scripts/static-checks.sh

Refs #84