### PR TITLE
refactor: share tail layout storage predicate

### DIFF
--- a/src/kafs_inode.h
+++ b/src/kafs_inode.h
@@ -178,10 +178,15 @@ static inline void kafs_ino_taildesc_v5_init(kafs_sinode_taildesc_v5_t *taildesc
   kafs_ino_taildesc_v5_layout_kind_set(taildesc, KAFS_TAIL_LAYOUT_INLINE);
 }
 
+static inline int kafs_tail_layout_uses_tail_storage(uint8_t kind)
+{
+  return kind == KAFS_TAIL_LAYOUT_TAIL_ONLY || kind == KAFS_TAIL_LAYOUT_MIXED_FULL_TAIL;
+}
+
 static inline int kafs_ino_taildesc_v5_uses_tail_storage(const kafs_sinode_taildesc_v5_t *taildesc)
 {
   uint8_t kind = kafs_ino_taildesc_v5_layout_kind_get(taildesc);
-  return kind == KAFS_TAIL_LAYOUT_TAIL_ONLY || kind == KAFS_TAIL_LAYOUT_MIXED_FULL_TAIL;
+  return kafs_tail_layout_uses_tail_storage(kind);
 }
 
 static inline size_t kafs_inode_inline_bytes(void) { return KAFS_INODE_DIRECT_BYTES; }

--- a/src/kafs_tailmeta.h
+++ b/src/kafs_tailmeta.h
@@ -449,7 +449,7 @@ kafs_tailmeta_inode_desc_to_inode_taildesc(kafs_sinode_taildesc_v5_t *taildesc,
 static inline int kafs_tailmeta_inode_desc_uses_tail_storage(const kafs_tailmeta_inode_desc_t *desc)
 {
   uint8_t kind = kafs_tailmeta_inode_desc_layout_kind_get(desc);
-  return kind == KAFS_TAIL_LAYOUT_TAIL_ONLY || kind == KAFS_TAIL_LAYOUT_MIXED_FULL_TAIL;
+  return kafs_tail_layout_uses_tail_storage(kind);
 }
 
 static inline int kafs_tailmeta_region_present(const kafs_ssuperblock_t *sb)


### PR DESCRIPTION
## Summary
- add a shared tail-layout predicate for deciding whether a layout uses tail storage
- switch inode-taildesc and tailmeta descriptor helpers to reuse the shared layout predicate
- remove one more small piece of duplicated future tail-layout logic

## Testing
- autoreconf -fi
- ./configure --enable-lto
- make -j"12"
- make check -j"12"
- ./scripts/format.sh
- ./scripts/clones.sh
- ./scripts/static-checks.sh

Refs #84