### PR TITLE
refactor: share tail layout known-kind helper

### DIFF
--- a/src/kafs_inode.h
+++ b/src/kafs_inode.h
@@ -178,6 +178,11 @@ static inline void kafs_ino_taildesc_v5_init(kafs_sinode_taildesc_v5_t *taildesc
   kafs_ino_taildesc_v5_layout_kind_set(taildesc, KAFS_TAIL_LAYOUT_INLINE);
 }
 
+static inline int kafs_tail_layout_is_known(uint8_t kind)
+{
+  return kind <= KAFS_TAIL_LAYOUT_MIXED_FULL_TAIL;
+}
+
 static inline int kafs_tail_layout_uses_tail_storage(uint8_t kind)
 {
   return kind == KAFS_TAIL_LAYOUT_TAIL_ONLY || kind == KAFS_TAIL_LAYOUT_MIXED_FULL_TAIL;

--- a/src/kafs_tailmeta.h
+++ b/src/kafs_tailmeta.h
@@ -607,29 +607,25 @@ static inline int kafs_tailmeta_inode_desc_validate(const kafs_tailmeta_inode_de
   generation = kafs_tailmeta_inode_desc_generation_get(desc);
   container_blo = kafs_tailmeta_inode_desc_container_blo_get(desc);
 
-  switch (kind)
+  if (!kafs_tail_layout_is_known(kind))
+    return -EPROTO;
+
+  if (!kafs_tail_layout_uses_tail_storage(kind))
   {
-  case KAFS_TAIL_LAYOUT_INLINE:
-  case KAFS_TAIL_LAYOUT_FULL_BLOCK:
     if (flags != 0u || len != 0u || off != 0u || generation != 0u)
       return -EPROTO;
     return (container_blo == (kafs_blkcnt_t)0) ? 0 : -EPROTO;
-
-  case KAFS_TAIL_LAYOUT_TAIL_ONLY:
-  case KAFS_TAIL_LAYOUT_MIXED_FULL_TAIL:
-    if ((flags & ~KAFS_TAILDESC_KNOWN_FLAGS) != 0u)
-      return -EPROTO;
-    if (class_bytes == 0u || len == 0u || len > class_bytes)
-      return -EPROTO;
-    if (container_blo == (kafs_blkcnt_t)0)
-      return -EPROTO;
-    if ((uint32_t)off + (uint32_t)len > (uint32_t)class_bytes)
-      return -EPROTO;
-    return 0;
-
-  default:
-    return -EPROTO;
   }
+
+  if ((flags & ~KAFS_TAILDESC_KNOWN_FLAGS) != 0u)
+    return -EPROTO;
+  if (class_bytes == 0u || len == 0u || len > class_bytes)
+    return -EPROTO;
+  if (container_blo == (kafs_blkcnt_t)0)
+    return -EPROTO;
+  if ((uint32_t)off + (uint32_t)len > (uint32_t)class_bytes)
+    return -EPROTO;
+  return 0;
 }
 
 static inline int kafs_tailmeta_inode_desc_matches_slot(const kafs_tailmeta_inode_desc_t *desc,

--- a/tests/tests_tailmeta_parser.c
+++ b/tests/tests_tailmeta_parser.c
@@ -50,8 +50,19 @@ static void assert_tail_layout_storage_matrix(uint8_t layout_kind, int uses_tail
         assert(kafs_tailmeta_inode_desc_uses_tail_storage(&desc) == uses_tail_storage);
 }
 
+static void assert_tail_layout_known_matrix(uint8_t layout_kind, int is_known)
+{
+        assert(kafs_tail_layout_is_known(layout_kind) == is_known);
+}
+
 int main(void)
 {
+        assert_tail_layout_known_matrix(KAFS_TAIL_LAYOUT_INLINE, 1);
+        assert_tail_layout_known_matrix(KAFS_TAIL_LAYOUT_FULL_BLOCK, 1);
+        assert_tail_layout_known_matrix(KAFS_TAIL_LAYOUT_TAIL_ONLY, 1);
+        assert_tail_layout_known_matrix(KAFS_TAIL_LAYOUT_MIXED_FULL_TAIL, 1);
+        assert_tail_layout_known_matrix(UINT8_MAX, 0);
+
         assert_tail_layout_storage_matrix(KAFS_TAIL_LAYOUT_INLINE, 0);
         assert_tail_layout_storage_matrix(KAFS_TAIL_LAYOUT_FULL_BLOCK, 0);
         assert_tail_layout_storage_matrix(KAFS_TAIL_LAYOUT_TAIL_ONLY, 1);
@@ -105,6 +116,9 @@ int main(void)
   kafs_tailmeta_inode_desc_init(&desc);
   assert(kafs_tailmeta_inode_desc_validate(&desc, 128) == 0);
   assert(!kafs_tailmeta_inode_desc_uses_tail_storage(&desc));
+        kafs_tailmeta_inode_desc_layout_kind_set(&desc, UINT8_MAX);
+        assert(kafs_tailmeta_inode_desc_validate(&desc, 128) != 0);
+        kafs_tailmeta_inode_desc_init(&desc);
 
   kafs_tailmeta_inode_desc_layout_kind_set(&desc, KAFS_TAIL_LAYOUT_TAIL_ONLY);
   kafs_tailmeta_inode_desc_flags_set(&desc, KAFS_TAILDESC_FLAG_PACKED_SMALL_FILE);


### PR DESCRIPTION
## Summary
- add a shared helper for determining whether a tail layout kind is one of the currently supported values
- switch tailmeta descriptor validation to reuse the shared known-kind helper together with the shared tail-storage helper
- extend tailmeta parser coverage to lock in known-kind semantics and invalid-kind rejection

## Testing
- autoreconf -fi
- ./configure --enable-lto
- make -j"12"
- make check -j"12"
- ./scripts/format.sh
- ./scripts/clones.sh
- ./scripts/static-checks.sh

Refs #84