### PR TITLE
mkfs: scale default inode count by image size

### DIFF
--- a/man/mkfs.kafs.8
+++ b/man/mkfs.kafs.8
@@ -37,7 +37,11 @@ is used and overrides this option.
 Block size as log2 value (default: 12 => 4096 bytes).
 .TP
 .BR -i ", " --inodes "=" count
-Number of inodes (default: 65536).
+Number of inodes.
+By default,
+.B mkfs.kafs
+uses roughly 1 inode per 16KiB of image size, with a minimum of 256 inodes.
+For the default 1GiB image size this yields 65536 inodes.
 .TP
 .BR -J ", " --journal-size-bytes "=" bytes
 Journal region size (default: 1MiB, minimum 4KiB). K/M/G suffixes are accepted.

--- a/src/mkfs_kafs.c
+++ b/src/mkfs_kafs.c
@@ -35,7 +35,9 @@ static void usage(const char *prog)
   fprintf(stderr, "  [Layout]\n");
   fprintf(stderr, "    -s, --size-bytes <N>              Total image size (default: 1GiB)\n");
   fprintf(stderr, "    -b, --blksize-log <L>             Block size log2 (default: 12 => 4096B)\n");
-  fprintf(stderr, "    -i, --inodes <I>                  Inode count (default: 65536)\n");
+  fprintf(
+      stderr,
+      "    -i, --inodes <I>                  Inode count (default: 1 inode per 16KiB, min: 256)\n");
   fprintf(stderr,
           "    -J, --journal-size-bytes <J>      Journal size (default: 1MiB, min: 4KiB)\n");
   fprintf(stderr, "    --hrl-entry-ratio <R>             HRL entries/data-block ratio (default: "
@@ -113,6 +115,25 @@ struct mkfs_layout
   size_t pendinglog_size;
   off_t pendinglog_off;
 };
+
+#define KAFS_MKFS_DEFAULT_BYTES_PER_INODE (16u * 1024u)
+#define KAFS_MKFS_MIN_INODES 256u
+
+static kafs_inocnt_t mkfs_default_inocnt_for_size(off_t total_bytes)
+{
+  uint64_t inode_count = 0;
+
+  if (total_bytes <= 0)
+    return KAFS_MKFS_MIN_INODES;
+
+  inode_count = (uint64_t)total_bytes / (uint64_t)KAFS_MKFS_DEFAULT_BYTES_PER_INODE;
+  if (inode_count < (uint64_t)KAFS_MKFS_MIN_INODES)
+    inode_count = (uint64_t)KAFS_MKFS_MIN_INODES;
+  if (inode_count > (uint64_t)UINT32_MAX)
+    inode_count = (uint64_t)UINT32_MAX;
+
+  return (kafs_inocnt_t)inode_count;
+}
 
 static void compute_layout(kafs_blkcnt_t blkcnt, kafs_blksize_t blksizemask, kafs_inocnt_t inocnt,
                            size_t journal_bytes, double hrl_entry_ratio, struct mkfs_layout *out)
@@ -236,10 +257,11 @@ int main(int argc, char **argv)
   kafs_blksize_t blksize = 1u << log_blksize;
   kafs_blksize_t blksizemask = blksize - 1u;
   off_t total_bytes = 1024ll * 1024ll * 1024ll; // 1GiB
-  kafs_inocnt_t inocnt = 65536;                 // number of inodes
+  kafs_inocnt_t inocnt = 0;                     // number of inodes
   size_t journal_bytes = 1u << 20;              // 1MiB default journal region
   double hrl_entry_ratio = 0.75;
   int size_arg_provided = 0;
+  int inocnt_arg_provided = 0;
   int trim_data_area = 0;
   int assume_yes = 0;
 
@@ -268,6 +290,7 @@ int main(int argc, char **argv)
     else if ((strcmp(argv[i], "--inodes") == 0 || strcmp(argv[i], "-i") == 0) && i + 1 < argc)
     {
       inocnt = (kafs_inocnt_t)strtoul(argv[++i], NULL, 0);
+      inocnt_arg_provided = 1;
     }
     else if ((strcmp(argv[i], "--journal-size-bytes") == 0 || strcmp(argv[i], "-J") == 0) &&
              i + 1 < argc)
@@ -369,6 +392,9 @@ int main(int argc, char **argv)
     return 1;
 #endif
   }
+
+  if (!inocnt_arg_provided)
+    inocnt = mkfs_default_inocnt_for_size(total_bytes);
 
   struct mkfs_layout layout = {0};
   kafs_blkcnt_t blkcnt = 0;

--- a/tests/tests_kafsresize.c
+++ b/tests/tests_kafsresize.c
@@ -667,6 +667,40 @@ int main(void)
     return 1;
   }
 
+  kafs_ssuperblock_t info_sb = {0};
+  if (read_superblock(info_img, &info_sb) != 0)
+  {
+    fprintf(stderr, "failed to read default-inode superblock\n");
+    return 1;
+  }
+  if (kafs_sb_inocnt_get(&info_sb) != 2048)
+  {
+      fprintf(stderr, "unexpected default inode count for 32M image: got=%lu want=2048\n",
+        (unsigned long)kafs_sb_inocnt_get(&info_sb));
+    return 1;
+  }
+
+  const char *small_img = "default-inodes-small.img";
+  char *small_mkfs_argv[] = {(char *)mkfs_abs, (char *)small_img, (char *)"-s", (char *)"5M", NULL};
+  if (run_cmd_status(small_mkfs_argv) != 0)
+  {
+    fprintf(stderr, "mkfs for small-image default inode count test failed\n");
+    return 1;
+  }
+
+  kafs_ssuperblock_t small_sb = {0};
+  if (read_superblock(small_img, &small_sb) != 0)
+  {
+    fprintf(stderr, "failed to read small-image default inode superblock\n");
+    return 1;
+  }
+  if (kafs_sb_inocnt_get(&small_sb) != 320)
+  {
+    fprintf(stderr, "unexpected default inode count for 5M image: got=%lu want=320\n",
+            (unsigned long)kafs_sb_inocnt_get(&small_sb));
+    return 1;
+  }
+
   kafs_sinode_t tombstone_1;
   memset(&tombstone_1, 0, sizeof(tombstone_1));
   kafs_ino_mode_set(&tombstone_1, S_IFREG | 0644);


### PR DESCRIPTION
## Summary
- make mkfs choose the default inode count from image size at roughly 1 inode per 16KiB
- keep explicit --inodes overrides unchanged and document the new default
- add regression coverage for 32MiB and 5MiB images

## Testing
- autoreconf -fi
- ./configure --enable-lto
- make -j"$(nproc)"
- make check -j"$(nproc)"
- ./scripts/format.sh
- ./scripts/clones.sh
- ./scripts/static-checks.sh

Refs #113
