### PR TITLE
prep: make inode-table access format-aware

### DIFF
--- a/src/fsck_kafs.c
+++ b/src/fsck_kafs.c
@@ -1275,7 +1275,7 @@ static int check_tailmeta_live_slot_owner(int fd, const kafs_ssuperblock_t *sb, 
   kafs_sinode_t inoent;
   kafs_inocnt_t owner = kafs_tailmeta_slot_owner_ino_get(slot);
   kafs_inocnt_t inocnt = kafs_sb_inocnt_get(sb);
-  uint64_t inode_off;
+  uint64_t inode_off = 0;
   kafs_off_t inode_size;
   uint16_t expected_len = 0;
   int rc;
@@ -1291,7 +1291,16 @@ static int check_tailmeta_live_slot_owner(int fd, const kafs_ssuperblock_t *sb, 
     return -1;
   }
 
-  inode_off = inode_table_off + (uint64_t)owner * sizeof(inoent);
+  rc = kafs_inode_offset_for_format(kafs_sb_format_version_get(sb), inode_table_off, owner,
+                                    &inode_off);
+  if (rc != 0)
+  {
+    fprintf(stderr,
+            "tailmeta container[%u] slot[%u] owner inode offset overflow: owner=%" PRIuFAST32
+            " rc=%d\n",
+            container_index, slot_index, owner, rc);
+    return -1;
+  }
   if (inode_off >= file_size || sizeof(inoent) > file_size - inode_off)
   {
     fprintf(stderr,

--- a/src/kafs_inode.h
+++ b/src/kafs_inode.h
@@ -229,6 +229,38 @@ static inline uint64_t kafs_inode_table_bytes_for_format(uint32_t format_version
   return (uint64_t)inode_bytes * inocnt;
 }
 
+static inline int kafs_inode_offset_for_format(uint32_t format_version, uint64_t inode_table_off,
+                                               uint64_t ino, uint64_t *out_off)
+{
+  size_t inode_bytes = kafs_inode_bytes_for_format(format_version);
+  uint64_t inode_off = 0;
+
+  if (!out_off)
+    return -EINVAL;
+  if (inode_bytes == 0)
+    return -EINVAL;
+  if (ino > (UINT64_MAX / (uint64_t)inode_bytes))
+    return -ERANGE;
+
+  inode_off = inode_table_off + ino * (uint64_t)inode_bytes;
+  if (inode_off < inode_table_off)
+    return -ERANGE;
+
+  *out_off = inode_off;
+  return 0;
+}
+
+static inline void *kafs_inode_ptr_in_table(void *inode_table_base, uint32_t format_version,
+                                            uint64_t ino)
+{
+  size_t inode_bytes = kafs_inode_bytes_for_format(format_version);
+
+  if (!inode_table_base || inode_bytes == 0)
+    return NULL;
+
+  return (void *)((char *)inode_table_base + ino * inode_bytes);
+}
+
 static kafs_mode_t kafs_ino_mode_get(const kafs_sinode_t *inoent)
 {
   return kafs_mode_stoh(inoent->i_mode);

--- a/src/mkfs_kafs.c
+++ b/src/mkfs_kafs.c
@@ -512,7 +512,8 @@ int main(int argc, char **argv)
 
   // root inode
   // inotbl はゼロ初期化済み
-  kafs_sinode_t *inoent_rootdir = &ctx.c_inotbl[KAFS_INO_ROOTDIR];
+  kafs_sinode_t *inoent_rootdir = (kafs_sinode_t *)kafs_inode_ptr_in_table(
+      ctx.c_inotbl, kafs_sb_format_version_get(ctx.c_superblock), KAFS_INO_ROOTDIR);
   // 安全性チェック
   {
     char *p = (char *)inoent_rootdir;

--- a/tests/tests_kafsresize.c
+++ b/tests/tests_kafsresize.c
@@ -236,12 +236,16 @@ static int write_inode_at(const char *img, kafs_inocnt_t ino, const kafs_sinode_
   layout += (r_blkcnt + 7u) >> 3;
   layout = (layout + 7u) & ~7u;
   layout = (layout + blksizemask) & ~blksizemask;
-  off_t inode_off = (off_t)layout + (off_t)ino * (off_t)sizeof(*inode);
+  uint64_t inode_off = 0;
+
+  rc = kafs_inode_offset_for_format(kafs_sb_format_version_get(&sb), layout, ino, &inode_off);
+  if (rc != 0)
+    return rc;
 
   int fd = open(img, O_RDWR);
   if (fd < 0)
     return -errno;
-  ssize_t n = pwrite(fd, inode, sizeof(*inode), inode_off);
+  ssize_t n = pwrite(fd, inode, sizeof(*inode), (off_t)inode_off);
   int saved = errno;
   close(fd);
   if (n != (ssize_t)sizeof(*inode))
@@ -264,12 +268,16 @@ static int read_inode_at(const char *img, kafs_inocnt_t ino, kafs_sinode_t *inod
   layout += (r_blkcnt + 7u) >> 3;
   layout = (layout + 7u) & ~7u;
   layout = (layout + blksizemask) & ~blksizemask;
-  off_t inode_off = (off_t)layout + (off_t)ino * (off_t)sizeof(*inode);
+  uint64_t inode_off = 0;
+
+  rc = kafs_inode_offset_for_format(kafs_sb_format_version_get(&sb), layout, ino, &inode_off);
+  if (rc != 0)
+    return rc;
 
   int fd = open(img, O_RDONLY);
   if (fd < 0)
     return -errno;
-  ssize_t n = pread(fd, inode, sizeof(*inode), inode_off);
+  ssize_t n = pread(fd, inode, sizeof(*inode), (off_t)inode_off);
   int saved = errno;
   close(fd);
   if (n != (ssize_t)sizeof(*inode))


### PR DESCRIPTION
## Summary
- add shared helpers for format-aware inode-table offsets and pointers
- switch mkfs root inode lookup and fsck tailmeta owner reads to the shared helpers
- update kafsresize raw inode test helpers to use format-aware offsets

## Testing
- autoreconf -fi
- ./configure --enable-lto
- make -j"$(nproc)"
- make check -j"$(nproc)"
- ./scripts/format.sh fix
- ./scripts/format.sh
- ./scripts/clones.sh
- ./scripts/static-checks.sh

Closes #115
Refs #51
Refs #113