### PR TITLE
mkfs: initialize empty tail metadata region scaffold

### DIFF
--- a/man/mkfs.kafs.8
+++ b/man/mkfs.kafs.8
@@ -9,6 +9,8 @@ mkfs.kafs \- create a KAFS filesystem image
 .IR size ]
 .RB [ -b
 .IR log2blksz ]
+.RB [ --format-version
+.IR version ]
 .RB [ -i
 .IR inodes ]
 .RB [ -J
@@ -35,6 +37,10 @@ is used and overrides this option.
 .TP
 .BR -b ", " --blksize-log "=" log2
 Block size as log2 value (default: 12 => 4096 bytes).
+.TP
+.BR --format-version "=" version
+On-disk format version to emit (default: 4).
+Version 5 enables an empty dedicated tail metadata region scaffold during mkfs.
 .TP
 .BR -i ", " --inodes "=" count
 Number of inodes.

--- a/src/mkfs_kafs.c
+++ b/src/mkfs_kafs.c
@@ -6,6 +6,7 @@
 #include "kafs_dirent.h"
 #include "kafs_hash.h"
 #include "kafs_journal.h"
+#include "kafs_tailmeta.h"
 #include "kafs_cli_opts.h"
 #include "kafs_tool_util.h"
 
@@ -35,6 +36,7 @@ static void usage(const char *prog)
   fprintf(stderr, "  [Layout]\n");
   fprintf(stderr, "    -s, --size-bytes <N>              Total image size (default: 1GiB)\n");
   fprintf(stderr, "    -b, --blksize-log <L>             Block size log2 (default: 12 => 4096B)\n");
+  fprintf(stderr, "    --format-version <V>              On-disk format version (default: 4)\n");
   fprintf(
       stderr,
       "    -i, --inodes <I>                  Inode count (default: 1 inode per 16KiB, min: 256)\n");
@@ -114,6 +116,8 @@ struct mkfs_layout
   off_t journal_off;
   size_t pendinglog_size;
   off_t pendinglog_off;
+  size_t tailmeta_size;
+  off_t tailmeta_off;
 };
 
 #define KAFS_MKFS_DEFAULT_BYTES_PER_INODE (16u * 1024u)
@@ -135,7 +139,27 @@ static kafs_inocnt_t mkfs_default_inocnt_for_size(off_t total_bytes)
   return (kafs_inocnt_t)inode_count;
 }
 
-static void compute_layout(kafs_blkcnt_t blkcnt, kafs_blksize_t blksizemask, kafs_inocnt_t inocnt,
+static int mkfs_format_version_is_supported(uint32_t format_version)
+{
+  return format_version == KAFS_FORMAT_VERSION || format_version == KAFS_FORMAT_VERSION_V5;
+}
+
+static size_t mkfs_tailmeta_region_size(uint32_t format_version, kafs_blksize_t blksize)
+{
+  return (format_version == KAFS_FORMAT_VERSION_V5) ? (size_t)blksize : 0u;
+}
+
+static uint64_t mkfs_feature_flags_for_format(uint32_t format_version)
+{
+  uint64_t flags = KAFS_FEATURE_ALLOC_V2;
+
+  if (format_version == KAFS_FORMAT_VERSION_V5)
+    flags |= KAFS_FEATURE_TAIL_META_REGION;
+  return flags;
+}
+
+static void compute_layout(uint32_t format_version, kafs_blkcnt_t blkcnt,
+                           kafs_blksize_t blksizemask, kafs_blksize_t blksize, kafs_inocnt_t inocnt,
                            size_t journal_bytes, double hrl_entry_ratio, struct mkfs_layout *out)
 {
   off_t mapsize = 0;
@@ -146,7 +170,7 @@ static void compute_layout(kafs_blkcnt_t blkcnt, kafs_blksize_t blksizemask, kaf
   mapsize = (mapsize + 7) & ~7;                     // 64-bit align
   mapsize = (mapsize + blksizemask) & ~blksizemask; // block align
   off_t inotbl_off = mapsize;
-  mapsize += (off_t)kafs_inode_table_bytes_for_format(KAFS_FORMAT_VERSION, inocnt);
+  mapsize += (off_t)kafs_inode_table_bytes_for_format(format_version, inocnt);
   mapsize = (mapsize + blksizemask) & ~blksizemask;
 
   // allocator v2 reserved metadata area (L1/L2 summaries, future use)
@@ -189,6 +213,11 @@ static void compute_layout(kafs_blkcnt_t blkcnt, kafs_blksize_t blksizemask, kaf
   mapsize += (off_t)pendinglog_size;
   mapsize = (mapsize + blksizemask) & ~blksizemask;
 
+  size_t tailmeta_size = mkfs_tailmeta_region_size(format_version, blksize);
+  off_t tailmeta_off = (tailmeta_size > 0u) ? mapsize : 0;
+  mapsize += (off_t)tailmeta_size;
+  mapsize = (mapsize + blksizemask) & ~blksizemask;
+
   if (out)
   {
     out->mapsize = mapsize;
@@ -204,11 +233,14 @@ static void compute_layout(kafs_blkcnt_t blkcnt, kafs_blksize_t blksizemask, kaf
     out->journal_off = journal_off;
     out->pendinglog_size = pendinglog_size;
     out->pendinglog_off = pendinglog_off;
+    out->tailmeta_size = tailmeta_size;
+    out->tailmeta_off = tailmeta_off;
   }
 }
 
-static int compute_blkcnt_for_total(off_t total_bytes, kafs_logblksize_t log_blksize,
-                                    kafs_blksize_t blksizemask, kafs_inocnt_t inocnt,
+static int compute_blkcnt_for_total(uint32_t format_version, off_t total_bytes,
+                                    kafs_logblksize_t log_blksize, kafs_blksize_t blksizemask,
+                                    kafs_blksize_t blksize, kafs_inocnt_t inocnt,
                                     size_t journal_bytes, double hrl_entry_ratio,
                                     kafs_blkcnt_t *out_blkcnt, struct mkfs_layout *out_layout)
 {
@@ -222,7 +254,8 @@ static int compute_blkcnt_for_total(off_t total_bytes, kafs_logblksize_t log_blk
   struct mkfs_layout layout = {0};
   for (int i = 0; i < 16; ++i)
   {
-    compute_layout(blkcnt, blksizemask, inocnt, journal_bytes, hrl_entry_ratio, &layout);
+    compute_layout(format_version, blkcnt, blksizemask, blksize, inocnt, journal_bytes,
+                   hrl_entry_ratio, &layout);
     if (total_bytes <= layout.mapsize)
       return -1;
     kafs_blkcnt_t next = (kafs_blkcnt_t)((total_bytes - layout.mapsize) >> log_blksize);
@@ -235,7 +268,8 @@ static int compute_blkcnt_for_total(off_t total_bytes, kafs_logblksize_t log_blk
 
   for (;;)
   {
-    compute_layout(blkcnt, blksizemask, inocnt, journal_bytes, hrl_entry_ratio, &layout);
+    compute_layout(format_version, blkcnt, blksizemask, blksize, inocnt, journal_bytes,
+                   hrl_entry_ratio, &layout);
     off_t imgsize = layout.mapsize + ((off_t)blkcnt << log_blksize);
     if (imgsize <= total_bytes)
       break;
@@ -253,6 +287,7 @@ static int compute_blkcnt_for_total(off_t total_bytes, kafs_logblksize_t log_blk
 int main(int argc, char **argv)
 {
   const char *img = NULL;
+  uint32_t format_version = KAFS_FORMAT_VERSION;
   kafs_logblksize_t log_blksize = 12; // 4096B
   kafs_blksize_t blksize = 1u << log_blksize;
   kafs_blksize_t blksizemask = blksize - 1u;
@@ -286,6 +321,15 @@ int main(int argc, char **argv)
       log_blksize = (kafs_logblksize_t)strtoul(argv[++i], NULL, 0);
       blksize = 1u << log_blksize;
       blksizemask = blksize - 1u;
+    }
+    else if (strcmp(argv[i], "--format-version") == 0 && i + 1 < argc)
+    {
+      format_version = (uint32_t)strtoul(argv[++i], NULL, 0);
+      if (!mkfs_format_version_is_supported(format_version))
+      {
+        fprintf(stderr, "unsupported format version: %u\n", format_version);
+        return 2;
+      }
     }
     else if ((strcmp(argv[i], "--inodes") == 0 || strcmp(argv[i], "-i") == 0) && i + 1 < argc)
     {
@@ -398,8 +442,8 @@ int main(int argc, char **argv)
 
   struct mkfs_layout layout = {0};
   kafs_blkcnt_t blkcnt = 0;
-  if (compute_blkcnt_for_total(total_bytes, log_blksize, blksizemask, inocnt, journal_bytes,
-                               hrl_entry_ratio, &blkcnt, &layout) != 0)
+  if (compute_blkcnt_for_total(format_version, total_bytes, log_blksize, blksizemask, blksize,
+                               inocnt, journal_bytes, hrl_entry_ratio, &blkcnt, &layout) != 0)
   {
     fprintf(stderr, "invalid total size: %lld\n", (long long)total_bytes);
     close(ctx.c_fd);
@@ -412,7 +456,7 @@ int main(int argc, char **argv)
     if (pread(ctx.c_fd, &sbcheck, sizeof(sbcheck), 0) == (ssize_t)sizeof(sbcheck))
     {
       if (kafs_sb_magic_get(&sbcheck) == KAFS_MAGIC &&
-          kafs_sb_format_version_get(&sbcheck) == KAFS_FORMAT_VERSION)
+          mkfs_format_version_is_supported(kafs_sb_format_version_get(&sbcheck)))
       {
         fprintf(stderr, "warning: image appears formatted and will be overwritten: %s\n", img);
         if (!assume_yes && !mkfs_confirm_overwrite_stdin())
@@ -452,7 +496,7 @@ int main(int argc, char **argv)
 
   // 境界チェックとゼロ初期化
   size_t blkmask_bytes = ((size_t)blkcnt + 7) >> 3; // ビットマップの総バイト数
-  size_t inotbl_bytes = (size_t)kafs_inode_table_bytes_for_format(KAFS_FORMAT_VERSION, inocnt);
+  size_t inotbl_bytes = (size_t)kafs_inode_table_bytes_for_format(format_version, inocnt);
   char *base = (char *)ctx.c_superblock;
   char *end = base + mapsize;
   char *bm_ptr = (char *)ctx.c_blkmasktbl;
@@ -471,7 +515,7 @@ int main(int argc, char **argv)
   // スーパーブロック基本
   kafs_sb_log_blksize_set(ctx.c_superblock, log_blksize);
   kafs_sb_magic_set(ctx.c_superblock, KAFS_MAGIC);
-  kafs_sb_format_version_set(ctx.c_superblock, KAFS_FORMAT_VERSION);
+  kafs_sb_format_version_set(ctx.c_superblock, format_version);
   kafs_sb_hash_fast_set(ctx.c_superblock, KAFS_HASH_FAST_XXH64);
   kafs_sb_hash_strong_set(ctx.c_superblock, KAFS_HASH_STRONG_BLAKE3_256);
   // HRL領域の割当
@@ -490,9 +534,9 @@ int main(int argc, char **argv)
   kafs_sb_pendinglog_size_set(ctx.c_superblock, (uint64_t)layout.pendinglog_size);
   kafs_sb_checkpoint_seq_set(ctx.c_superblock, 0);
   kafs_sb_commit_seq_set(ctx.c_superblock, 0);
-  kafs_sb_tailmeta_offset_set(ctx.c_superblock, 0);
-  kafs_sb_tailmeta_size_set(ctx.c_superblock, 0);
-  kafs_sb_feature_flags_set(ctx.c_superblock, KAFS_FEATURE_ALLOC_V2);
+  kafs_sb_tailmeta_offset_set(ctx.c_superblock, (uint64_t)layout.tailmeta_off);
+  kafs_sb_tailmeta_size_set(ctx.c_superblock, (uint64_t)layout.tailmeta_size);
+  kafs_sb_feature_flags_set(ctx.c_superblock, mkfs_feature_flags_for_format(format_version));
   kafs_sb_compat_flags_set(ctx.c_superblock, 0);
 
   // R/O items
@@ -577,6 +621,18 @@ int main(int argc, char **argv)
     }
   }
 
+  if (layout.tailmeta_size >= sizeof(kafs_tailmeta_region_hdr_t))
+  {
+    kafs_tailmeta_region_hdr_t region_hdr;
+    char *tailmeta_ptr = (char *)ctx.c_superblock + layout.tailmeta_off;
+    char *base4 = (char *)ctx.c_superblock;
+    char *end4 = base4 + mapsize;
+
+    assert(tailmeta_ptr >= base4 && tailmeta_ptr + layout.tailmeta_size <= end4);
+    kafs_tailmeta_region_hdr_init(&region_hdr);
+    memcpy(tailmeta_ptr, &region_hdr, sizeof(region_hdr));
+  }
+
   if (trim_data_area)
   {
     off_t data_off = (off_t)fdb << log_blksize;
@@ -591,7 +647,8 @@ int main(int argc, char **argv)
   munmap(ctx.c_superblock, mapsize);
   close(ctx.c_fd);
 
-  fprintf(stderr, "Formatted %s: size=%lld bytes, blksize=%u, blocks=%u, inodes=%u\n", img,
-          (long long)total_bytes, (unsigned)blksize, (unsigned)blkcnt, (unsigned)inocnt);
+  fprintf(stderr, "Formatted %s: format=v%u size=%lld bytes, blksize=%u, blocks=%u, inodes=%u\n",
+          img, (unsigned)format_version, (long long)total_bytes, (unsigned)blksize,
+          (unsigned)blkcnt, (unsigned)inocnt);
   return 0;
 }

--- a/tests/tests_kafsresize.c
+++ b/tests/tests_kafsresize.c
@@ -2,6 +2,7 @@
 #include "kafs_block.h"
 #include "kafs_dirent.h"
 #include "kafs_inode.h"
+#include "kafs_tailmeta.h"
 #include "test_utils.h"
 
 #include <errno.h>
@@ -221,6 +222,20 @@ static int write_superblock(const char *img, const kafs_ssuperblock_t *sb)
   return 0;
 }
 
+static int read_tailmeta_region_header(const char *img, uint64_t off,
+                                       kafs_tailmeta_region_hdr_t *hdr)
+{
+  int fd = open(img, O_RDONLY);
+  if (fd < 0)
+    return -errno;
+  ssize_t n = pread(fd, hdr, sizeof(*hdr), (off_t)off);
+  int saved = errno;
+  close(fd);
+  if (n != (ssize_t)sizeof(*hdr))
+    return (n < 0) ? -saved : -EIO;
+  return 0;
+}
+
 static int write_inode_at(const char *img, kafs_inocnt_t ino, const kafs_sinode_t *inode)
 {
   kafs_ssuperblock_t sb = {0};
@@ -431,6 +446,7 @@ int main(void)
   char info_abs[PATH_MAX];
   char kafsctl_abs[PATH_MAX];
   char kafs_abs[PATH_MAX];
+  const char *fsck_abs = kafs_test_fsck_bin();
   const char *mkfs_cands[] = {
       "../src/mkfs.kafs",
       "./src/mkfs.kafs",
@@ -468,6 +484,11 @@ int main(void)
       resolve_tool_path("KAFS_TEST_KAFS", kafs_cands, kafs_abs, sizeof(kafs_abs)) != 0)
   {
     fprintf(stderr, "failed to resolve test tool paths\n");
+    return 1;
+  }
+  if (access(fsck_abs, X_OK) != 0)
+  {
+    fprintf(stderr, "failed to resolve fsck.kafs path\n");
     return 1;
   }
 
@@ -706,6 +727,80 @@ int main(void)
   {
     fprintf(stderr, "unexpected default inode count for 5M image: got=%lu want=320\n",
             (unsigned long)kafs_sb_inocnt_get(&small_sb));
+    return 1;
+  }
+
+  const char *tailmeta_img = "tailmeta-v5.img";
+  char *tailmeta_mkfs_argv[] = {(char *)mkfs_abs, (char *)tailmeta_img, (char *)"-s",
+                                (char *)"32M",    (char *)"--format-version",
+                                (char *)"5",      NULL};
+  if (run_cmd_status(tailmeta_mkfs_argv) != 0)
+  {
+    fprintf(stderr, "mkfs for v5 tailmeta scaffold test failed\n");
+    return 1;
+  }
+
+  kafs_ssuperblock_t tailmeta_sb = {0};
+  if (read_superblock(tailmeta_img, &tailmeta_sb) != 0)
+  {
+    fprintf(stderr, "failed to read v5 tailmeta superblock\n");
+    return 1;
+  }
+  if (kafs_sb_format_version_get(&tailmeta_sb) != KAFS_FORMAT_VERSION_V5)
+  {
+    fprintf(stderr, "unexpected tailmeta image format version\n");
+    return 1;
+  }
+  if ((kafs_sb_feature_flags_get(&tailmeta_sb) & KAFS_FEATURE_TAIL_META_REGION) == 0)
+  {
+    fprintf(stderr, "tailmeta feature flag not set on v5 image\n");
+    return 1;
+  }
+  if (kafs_sb_tailmeta_offset_get(&tailmeta_sb) == 0 || kafs_sb_tailmeta_size_get(&tailmeta_sb) == 0)
+  {
+    fprintf(stderr, "tailmeta region not initialized on v5 image\n");
+    return 1;
+  }
+  {
+    uint64_t blksize_v5 = 1u << kafs_sb_log_blksize_get(&tailmeta_sb);
+    uint64_t data_off = (uint64_t)kafs_sb_first_data_block_get(&tailmeta_sb)
+                        << kafs_sb_log_blksize_get(&tailmeta_sb);
+    uint64_t region_off = kafs_sb_tailmeta_offset_get(&tailmeta_sb);
+    uint64_t region_size = kafs_sb_tailmeta_size_get(&tailmeta_sb);
+    kafs_tailmeta_region_hdr_t region_hdr;
+
+    if ((region_off & (blksize_v5 - 1u)) != 0 || (region_size & (blksize_v5 - 1u)) != 0)
+    {
+      fprintf(stderr, "tailmeta region not block-aligned\n");
+      return 1;
+    }
+    if (region_off + region_size > data_off)
+    {
+      fprintf(stderr, "tailmeta region overlaps data area\n");
+      return 1;
+    }
+    if (read_tailmeta_region_header(tailmeta_img, region_off, &region_hdr) != 0)
+    {
+      fprintf(stderr, "failed to read tailmeta region header\n");
+      return 1;
+    }
+    if (kafs_tailmeta_region_hdr_validate(&region_hdr, region_size) != 0)
+    {
+      fprintf(stderr, "tailmeta region header is invalid\n");
+      return 1;
+    }
+    if (kafs_tailmeta_region_hdr_container_count_get(&region_hdr) != 0 ||
+        kafs_tailmeta_region_hdr_container_table_bytes_get(&region_hdr) != 0)
+    {
+      fprintf(stderr, "tailmeta region should be initialized empty\n");
+      return 1;
+    }
+  }
+
+  char *tailmeta_fsck_argv[] = {(char *)fsck_abs, (char *)tailmeta_img, NULL};
+  if (run_cmd_status(tailmeta_fsck_argv) != 0)
+  {
+    fprintf(stderr, "fsck failed on empty v5 tailmeta image\n");
     return 1;
   }
 


### PR DESCRIPTION
## Summary
- add a mkfs format-version path so v5 images can be emitted intentionally
- reserve and initialize an empty block-aligned tail metadata region for v5 images
- add regression coverage that validates the empty region geometry and fsck acceptance

## Testing
- autoreconf -fi
- ./configure --enable-lto
- make -j"$(nproc)"
- make check -j"$(nproc)"
- ./scripts/format.sh fix
- ./scripts/format.sh
- ./scripts/clones.sh
- ./scripts/static-checks.sh

Closes #113
Refs #51