### PR TITLE
kafsresize: plumb format version to migrate-create

### DIFF
--- a/man/kafsresize.8
+++ b/man/kafsresize.8
@@ -73,6 +73,13 @@ Destination image path used by
 Destination inode count for
 .BR --migrate-create .
 .TP
+.B --format-version V
+Optional on-disk format version forwarded to
+.BR mkfs.kafs .
+This allows
+.B --migrate-create
+to create future-format destination images such as v5 scaffold images.
+.TP
 .B --journal-size-bytes N
 Optional journal size forwarded to
 .BR mkfs.kafs .

--- a/src/kafsresize.c
+++ b/src/kafsresize.c
@@ -31,6 +31,7 @@ static void usage(const char *prog)
           "    - migrate-create builds a new image with target size/inodes via mkfs.kafs\n"
           "    - migrate-create without --size-bytes auto-detects size from --dst-image\n"
           "  options for --migrate-create:\n"
+          "    --format-version V      on-disk format version passed to mkfs.kafs\n"
           "    --journal-size-bytes N   journal size passed to mkfs.kafs\n"
           "    --blksize-log L          block-size log2 passed to mkfs.kafs\n"
           "    --hrl-entry-ratio R      HRL entries/data-block ratio passed to mkfs.kafs\n"
@@ -360,9 +361,9 @@ static int cmd_grow(const char *image, uint64_t target_bytes)
 }
 
 static int cmd_migrate_create(const char *dst_image, uint64_t size_bytes, uint32_t inodes,
-                              uint64_t journal_bytes, int blksize_log, double hrl_entry_ratio,
-                              const char *src_mount, const char *dst_mount, int assume_yes,
-                              int force)
+                              uint32_t format_version, uint64_t journal_bytes, int blksize_log,
+                              double hrl_entry_ratio, const char *src_mount, const char *dst_mount,
+                              int assume_yes, int force)
 {
   if (!dst_image || !*dst_image)
   {
@@ -422,17 +423,19 @@ static int cmd_migrate_create(const char *dst_image, uint64_t size_bytes, uint32
 
   char size_buf[32];
   char inode_buf[32];
+  char format_buf[32];
   char jbuf[32];
   char lbuf[32];
   char rbuf[32];
   snprintf(size_buf, sizeof(size_buf), "%" PRIu64, size_bytes);
   snprintf(inode_buf, sizeof(inode_buf), "%" PRIu32, inodes);
+  snprintf(format_buf, sizeof(format_buf), "%" PRIu32, format_version);
   snprintf(jbuf, sizeof(jbuf), "%" PRIu64, journal_bytes);
   snprintf(lbuf, sizeof(lbuf), "%d", blksize_log);
   snprintf(rbuf, sizeof(rbuf), "%.6f", hrl_entry_ratio);
 
   const char *mkfs = resolve_mkfs_prog();
-  char *argv[20];
+  char *argv[24];
   int ai = 0;
   argv[ai++] = (char *)mkfs;
   argv[ai++] = (char *)dst_image;
@@ -440,6 +443,11 @@ static int cmd_migrate_create(const char *dst_image, uint64_t size_bytes, uint32
   argv[ai++] = size_buf;
   argv[ai++] = "--inodes";
   argv[ai++] = inode_buf;
+  if (format_version > 0)
+  {
+    argv[ai++] = "--format-version";
+    argv[ai++] = format_buf;
+  }
   if (journal_bytes > 0)
   {
     argv[ai++] = "--journal-size-bytes";
@@ -468,6 +476,8 @@ static int cmd_migrate_create(const char *dst_image, uint64_t size_bytes, uint32
   printf("  dst_image: %s\n", dst_image);
   printf("  size_bytes: %" PRIu64 "\n", size_bytes);
   printf("  inodes: %" PRIu32 "\n", inodes);
+  if (format_version > 0)
+    printf("  format_version: %" PRIu32 "\n", format_version);
   if (journal_bytes > 0)
     printf("  journal_bytes: %" PRIu64 "\n", journal_bytes);
   if (blksize_log > 0)
@@ -487,6 +497,7 @@ int main(int argc, char **argv)
   int assume_yes = 0;
   int force = 0;
   uint64_t target_bytes = 0;
+  uint32_t format_version = 0;
   uint64_t journal_bytes = 0;
   int blksize_log = 0;
   double hrl_entry_ratio = 0.0;
@@ -527,6 +538,17 @@ int main(int argc, char **argv)
         fprintf(stderr, "invalid journal-size-bytes: %s\n", argv[i]);
         return 2;
       }
+      continue;
+    }
+    if (strcmp(argv[i], "--format-version") == 0 && i + 1 < argc)
+    {
+      unsigned long long v = strtoull(argv[++i], NULL, 0);
+      if (v == 0 || v > UINT32_MAX)
+      {
+        fprintf(stderr, "invalid format-version: %s\n", argv[i]);
+        return 2;
+      }
+      format_version = (uint32_t)v;
       continue;
     }
     if (strcmp(argv[i], "--blksize-log") == 0 && i + 1 < argc)
@@ -615,8 +637,9 @@ int main(int argc, char **argv)
       usage(argv[0]);
       return 2;
     }
-    return cmd_migrate_create(dst_image, target_bytes, inodes, journal_bytes, blksize_log,
-                              hrl_entry_ratio, src_mount, dst_mount, assume_yes, force);
+    return cmd_migrate_create(dst_image, target_bytes, inodes, format_version, journal_bytes,
+                              blksize_log, hrl_entry_ratio, src_mount, dst_mount, assume_yes,
+                              force);
   }
 
   usage(argv[0]);

--- a/tests/tests_kafsresize.c
+++ b/tests/tests_kafsresize.c
@@ -688,6 +688,60 @@ int main(void)
     return 1;
   }
 
+  const char *dst_v5_img = "migrate-dst-v5.img";
+  int dst_v5_fd = open(dst_v5_img, O_RDWR | O_CREAT | O_TRUNC, 0600);
+  if (dst_v5_fd < 0)
+  {
+    fprintf(stderr, "failed to create v5 migrate dst image\n");
+    return 1;
+  }
+  if (ftruncate(dst_v5_fd, 64 * 1024 * 1024) != 0)
+  {
+    fprintf(stderr, "failed to size v5 migrate dst image\n");
+    close(dst_v5_fd);
+    return 1;
+  }
+  close(dst_v5_fd);
+
+  char migrate_v5_stdout[4096];
+  char *migrate_create_v5_argv[] = {(char *)resize_abs,
+                                    (char *)"--migrate-create",
+                                    (char *)"--dst-image",
+                                    (char *)dst_v5_img,
+                                    (char *)"--force",
+                                    (char *)"--inodes",
+                                    (char *)"4096",
+                                    (char *)"--format-version",
+                                    (char *)"5",
+                                    (char *)"--yes",
+                                    NULL};
+  if (run_cmd_capture_stdout(migrate_create_v5_argv, migrate_v5_stdout,
+                             sizeof(migrate_v5_stdout)) != 0)
+  {
+    fprintf(stderr, "migrate-create v5 failed\n");
+    return 1;
+  }
+
+  kafs_ssuperblock_t migrate_v5_sb = {0};
+  if (read_superblock(dst_v5_img, &migrate_v5_sb) != 0)
+  {
+    fprintf(stderr, "failed to read migrate-create v5 superblock\n");
+    return 1;
+  }
+  if (kafs_sb_magic_get(&migrate_v5_sb) != KAFS_MAGIC ||
+      kafs_sb_format_version_get(&migrate_v5_sb) != KAFS_FORMAT_VERSION_V5 ||
+      (kafs_sb_feature_flags_get(&migrate_v5_sb) & KAFS_FEATURE_TAIL_META_REGION) == 0 ||
+      kafs_sb_tailmeta_size_get(&migrate_v5_sb) == 0)
+  {
+    fprintf(stderr, "unexpected migrate-create v5 image format\n");
+    return 1;
+  }
+  if (!strstr(migrate_v5_stdout, "format_version: 5"))
+  {
+    fprintf(stderr, "migrate-create v5 output missing format version summary\n");
+    return 1;
+  }
+
   const char *info_img = "info-tombstone.img";
   char *info_mkfs_argv[] = {(char *)mkfs_abs, (char *)info_img, (char *)"-s", (char *)"32M", NULL};
   if (run_cmd_status(info_mkfs_argv) != 0)


### PR DESCRIPTION
## Summary
- add `--format-version` parsing for `kafsresize --migrate-create`
- forward the selected format version to `mkfs.kafs`
- add regression coverage for creating a v5 migrate-create destination image

## Testing
- autoreconf -fi
- ./configure --enable-lto
- make -j"$(nproc)"
- make check -j"$(nproc)"
- ./scripts/format.sh fix
- ./scripts/format.sh
- ./scripts/clones.sh
- ./scripts/static-checks.sh

Closes #118
Refs #51