### PR TITLE
docs: mention v5 tail metadata in manpages

### DIFF
--- a/man/kafs-info.8
+++ b/man/kafs-info.8
@@ -17,7 +17,14 @@ tombstone inode count and oldest deletion timestamp,
 .IP \[bu] 2
 hash settings,
 .IP \[bu] 2
-HRL index/entry region summary.
+HRL index/entry region summary,
+.IP \[bu] 2
+tail metadata region state, offset, and size.
+.PP
+For format version 5 images,
+.B kafs-info
+reports whether the dedicated tail metadata region is enabled and prints its
+byte offset and byte size as part of the top-level summary.
 .PP
 This command does not modify image contents.
 .SH EXIT STATUS

--- a/man/kafsdump.8
+++ b/man/kafsdump.8
@@ -14,7 +14,13 @@ The tool never writes image contents.
 The dump contains the following sections:
 .TP
 .B superblock
-Magic/version, block geometry, and free counters.
+Magic/version, block geometry, free counters, and tail metadata region flags,
+offset, and size.
+.TP
+.B tail_metadata
+Tail metadata probe status and, when available, the region header summary
+including container and slot counters. Empty format version 5 scaffold images
+report this section as available with zero containers and zero live slots.
 .TP
 .B inode_summary
 Inode totals, used/free counts, and number of in-use inodes with link count 0.


### PR DESCRIPTION
## Summary\n- describe the v5 tail metadata fields shown by kafs-info\n- document the tail_metadata section emitted by kafsdump\n\n## Testing\n- autoreconf -fi\n- ./configure --enable-lto\n- make -j"12"\n- make check -j"12"\n- ./scripts/clones.sh\n- ./scripts/static-checks.sh\n\n## Parent\n- refs #128\n- refs #51\n