### PR TITLE
docs: refresh README doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,5 +334,5 @@ make check
 - docs/hotplug-*.md and docs/hotplug-pipe-*.md: hotplug plans/designs
 - docs/dedup-design.md: deduplication design notes
 - docs/kafsimage-format.md: kafsimage mode semantics and output rules
-- man/: manual pages for kafs, mkfs.kafs, fsck.kafs, kafsctl
+- man/: manual pages for kafs, kafsctl, mkfs.kafs, fsck.kafs, kafs-info, kafsdump, kafsimage, and kafsresize
 - CHANGELOG.md: release notes


### PR DESCRIPTION
## Summary\n- refresh the README documentation footer so it lists the current offline tool man pages\n- keep the change limited to documentation links and descriptions\n\n## Testing\n- autoreconf -fi\n- ./configure --enable-lto\n- make -j"12"\n- make check -j"12"\n- ./scripts/clones.sh\n- ./scripts/static-checks.sh\n\n## Parent\n- refs #134\n- refs #51\n