### PR TITLE
docs: refresh tools suite wording

### DIFF
--- a/docs/tools-suite.md
+++ b/docs/tools-suite.md
@@ -23,7 +23,7 @@
   - `kafsimage`（オフライン image のエクスポート）
     - `--metadata-only` / `--raw` / `--sparse` と `--verify` を提供。
     - metadata-only ではメタデータ先頭領域 `[0, first_data_block * block_size)` を書き出す。
-  - `kafsresize`（オフライン image の grow-only リサイズ）
+  - `kafsresize`（オフライン image の resize / migration-image 作成）
     - `--grow --size-bytes` と `--migrate-create` を提供。
     - 事前確保ヘッドルーム（`s_blkcnt < s_r_blkcnt`）内の増設のみ対応。
     - format version 5 scaffold image の grow と offline migrate-create を受け付ける。


### PR DESCRIPTION
## Summary\n- update the docs/tools-suite.md kafsresize heading so it no longer says grow-only\n- keep the change limited to the current-state wording already describing --migrate-create\n\n## Testing\n- autoreconf -fi\n- ./configure --enable-lto\n- make -j"12"\n- make check -j"12"\n- ./scripts/clones.sh\n- ./scripts/static-checks.sh\n\n## Parent\n- refs #142\n- refs #51\n