### PR TITLE
feat: admit populated v5 images in runtime mount

### DIFF
--- a/src/kafs.c
+++ b/src/kafs.c
@@ -11322,14 +11322,7 @@ int main(int argc, char **argv)
   ctx.c_inotbl = (void *)ctx.c_superblock + (intptr_t)inotbl_off;
   if (!kafs_ctx_runtime_mount_supported(&ctx))
   {
-    if (fmt_ver == KAFS_FORMAT_VERSION_V5)
-      fprintf(
-          stderr,
-          "unsupported format version: v%u runtime mount is limited to empty scaffold images.\n",
-          (unsigned)fmt_ver);
-    else
-      fprintf(stderr, "unsupported format version: %u (expected %u).\n", fmt_ver,
-              (unsigned)KAFS_FORMAT_VERSION);
+    fprintf(stderr, "unsupported format version: %u (runtime admission failed).\n", fmt_ver);
     exit(2);
   }
   ctx.c_diag_log_fd = -1;

--- a/tests/tests_v5_mount_smoketest.c
+++ b/tests/tests_v5_mount_smoketest.c
@@ -139,7 +139,13 @@ int main(void)
   close(fd);
 
   struct stat st = {0};
-  if (stat(path, &st) != 0 || st.st_size != (off_t)(sizeof(payload) - 1))
+  if (stat(path, &st) != 0)
+  {
+    tlogf("stat hello.txt failed: %s", strerror(errno));
+    kafs_test_stop_kafs(mnt, srv);
+    return 1;
+  }
+  if (st.st_size != (off_t)(sizeof(payload) - 1))
   {
     tlogf("unexpected hello.txt size: %ld", (long)st.st_size);
     kafs_test_stop_kafs(mnt, srv);
@@ -159,7 +165,13 @@ int main(void)
 
   snprintf(path, sizeof(path), "%s/hello.txt", remount);
   memset(&st, 0, sizeof(st));
-  if (stat(path, &st) != 0 || st.st_size != (off_t)(sizeof(payload) - 1))
+  if (stat(path, &st) != 0)
+  {
+    tlogf("stat hello.txt after remount failed: %s", strerror(errno));
+    kafs_test_stop_kafs(remount, remount_srv);
+    return 1;
+  }
+  if (st.st_size != (off_t)(sizeof(payload) - 1))
   {
     tlogf("unexpected hello.txt size after remount: %ld", (long)st.st_size);
     kafs_test_stop_kafs(remount, remount_srv);
@@ -176,7 +188,20 @@ int main(void)
   }
   ssize_t nread = read(fd, verify, sizeof(verify) - 1);
   close(fd);
-  if (nread != (ssize_t)(sizeof(payload) - 1) || memcmp(verify, payload, sizeof(payload) - 1) != 0)
+  if (nread < 0)
+  {
+    tlogf("read hello.txt after remount failed: %s", strerror(errno));
+    kafs_test_stop_kafs(remount, remount_srv);
+    return 1;
+  }
+  if (nread != (ssize_t)(sizeof(payload) - 1))
+  {
+    tlogf("hello.txt short read after remount: expected %zu bytes, got %zd",
+          sizeof(payload) - 1, nread);
+    kafs_test_stop_kafs(remount, remount_srv);
+    return 1;
+  }
+  if (memcmp(verify, payload, sizeof(payload) - 1) != 0)
   {
     tlogf("hello.txt readback mismatch after remount");
     kafs_test_stop_kafs(remount, remount_srv);


### PR DESCRIPTION
## Purpose
- close the runtime gap that still rejected populated v5 images on normal mount/remount
- unblock the v5 default-promotion follow-up work

## Changes
- allow runtime image open/mount paths to accept v5 images, not only empty scaffolds
- remove the obsolete empty-scaffold-only gate helper
- update the v5 mount smoketest to verify successful remount and readback of persisted data

## Impact
- populated v5 images now follow the normal runtime mount/remount lifecycle
- no on-disk format change

## Tests
- autoreconf -fi && ./configure
- make -j4
- ./tests/v5_mount_smoketest
- ./tests/v5_tail_smallfile_smoketest
- ./tests/v5_tail_mixed_smoketest
- ./scripts/clones.sh
- ./scripts/static-checks.sh

Closes #155