### PR TITLE
fix: restore make check after offsetof use

### DIFF
--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -13,6 +13,7 @@
 #include <ftw.h>
 #include <limits.h>
 #include <signal.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/tests_kafsresize.c
+++ b/tests/tests_kafsresize.c
@@ -9,6 +9,7 @@
 #include <fcntl.h>
 #include <inttypes.h>
 #include <limits.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
## Summary
- add the missing `<stddef.h>` include in `tests/test_utils.c`
- add the missing `<stddef.h>` include in `tests/tests_kafsresize.c`
- restore `make check` for the affected test builds using `offsetof()` under `-Werror`

## Testing
- `make check`
- `./scripts/clones.sh`
- `./scripts/static-checks.sh`

Closes #173