### PR TITLE
Refactor static-analysis wave 1

### DIFF
--- a/docs/duplicate-policy.md
+++ b/docs/duplicate-policy.md
@@ -1,6 +1,9 @@
 # Duplicate Code Policy
 
-- We run jscpd with formats `c,c-header` scanning `src/**/*.{c,h}`.
+- We run jscpd in two separate passes with formats `c,c-header`.
 - Test utilities are extracted into `test_utils.c/h` to reduce duplication across tests.
-- Acceptable duplication threshold is `--min-lines=10` and `--threshold=1` in scripts/clones.sh.
-- If the remaining clones only appear in generated or non-critical boilerplate, consider adding targeted `--ignore` patterns with justification in this file.
+- Generated artifacts stay out of scope, including `.deps/**` and generated `Makefile*` files.
+- The strict gate scans `src/**/*.{c,h}` with `--min-lines=8` and `--threshold=1`.
+- A separate informational report scans `tests/**/*.{c,h}` with the same minimum match size and a non-gating threshold.
+- Because the scans are separated, duplication between `src/` and `tests/` is intentionally ignored.
+- If the remaining clones only appear in generated or non-critical boilerplate, add targeted `--ignore` patterns with justification in this file.

--- a/docs/static-checks.md
+++ b/docs/static-checks.md
@@ -2,7 +2,7 @@
 
 - Formatting: clang-format via scripts/format.sh
 - Lint: compiler warnings-as-errors via scripts/lint.sh
-- Clones: jscpd via scripts/clones.sh (formats: c,c-header)
+- Clones: jscpd via scripts/clones.sh with a strict `src/**/*.{c,h}` gate plus a separate non-gating `tests/**/*.{c,h}` report (formats: c,c-header)
 - Dead code: cppcheck via scripts/deadcode.sh
 - Complexity: lizard via scripts/complexity.sh
 

--- a/scripts/clones.sh
+++ b/scripts/clones.sh
@@ -9,20 +9,38 @@ REPORT_DIR=${REPORT_DIR:-report/clone}
 CLONES_TIMEOUT_SECONDS=${CLONES_TIMEOUT_SECONDS:-180}
 mkdir -p "$REPORT_DIR"
 
-JSCPD_CMD=(
-  npx --yes jscpd@latest
-  --min-lines 8
-  --threshold 5
-  --reporters json,console
-  --ignore "**/autom4te.cache/**"
-  --ignore "**/tests_*.c"
-  --format "c,c-header"
-  --pattern "src/**/*.{c,h}"
-  --output "$REPORT_DIR"
-)
+run_jscpd() {
+  local output_dir=$1
+  local threshold=$2
+  local pattern=$3
 
-if command -v timeout >/dev/null 2>&1; then
-  NPM_CONFIG_UPDATE_NOTIFIER=false timeout --preserve-status "${CLONES_TIMEOUT_SECONDS}s" "${JSCPD_CMD[@]}"
-else
-  NPM_CONFIG_UPDATE_NOTIFIER=false "${JSCPD_CMD[@]}"
+  local cmd=(
+    npx --yes jscpd@latest
+    --min-lines 8
+    --threshold "$threshold"
+    --reporters json,console
+    --ignore "**/autom4te.cache/**"
+    --ignore "**/.deps/**"
+    --ignore "**/Makefile.in"
+    --ignore "**/Makefile"
+    --format "c,c-header"
+    --pattern "$pattern"
+    --output "$output_dir"
+  )
+
+  if command -v timeout >/dev/null 2>&1; then
+    NPM_CONFIG_UPDATE_NOTIFIER=false timeout --preserve-status "${CLONES_TIMEOUT_SECONDS}s" "${cmd[@]}"
+  else
+    NPM_CONFIG_UPDATE_NOTIFIER=false "${cmd[@]}"
+  fi
+}
+
+echo "[clones] strict gate: src/**/*.{c,h}"
+run_jscpd "$REPORT_DIR/src" 1 "src/**/*.{c,h}"
+
+echo "[clones] informational report: tests/**/*.{c,h}"
+run_jscpd "$REPORT_DIR/tests" 100 "tests/**/*.{c,h}"
+
+if [ -f "$REPORT_DIR/src/jscpd-report.json" ]; then
+  cp "$REPORT_DIR/src/jscpd-report.json" "$REPORT_DIR/jscpd-report.json"
 fi

--- a/src/fsck_kafs.c
+++ b/src/fsck_kafs.c
@@ -2,7 +2,6 @@
 #include "kafs_inode.h"
 #include "kafs_dirent.h"
 #include "kafs_hash.h"
-#include "kafs_locks.h"
 #include "kafs_tailmeta.h"
 #include "kafs_block.h"
 #include "kafs_cli_opts.h"
@@ -90,6 +89,18 @@ struct dir_v4_stats
   uint64_t repaired_dirs;
 };
 
+struct fsck_dir_v4_scan_result
+{
+  uint32_t live_count;
+  uint32_t tombstone_count;
+  uint32_t dotdot_live;
+  size_t bad_off;
+  uint16_t bad_rec_len;
+  uint16_t bad_flags;
+  kafs_inocnt_t bad_dino;
+  kafs_filenamelen_t bad_namelen;
+};
+
 typedef enum fsck_mode
 {
   FSCK_MODE_UNSET = 0,
@@ -100,6 +111,696 @@ typedef enum fsck_mode
   FSCK_MODE_FULL_CHECK,
   FSCK_MODE_FULL_REPAIR,
 } fsck_mode_t;
+
+struct fsck_options
+{
+  int do_journal_reset;
+  int do_check_dirent_ino_orphans;
+  int do_repair_dirent_ino_orphans;
+  int do_check_hrl_blo_refcounts;
+  int do_repair_hrl_blo_refcounts;
+  int do_check_inode_block_counts;
+  int do_repair_inode_block_counts;
+  int do_replay_journal;
+  int do_punch_hole_unreferenced_data_blocks;
+  int do_trim_free_data_blocks;
+  int do_check_journal;
+  int has_preset_mode;
+  int has_low_level_mode;
+  fsck_mode_t mode;
+  const char *img;
+};
+
+struct fsck_image_info
+{
+  int fd;
+  kafs_ssuperblock_t sb;
+  uint64_t file_size;
+};
+
+static int check_tailmeta_live_slot_owner(int fd, const kafs_ssuperblock_t *sb, uint64_t file_size,
+                                          uint64_t inode_table_off, uint32_t container_index,
+                                          uint16_t slot_index,
+                                          const kafs_tailmeta_slot_desc_t *slot);
+
+static int pread_all(int fd, void *buf, size_t sz, off_t off);
+static int pwrite_all(int fd, const void *buf, size_t sz, off_t off);
+static int orphan_reclaim(kafs_context_t *ctx, int do_fix, struct orphan_stats *stats);
+static int fsck_check_or_repair_dir_v4(kafs_context_t *ctx, int do_fix, struct dir_v4_stats *stats);
+static int check_hrl_blo_refcounts(kafs_context_t *ctx, struct hrl_refcheck_stats *stats);
+static int repair_hrl_blo_refcounts(kafs_context_t *ctx, struct hrl_repair_stats *stats);
+static int punch_unreferenced_data_blocks(kafs_context_t *ctx, int fd, struct punch_stats *stats);
+static int trim_free_data_blocks(kafs_context_t *ctx, int fd, struct punch_stats *stats);
+static int check_or_repair_inode_block_counts(kafs_context_t *ctx, int do_fix,
+                                              struct inode_blocks_stats *stats);
+static int check_region_bounds(const char *name, uint64_t off, uint64_t size, uint64_t file_size);
+static int check_tailmeta_region(int fd, const kafs_ssuperblock_t *sb, uint64_t file_size);
+
+static void fsck_options_init(struct fsck_options *opts)
+{
+  memset(opts, 0, sizeof(*opts));
+  opts->do_check_journal = 1;
+  opts->mode = FSCK_MODE_UNSET;
+}
+
+static int fsck_parse_preset_mode(const char *arg, struct fsck_options *opts)
+{
+  if (strcmp(arg, "--full-check") == 0)
+    opts->mode = FSCK_MODE_FULL_CHECK;
+  else if (strcmp(arg, "--full-repair") == 0)
+    opts->mode = FSCK_MODE_FULL_REPAIR;
+  else if (strcmp(arg, "--balanced-check") == 0 || strcmp(arg, "--check") == 0)
+    opts->mode = FSCK_MODE_BALANCED_CHECK;
+  else if (strcmp(arg, "--balanced-repair") == 0 || strcmp(arg, "--repair") == 0)
+    opts->mode = FSCK_MODE_BALANCED_REPAIR;
+  else if (strcmp(arg, "--fast-check") == 0)
+    opts->mode = FSCK_MODE_FAST_CHECK;
+  else if (strcmp(arg, "--fast-repair") == 0)
+    opts->mode = FSCK_MODE_FAST_REPAIR;
+  else
+    return 0;
+
+  opts->has_preset_mode = 1;
+  return 1;
+}
+
+static int fsck_parse_low_level_mode(const char *arg, struct fsck_options *opts)
+{
+  if (strcmp(arg, "--check-journal") == 0)
+  {
+    opts->has_low_level_mode = 1;
+    return 1;
+  }
+  if (strcmp(arg, "--repair-journal-reset") == 0)
+    opts->do_journal_reset = 1;
+  else if (strcmp(arg, "--repair-dirent-ino-orphans") == 0)
+    opts->do_repair_dirent_ino_orphans = 1;
+  else if (strcmp(arg, "--check-dirent-ino-orphans") == 0)
+    opts->do_check_dirent_ino_orphans = 1;
+  else if (strcmp(arg, "--check-hrl-blo-refcounts") == 0)
+    opts->do_check_hrl_blo_refcounts = 1;
+  else if (strcmp(arg, "--repair-hrl-blo-refcounts") == 0)
+    opts->do_repair_hrl_blo_refcounts = 1;
+  else if (strcmp(arg, "--check-inode-block-counts") == 0)
+    opts->do_check_inode_block_counts = 1;
+  else if (strcmp(arg, "--repair-inode-block-counts") == 0)
+    opts->do_repair_inode_block_counts = 1;
+  else if (strcmp(arg, "--replay-journal") == 0)
+    opts->do_replay_journal = 1;
+  else if (strcmp(arg, "--punch-hole-unreferenced-data-blocks") == 0)
+    opts->do_punch_hole_unreferenced_data_blocks = 1;
+  else if (strcmp(arg, "--trim-free-data-blocks") == 0)
+    opts->do_trim_free_data_blocks = 1;
+  else
+    return 0;
+
+  opts->has_low_level_mode = 1;
+  return 1;
+}
+
+static int fsck_parse_args(int argc, char **argv, struct fsck_options *opts)
+{
+  for (int i = 1; i < argc; ++i)
+  {
+    if (fsck_parse_preset_mode(argv[i], opts) || fsck_parse_low_level_mode(argv[i], opts))
+      continue;
+    if (argv[i][0] != '-' && !opts->img)
+    {
+      opts->img = argv[i];
+      continue;
+    }
+    return -1;
+  }
+
+  if (!opts->img || (opts->has_preset_mode && opts->has_low_level_mode))
+    return -1;
+  return 0;
+}
+
+static void fsck_apply_mode_defaults(struct fsck_options *opts)
+{
+  if (opts->has_preset_mode)
+  {
+    opts->do_check_journal = 1;
+    opts->do_journal_reset = 0;
+    opts->do_check_dirent_ino_orphans = 0;
+    opts->do_repair_dirent_ino_orphans = 0;
+    opts->do_check_hrl_blo_refcounts = 0;
+    opts->do_repair_hrl_blo_refcounts = 0;
+
+    switch (opts->mode)
+    {
+    case FSCK_MODE_FAST_CHECK:
+      break;
+    case FSCK_MODE_FAST_REPAIR:
+      opts->do_journal_reset = 1;
+      break;
+    case FSCK_MODE_BALANCED_CHECK:
+      opts->do_check_dirent_ino_orphans = 1;
+      break;
+    case FSCK_MODE_BALANCED_REPAIR:
+      opts->do_journal_reset = 1;
+      opts->do_repair_dirent_ino_orphans = 1;
+      break;
+    case FSCK_MODE_FULL_CHECK:
+      opts->do_check_dirent_ino_orphans = 1;
+      opts->do_check_hrl_blo_refcounts = 1;
+      break;
+    case FSCK_MODE_FULL_REPAIR:
+      opts->do_journal_reset = 1;
+      opts->do_repair_dirent_ino_orphans = 1;
+      opts->do_check_hrl_blo_refcounts = 1;
+      opts->do_repair_hrl_blo_refcounts = 1;
+      break;
+    case FSCK_MODE_UNSET:
+    default:
+      break;
+    }
+    return;
+  }
+
+  if (!opts->has_low_level_mode)
+  {
+    opts->do_check_journal = 1;
+    opts->do_check_dirent_ino_orphans = 1;
+  }
+}
+
+static int fsck_want_write(const struct fsck_options *opts)
+{
+  return opts->do_journal_reset || opts->do_repair_dirent_ino_orphans ||
+         opts->do_repair_hrl_blo_refcounts || opts->do_repair_inode_block_counts ||
+         opts->do_replay_journal || opts->do_punch_hole_unreferenced_data_blocks ||
+         opts->do_trim_free_data_blocks;
+}
+
+static int fsck_detect_file_size(int fd, uint64_t *file_size)
+{
+  struct stat st;
+
+  if (fstat(fd, &st) != 0)
+  {
+    perror("fstat");
+    return -1;
+  }
+  if (S_ISREG(st.st_mode))
+  {
+    *file_size = (uint64_t)st.st_size;
+    return 0;
+  }
+  if (S_ISBLK(st.st_mode))
+  {
+#ifdef __linux__
+    if (ioctl(fd, BLKGETSIZE64, file_size) != 0)
+    {
+      perror("ioctl(BLKGETSIZE64)");
+      return -1;
+    }
+    return 0;
+#else
+    fprintf(stderr, "block devices are not supported on this platform\n");
+    return -1;
+#endif
+  }
+
+  fprintf(stderr, "unsupported file type\n");
+  return -1;
+}
+
+static int fsck_open_image(const struct fsck_options *opts, int want_write,
+                           struct fsck_image_info *info)
+{
+  memset(info, 0, sizeof(*info));
+  info->fd = open(opts->img, want_write ? O_RDWR : O_RDONLY);
+  if (info->fd < 0)
+  {
+    perror("open");
+    return -1;
+  }
+  if (pread_all(info->fd, &info->sb, sizeof(info->sb), 0) != 0)
+  {
+    perror("pread superblock");
+    close(info->fd);
+    return -1;
+  }
+  if (fsck_detect_file_size(info->fd, &info->file_size) != 0)
+  {
+    close(info->fd);
+    return -1;
+  }
+  return 0;
+}
+
+static int fsck_validate_regions(const struct fsck_image_info *info)
+{
+  if (check_region_bounds("allocator", kafs_sb_allocator_offset_get(&info->sb),
+                          kafs_sb_allocator_size_get(&info->sb), info->file_size) != 0)
+    return 3;
+  if (check_region_bounds("pendinglog", kafs_sb_pendinglog_offset_get(&info->sb),
+                          kafs_sb_pendinglog_size_get(&info->sb), info->file_size) != 0)
+    return FSCK_EXIT_JOURNAL_CHECK_FAILED;
+
+  uint64_t tail_off = kafs_sb_tailmeta_offset_get(&info->sb);
+  uint64_t tail_size = kafs_sb_tailmeta_size_get(&info->sb);
+  uint64_t feature_flags = kafs_sb_feature_flags_get(&info->sb);
+  if (((feature_flags & KAFS_FEATURE_TAIL_META_REGION) != 0 || tail_off != 0 || tail_size != 0) &&
+      check_region_bounds("tailmeta", tail_off, tail_size, info->file_size) != 0)
+    return 3;
+
+  if (check_tailmeta_region(info->fd, &info->sb, info->file_size) != 0)
+    return FSCK_EXIT_TAILMETA_INCONSISTENT;
+  return 0;
+}
+
+static int fsck_map_context(int fd, const kafs_ssuperblock_t *sb, int want_write,
+                            kafs_context_t *ctx)
+{
+  memset(ctx, 0, sizeof(*ctx));
+  ctx->c_fd = fd;
+
+  kafs_logblksize_t log_blksize = kafs_sb_log_blksize_get(sb);
+  kafs_blksize_t blksize = 1u << log_blksize;
+  kafs_blksize_t blksizemask = blksize - 1u;
+  kafs_inocnt_t inocnt = kafs_inocnt_stoh(sb->s_inocnt);
+  kafs_blkcnt_t r_blkcnt = kafs_blkcnt_stoh(sb->s_r_blkcnt);
+
+  off_t mapsize = sizeof(kafs_ssuperblock_t);
+  mapsize = (mapsize + blksizemask) & ~blksizemask;
+  void *blkmask_off = (void *)mapsize;
+  mapsize += (r_blkcnt + 7) >> 3;
+  mapsize = (mapsize + 7) & ~7;
+  mapsize = (mapsize + blksizemask) & ~blksizemask;
+  void *inotbl_off = (void *)mapsize;
+  mapsize += (off_t)kafs_inode_table_bytes_for_format(kafs_sb_format_version_get(sb), inocnt);
+  mapsize = (mapsize + blksizemask) & ~blksizemask;
+
+  off_t imgsize = (off_t)r_blkcnt << log_blksize;
+  uint64_t idx_off = kafs_sb_hrl_index_offset_get(sb);
+  uint64_t idx_size = kafs_sb_hrl_index_size_get(sb);
+  uint64_t ent_off = kafs_sb_hrl_entry_offset_get(sb);
+  uint64_t ent_cnt = kafs_sb_hrl_entry_cnt_get(sb);
+  uint64_t ent_size = ent_cnt * (uint64_t)sizeof(kafs_hrl_entry_t);
+  uint64_t j_off = kafs_sb_journal_offset_get(sb);
+  uint64_t j_size = kafs_sb_journal_size_get(sb);
+  uint64_t max_end = (idx_off && idx_size) ? (idx_off + idx_size) : 0;
+  if (((ent_off && ent_size) ? (ent_off + ent_size) : 0) > max_end)
+    max_end = ent_off + ent_size;
+  if (((j_off && j_size) ? (j_off + j_size) : 0) > max_end)
+    max_end = j_off + j_size;
+  if ((off_t)max_end > imgsize)
+    imgsize = (off_t)max_end;
+  imgsize = (imgsize + blksizemask) & ~blksizemask;
+
+  int prot = want_write ? (PROT_READ | PROT_WRITE) : PROT_READ;
+  ctx->c_img_base = mmap(NULL, (size_t)imgsize, prot, MAP_SHARED, fd, 0);
+  if (ctx->c_img_base == MAP_FAILED)
+  {
+    perror("mmap");
+    return -1;
+  }
+
+  ctx->c_img_size = (size_t)imgsize;
+  ctx->c_superblock = (kafs_ssuperblock_t *)ctx->c_img_base;
+  ctx->c_mapsize = (size_t)mapsize;
+  ctx->c_blkmasktbl = (void *)((char *)ctx->c_superblock + (intptr_t)blkmask_off);
+  ctx->c_inotbl = (void *)((char *)ctx->c_superblock + (intptr_t)inotbl_off);
+  return 0;
+}
+
+static int fsck_handle_dirent_ops(kafs_context_t *ctx, const struct fsck_options *opts,
+                                  int *exit_code)
+{
+  struct orphan_stats ost;
+  struct dir_v4_stats dst;
+  memset(&ost, 0, sizeof(ost));
+  memset(&dst, 0, sizeof(dst));
+
+  int drc = fsck_check_or_repair_dir_v4(ctx, opts->do_repair_dirent_ino_orphans, &dst);
+  if (drc != 0)
+    return -1;
+
+  if (dst.invalid_dirs > 0)
+  {
+    fprintf(stderr,
+            "Dir-v4 summary: checked=%" PRIu64 " invalid=%" PRIu64 " repaired=%" PRIu64 "\n",
+            dst.dirs_checked, dst.invalid_dirs, dst.repaired_dirs);
+    if (opts->do_repair_dirent_ino_orphans)
+    {
+      if (dst.invalid_dirs != dst.repaired_dirs)
+        *exit_code = FSCK_EXIT_DIRENT_FORMAT_INCONSISTENT;
+    }
+    else
+    {
+      *exit_code = FSCK_EXIT_DIRENT_FORMAT_INCONSISTENT;
+    }
+  }
+
+  if (opts->do_repair_dirent_ino_orphans)
+    (void)kafs_hrl_open(ctx);
+
+  int found = orphan_reclaim(ctx, opts->do_repair_dirent_ino_orphans, &ost);
+  if (found < 0)
+  {
+    if (opts->do_repair_dirent_ino_orphans)
+      (void)kafs_hrl_close(ctx);
+    return -1;
+  }
+
+  if (opts->do_repair_dirent_ino_orphans)
+  {
+    (void)kafs_hrl_close(ctx);
+    fprintf(stderr,
+            "Dirent->ino orphan repair summary: found=%" PRIu64 " dec_attempted=%" PRIu64
+            " dec_failed=%" PRIu64 "\n",
+            ost.found, ost.dec_attempted, ost.dec_failed);
+    if (ost.dec_failed > 0)
+      *exit_code = FSCK_EXIT_DIRENT_INO_REPAIR_PARTIAL;
+  }
+  else if (ost.found > 0)
+  {
+    *exit_code = FSCK_EXIT_DIRENT_INO_INCONSISTENT;
+  }
+
+  return 0;
+}
+
+static int fsck_handle_hrl_ops(kafs_context_t *ctx, const struct fsck_options *opts, int *exit_code)
+{
+  if (opts->do_repair_hrl_blo_refcounts)
+  {
+    struct hrl_repair_stats rst;
+    memset(&rst, 0, sizeof(rst));
+    if (kafs_hrl_open(ctx) != 0)
+      return -1;
+    int rc = repair_hrl_blo_refcounts(ctx, &rst);
+    (void)kafs_hrl_close(ctx);
+    if (rc != 0)
+      return -1;
+
+    fprintf(stderr,
+            "HRL->BLO repair summary: inc_attempted=%" PRIu64 " inc_failed=%" PRIu64
+            " dec_attempted=%" PRIu64 " dec_failed=%" PRIu64 "\n",
+            rst.inc_attempted, rst.inc_failed, rst.dec_attempted, rst.dec_failed);
+    if ((rst.inc_failed > 0 || rst.dec_failed > 0) && *exit_code == 0)
+      *exit_code = FSCK_EXIT_HRL_BLO_INCONSISTENT;
+  }
+
+  if (opts->do_check_hrl_blo_refcounts)
+  {
+    struct hrl_refcheck_stats hst;
+    memset(&hst, 0, sizeof(hst));
+    if (check_hrl_blo_refcounts(ctx, &hst) != 0)
+      return -1;
+
+    fprintf(stderr,
+            "HRL->BLO check summary: inode_refs=%" PRIu64 " pending_refs=%" PRIu64
+            " invalid_refs=%" PRIu64 " live_entries=%" PRIu64 " invalid_entries=%" PRIu64
+            " mismatches=%" PRIu64 "\n",
+            hst.inode_refs, hst.pending_refs, hst.invalid_refs, hst.live_entries,
+            hst.hrl_invalid_entries, hst.mismatch_entries);
+    if ((hst.mismatch_entries > 0 || hst.pending_refs > 0 || hst.invalid_refs > 0 ||
+         hst.hrl_invalid_entries > 0) &&
+        *exit_code == 0)
+      *exit_code = FSCK_EXIT_HRL_BLO_INCONSISTENT;
+  }
+
+  return 0;
+}
+
+static int fsck_handle_inode_and_punch_ops(kafs_context_t *ctx, int fd,
+                                           const struct fsck_options *opts, int *exit_code)
+{
+  if (opts->do_check_inode_block_counts || opts->do_repair_inode_block_counts)
+  {
+    struct inode_blocks_stats ibs;
+    memset(&ibs, 0, sizeof(ibs));
+    if (check_or_repair_inode_block_counts(ctx, opts->do_repair_inode_block_counts, &ibs) != 0)
+      return -1;
+
+    fprintf(stderr,
+            "inode block-count %s summary: checked=%" PRIu64 " mismatches=%" PRIu64
+            " repaired=%" PRIu64 "\n",
+            opts->do_repair_inode_block_counts ? "repair" : "check", ibs.checked, ibs.mismatches,
+            ibs.repaired);
+    if (!opts->do_repair_inode_block_counts && ibs.mismatches > 0 && *exit_code == 0)
+      *exit_code = FSCK_EXIT_INODE_BLOCKS_INCONSISTENT;
+  }
+
+  if (opts->do_punch_hole_unreferenced_data_blocks)
+  {
+    struct punch_stats pst;
+    memset(&pst, 0, sizeof(pst));
+    if (punch_unreferenced_data_blocks(ctx, fd, &pst) != 0)
+      return -1;
+
+    fprintf(stderr,
+            "Punch-hole summary: candidates=%" PRIu64 " already_free=%" PRIu64 " punched=%" PRIu64
+            " punch_failed=%" PRIu64 " mark_failed=%" PRIu64 "\n",
+            pst.candidates, pst.already_free, pst.punched, pst.punch_failed, pst.mark_failed);
+    if ((pst.punch_failed > 0 || pst.mark_failed > 0) && *exit_code == 0)
+      *exit_code = FSCK_EXIT_PUNCH_HOLE_PARTIAL;
+  }
+
+  if (opts->do_trim_free_data_blocks)
+  {
+    struct punch_stats tst;
+    if (trim_free_data_blocks(ctx, fd, &tst) != 0)
+      return -1;
+
+    fprintf(stderr,
+            "Trim-free summary: candidates=%" PRIu64 " punched=%" PRIu64 " punch_failed=%" PRIu64
+            "\n",
+            tst.candidates, tst.punched, tst.punch_failed);
+    if (tst.punch_failed > 0 && *exit_code == 0)
+      *exit_code = FSCK_EXIT_PUNCH_HOLE_PARTIAL;
+  }
+
+  return 0;
+}
+
+static int fsck_run_mapped_ops(int fd, int want_write, const struct fsck_options *opts,
+                               int *exit_code, const kafs_ssuperblock_t *sb)
+{
+  kafs_context_t ctx;
+  if (fsck_map_context(fd, sb, want_write, &ctx) != 0)
+    return 1;
+
+  ctx.c_blo_search = 0;
+  ctx.c_ino_search = 0;
+  if (opts->do_replay_journal)
+  {
+    int rc = kafs_journal_replay(&ctx, NULL, NULL);
+    if (rc != 0)
+    {
+      munmap(ctx.c_img_base, ctx.c_img_size);
+      return FSCK_EXIT_JOURNAL_REPLAY_FAILED;
+    }
+    fprintf(stderr, "Journal replay: applied pending metadata and cleared ring.\n");
+  }
+
+  if ((opts->do_check_dirent_ino_orphans || opts->do_repair_dirent_ino_orphans) &&
+      fsck_handle_dirent_ops(&ctx, opts, exit_code) != 0)
+  {
+    munmap(ctx.c_img_base, ctx.c_img_size);
+    return 1;
+  }
+  if (fsck_handle_hrl_ops(&ctx, opts, exit_code) != 0 ||
+      fsck_handle_inode_and_punch_ops(&ctx, fd, opts, exit_code) != 0)
+  {
+    munmap(ctx.c_img_base, ctx.c_img_size);
+    return 1;
+  }
+
+  if (want_write)
+  {
+    (void)msync(ctx.c_img_base, ctx.c_img_size, MS_SYNC);
+    (void)fsync(fd);
+  }
+  munmap(ctx.c_img_base, ctx.c_img_size);
+  return 0;
+}
+
+static int fsck_handle_offline_ops(int fd, int want_write, const struct fsck_options *opts,
+                                   int *exit_code, const kafs_ssuperblock_t *sb)
+{
+  if (!opts->do_check_dirent_ino_orphans && !opts->do_repair_dirent_ino_orphans &&
+      !opts->do_check_hrl_blo_refcounts && !opts->do_repair_hrl_blo_refcounts &&
+      !opts->do_check_inode_block_counts && !opts->do_repair_inode_block_counts &&
+      !opts->do_replay_journal && !opts->do_punch_hole_unreferenced_data_blocks &&
+      !opts->do_trim_free_data_blocks)
+    return 0;
+
+  return fsck_run_mapped_ops(fd, want_write, opts, exit_code, sb);
+}
+
+static int fsck_reset_journal_ring(int fd, uint64_t joff, uint64_t data_off, uint64_t area_size,
+                                   const kj_header_t *hdr, int header_ok, int exit_code)
+{
+  const size_t chunk = 4096;
+  char z[chunk];
+  memset(z, 0, sizeof(z));
+
+  for (uint64_t rem = area_size, off = 0; rem != 0;)
+  {
+    size_t n = rem > chunk ? chunk : (size_t)rem;
+    if (pwrite_all(fd, z, n, (off_t)(data_off + off)) != 0)
+    {
+      perror("pwrite zero");
+      return FSCK_EXIT_JOURNAL_RESET_FAILED;
+    }
+    off += n;
+    rem -= n;
+  }
+
+  kj_header_t nh = {
+      .magic = KJ_MAGIC,
+      .version = KJ_VER,
+      .flags = 0,
+      .area_size = area_size,
+      .write_off = 0,
+      .seq = (header_ok ? hdr->seq : 0),
+      .reserved0 = 0,
+      .header_crc = 0,
+  };
+  nh.header_crc = kj_crc32(&nh, sizeof(nh));
+  if (pwrite_all(fd, &nh, sizeof(nh), (off_t)joff) != 0)
+  {
+    perror("pwrite header");
+    return FSCK_EXIT_JOURNAL_RESET_FAILED;
+  }
+  if (fsync(fd) != 0)
+  {
+    perror("fsync");
+    return FSCK_EXIT_JOURNAL_RESET_FAILED;
+  }
+  fprintf(stderr, "Journal cleared.\n");
+  return exit_code;
+}
+
+static int fsck_scan_journal_records(int fd, uint64_t data_off, const kj_header_t *hdr)
+{
+  uint64_t pos = 0;
+
+  while (pos + sizeof(kj_rec_hdr_t) <= hdr->write_off)
+  {
+    kj_rec_hdr_t rh;
+    if (pread_all(fd, &rh, sizeof(rh), (off_t)(data_off + pos)) != 0)
+    {
+      perror("pread rec hdr");
+      return -1;
+    }
+    pos += sizeof(rh);
+    if (rh.tag == KJ_TAG_WRAP)
+    {
+      pos = 0;
+      continue;
+    }
+    if (pos + rh.size > hdr->write_off)
+    {
+      fprintf(stderr, "Journal: partial tail\n");
+      return -1;
+    }
+
+    char *pl = NULL;
+    if (rh.size)
+    {
+      pl = (char *)malloc((size_t)rh.size);
+      if (!pl)
+      {
+        perror("malloc");
+        return -1;
+      }
+      if (pread_all(fd, pl, rh.size, (off_t)(data_off + pos)) != 0)
+      {
+        perror("pread rec payload");
+        free(pl);
+        return -1;
+      }
+    }
+
+    kj_rec_hdr_t rh2 = rh;
+    rh2.crc32 = 0;
+    uint32_t c = kj_crc32_update(0, (const uint8_t *)&rh2, sizeof(rh2));
+    if (rh.size && pl)
+      c = kj_crc32_update(c, (const uint8_t *)pl, rh.size);
+    free(pl);
+    if (c != rh.crc32)
+    {
+      fprintf(stderr, "Journal: record CRC mismatch at off=%" PRIu64 "\n",
+              (uint64_t)(pos - sizeof(rh)));
+      return -1;
+    }
+    pos += rh.size;
+  }
+
+  return 0;
+}
+
+static int fsck_validate_or_reset_journal(const struct fsck_options *opts,
+                                          const struct fsck_image_info *info, int exit_code)
+{
+  uint64_t joff = kafs_sb_journal_offset_get(&info->sb);
+  uint64_t jsize = kafs_sb_journal_size_get(&info->sb);
+  if (check_region_bounds("journal", joff, jsize, info->file_size) != 0)
+    return FSCK_EXIT_JOURNAL_CHECK_FAILED;
+  if (joff == 0 || jsize < 4096)
+  {
+    fprintf(stderr, "No in-image journal: off=%" PRIu64 " size=%" PRIu64 "\n", joff, jsize);
+    return exit_code;
+  }
+
+  size_t hsz = kj_header_size();
+  uint64_t data_off = joff + hsz;
+  uint64_t area_size = (jsize > hsz) ? (jsize - hsz) : 0;
+  if (area_size == 0)
+  {
+    fprintf(stderr, "Invalid journal area size 0\n");
+    return 1;
+  }
+
+  kj_header_t hdr;
+  if (pread_all(info->fd, &hdr, sizeof(hdr), (off_t)joff) != 0)
+  {
+    perror("pread journal header");
+    return 1;
+  }
+
+  int header_ok = 1;
+  if (hdr.magic != KJ_MAGIC)
+  {
+    fprintf(stderr, "Journal: bad magic\n");
+    header_ok = 0;
+  }
+  if (hdr.version != KJ_VER)
+  {
+    fprintf(stderr, "Journal: bad version (%u)\n", hdr.version);
+    header_ok = 0;
+  }
+  if (hdr.area_size != area_size)
+  {
+    fprintf(stderr, "Journal: area_size mismatch (sb=%" PRIu64 ", hdr=%" PRIu64 ")\n", area_size,
+            (uint64_t)hdr.area_size);
+    header_ok = 0;
+  }
+  kj_header_t tmp = hdr;
+  tmp.header_crc = 0;
+  if (kj_crc32(&tmp, sizeof(tmp)) != hdr.header_crc)
+  {
+    fprintf(stderr, "Journal: header CRC mismatch\n");
+    header_ok = 0;
+  }
+
+  int ok = header_ok;
+  if (ok)
+    ok = (fsck_scan_journal_records(info->fd, data_off, &hdr) == 0);
+  if (!ok && !opts->do_journal_reset)
+    return FSCK_EXIT_JOURNAL_CHECK_FAILED;
+  if (!ok)
+    return fsck_reset_journal_ring(info->fd, joff, data_off, area_size, &hdr, header_ok, exit_code);
+
+  fprintf(stderr, "Journal check: OK\n");
+  return exit_code;
+}
 
 static int fsck_decode_data_ref(kafs_blkcnt_t raw, kafs_blkcnt_t *out_blo, int *out_is_pending)
 {
@@ -401,6 +1102,171 @@ static void fsck_log_dir_head_sample(kafs_context_t *ctx, const kafs_sinode_t *i
   fprintf(stderr, "'\n");
 }
 
+static void fsck_dir_v4_log_invalid_inode(kafs_context_t *ctx, kafs_inocnt_t ino,
+                                          const kafs_sinode_t *inoent)
+{
+  fsck_log_inode_brief(ino, inoent);
+  fsck_log_dir_head_sample(ctx, inoent, ino);
+}
+
+static int fsck_dir_v4_read_header(kafs_context_t *ctx, const kafs_sinode_t *inoent,
+                                   kafs_sdir_v4_hdr_t *hdr)
+{
+  ssize_t hdr_read = fsck_inode_pread(ctx, inoent, hdr, (kafs_off_t)sizeof(*hdr), 0);
+  return (hdr_read == (ssize_t)sizeof(*hdr)) ? 0 : -EIO;
+}
+
+static int fsck_dir_v4_load_file(kafs_context_t *ctx, const kafs_sinode_t *inoent, kafs_off_t size,
+                                 char **out_buf)
+{
+  *out_buf = NULL;
+  if (size <= 0)
+    return 0;
+
+  char *buf = (char *)malloc((size_t)size);
+  if (!buf)
+    return -ENOMEM;
+
+  ssize_t dir_read = fsck_inode_pread(ctx, inoent, buf, size, 0);
+  if (dir_read != (ssize_t)size)
+  {
+    free(buf);
+    return -EIO;
+  }
+
+  *out_buf = buf;
+  return 0;
+}
+
+static int fsck_dir_v4_validate_header_fields(const kafs_sdir_v4_hdr_t *hdr, kafs_off_t size)
+{
+  if (kafs_u32_stoh(hdr->dh_magic) != KAFS_DIRENT_V4_MAGIC ||
+      kafs_dir_v4_hdr_format_get(hdr) != KAFS_DIRENT_V4_FORMAT_VERSION ||
+      kafs_dir_v4_hdr_flags_get(hdr) != 0u)
+    return -1;
+
+  uint32_t record_bytes = kafs_dir_v4_hdr_record_bytes_get(hdr);
+  return ((kafs_off_t)sizeof(*hdr) + (kafs_off_t)record_bytes == size) ? 0 : -1;
+}
+
+static void fsck_dir_v4_report_bad_header(kafs_context_t *ctx, kafs_inocnt_t ino,
+                                          const kafs_sinode_t *inoent,
+                                          const kafs_sdir_v4_hdr_t *hdr, kafs_off_t size)
+{
+  if (kafs_u32_stoh(hdr->dh_magic) != KAFS_DIRENT_V4_MAGIC ||
+      kafs_dir_v4_hdr_format_get(hdr) != KAFS_DIRENT_V4_FORMAT_VERSION ||
+      kafs_dir_v4_hdr_flags_get(hdr) != 0u)
+  {
+    fprintf(stderr, "dir-v4 invalid: ino=%" PRIuFAST32 " bad header magic=%08x fmt=%u flags=%u\n",
+            ino, kafs_u32_stoh(hdr->dh_magic), (unsigned)kafs_dir_v4_hdr_format_get(hdr),
+            (unsigned)kafs_dir_v4_hdr_flags_get(hdr));
+  }
+  else
+  {
+    fprintf(stderr,
+            "dir-v4 invalid: ino=%" PRIuFAST32 " size/header mismatch size=%" PRIiFAST64
+            " record_bytes=%u\n",
+            ino, (int64_t)size, (unsigned)kafs_dir_v4_hdr_record_bytes_get(hdr));
+  }
+  fsck_dir_v4_log_invalid_inode(ctx, ino, inoent);
+}
+
+static int fsck_dir_v4_scan_records(kafs_context_t *ctx, const char *buf, kafs_off_t size,
+                                    kafs_inocnt_t inocnt, struct fsck_dir_v4_scan_result *scan)
+{
+  memset(scan, 0, sizeof(*scan));
+  scan->bad_dino = KAFS_INO_NONE;
+
+  for (size_t off = sizeof(kafs_sdir_v4_hdr_t); off < (size_t)size;)
+  {
+    scan->bad_off = off;
+    if ((size_t)size - off < sizeof(kafs_sdirent_v4_t))
+      return -1;
+
+    kafs_sdirent_v4_t rec;
+    memcpy(&rec, buf + off, sizeof(rec));
+    uint16_t rec_len = kafs_dirent_v4_rec_len_get(&rec);
+    uint16_t flags = kafs_dirent_v4_flags_get(&rec);
+    kafs_inocnt_t dino = kafs_dirent_v4_ino_get(&rec);
+    kafs_filenamelen_t namelen = kafs_dirent_v4_filenamelen_get(&rec);
+    scan->bad_rec_len = rec_len;
+    scan->bad_flags = flags;
+    scan->bad_dino = dino;
+    scan->bad_namelen = namelen;
+
+    if (rec_len < sizeof(kafs_sdirent_v4_t) || off + rec_len > (size_t)size || namelen == 0 ||
+        namelen >= FILENAME_MAX || (size_t)namelen > rec_len - sizeof(kafs_sdirent_v4_t) ||
+        (flags & ~KAFS_DIRENT_FLAG_TOMBSTONE) != 0u)
+      return -1;
+
+    const char *name = buf + off + sizeof(kafs_sdirent_v4_t);
+    if ((flags & KAFS_DIRENT_FLAG_TOMBSTONE) != 0)
+    {
+      scan->tombstone_count++;
+    }
+    else
+    {
+      if (dino == KAFS_INO_NONE || dino >= inocnt || !kafs_ino_get_usage(kafs_ctx_inode(ctx, dino)))
+        return -1;
+      scan->live_count++;
+      if (namelen == 2 && memcmp(name, "..", 2) == 0)
+        scan->dotdot_live++;
+    }
+    off += rec_len;
+  }
+
+  return 0;
+}
+
+static void fsck_dir_v4_report_malformed(kafs_context_t *ctx, kafs_inocnt_t ino,
+                                         const kafs_sinode_t *inoent, const char *buf,
+                                         kafs_off_t size,
+                                         const struct fsck_dir_v4_scan_result *scan)
+{
+  fprintf(stderr,
+          "dir-v4 invalid: ino=%" PRIuFAST32
+          " malformed record stream off=%zu rec_len=%u flags=%u dino=%" PRIuFAST32
+          " namelen=%" PRIuFAST16 "\n",
+          ino, scan->bad_off, (unsigned)scan->bad_rec_len, (unsigned)scan->bad_flags,
+          scan->bad_dino, (uint_fast16_t)scan->bad_namelen);
+  fsck_dir_v4_log_invalid_inode(ctx, ino, inoent);
+  if (buf && scan->bad_off < (size_t)size)
+  {
+    size_t remain = (size_t)size - scan->bad_off;
+    size_t sample_len = remain < 32u ? remain : 32u;
+    fprintf(stderr, "  bad-record-head: off=%zu bytes[%zu]=", scan->bad_off, sample_len);
+    fsck_dump_bytes_hex(stderr, buf + scan->bad_off, sample_len);
+    fprintf(stderr, " ascii='");
+    fsck_dump_bytes_ascii(stderr, buf + scan->bad_off, sample_len);
+    fprintf(stderr, "'\n");
+  }
+}
+
+static int fsck_dir_v4_has_bad_counts(kafs_inocnt_t ino, const kafs_sdir_v4_hdr_t *hdr,
+                                      const struct fsck_dir_v4_scan_result *scan)
+{
+  if (scan->live_count != kafs_dir_v4_hdr_live_count_get(hdr) ||
+      scan->tombstone_count != kafs_dir_v4_hdr_tombstone_count_get(hdr))
+    return 1;
+  if (ino == KAFS_INO_ROOTDIR)
+    return scan->dotdot_live != 0;
+  return scan->dotdot_live != 1;
+}
+
+static void fsck_dir_v4_report_count_mismatch(kafs_context_t *ctx, kafs_inocnt_t ino,
+                                              const kafs_sinode_t *inoent,
+                                              const kafs_sdir_v4_hdr_t *hdr,
+                                              const struct fsck_dir_v4_scan_result *scan)
+{
+  fprintf(stderr,
+          "dir-v4 mismatch: ino=%" PRIuFAST32
+          " hdr_live=%u calc_live=%u hdr_tomb=%u calc_tomb=%u dotdot=%u\n",
+          ino, (unsigned)kafs_dir_v4_hdr_live_count_get(hdr), (unsigned)scan->live_count,
+          (unsigned)kafs_dir_v4_hdr_tombstone_count_get(hdr), (unsigned)scan->tombstone_count,
+          (unsigned)scan->dotdot_live);
+  fsck_dir_v4_log_invalid_inode(ctx, ino, inoent);
+}
+
 static int fsck_inode_is_tombstone(const kafs_sinode_t *inoent)
 {
   if (!inoent || !kafs_ino_get_usage(inoent))
@@ -565,168 +1431,180 @@ static int fsck_check_or_repair_dir_v4(kafs_context_t *ctx, int do_fix, struct d
     {
       fprintf(stderr, "dir-v4 invalid: ino=%" PRIuFAST32 " size=%" PRIiFAST64 " too small\n", ino,
               (int64_t)size);
-      fsck_log_inode_brief(ino, inoent);
-      fsck_log_dir_head_sample(ctx, inoent, ino);
+      fsck_dir_v4_log_invalid_inode(ctx, ino, inoent);
       stats->invalid_dirs++;
       continue;
     }
 
     kafs_sdir_v4_hdr_t hdr;
-    ssize_t hdr_read = fsck_inode_pread(ctx, inoent, &hdr, (kafs_off_t)sizeof(hdr), 0);
-    if (hdr_read != (ssize_t)sizeof(hdr))
+    if (fsck_dir_v4_read_header(ctx, inoent, &hdr) != 0)
       return -EIO;
-    if (kafs_u32_stoh(hdr.dh_magic) != KAFS_DIRENT_V4_MAGIC ||
-        kafs_dir_v4_hdr_format_get(&hdr) != KAFS_DIRENT_V4_FORMAT_VERSION ||
-        kafs_dir_v4_hdr_flags_get(&hdr) != 0u)
+    if (fsck_dir_v4_validate_header_fields(&hdr, size) != 0)
     {
-      fprintf(stderr, "dir-v4 invalid: ino=%" PRIuFAST32 " bad header magic=%08x fmt=%u flags=%u\n",
-              ino, kafs_u32_stoh(hdr.dh_magic), (unsigned)kafs_dir_v4_hdr_format_get(&hdr),
-              (unsigned)kafs_dir_v4_hdr_flags_get(&hdr));
-      fsck_log_inode_brief(ino, inoent);
-      fsck_log_dir_head_sample(ctx, inoent, ino);
-      stats->invalid_dirs++;
-      continue;
-    }
-
-    uint32_t record_bytes = kafs_dir_v4_hdr_record_bytes_get(&hdr);
-    if ((kafs_off_t)sizeof(hdr) + (kafs_off_t)record_bytes != size)
-    {
-      fprintf(stderr,
-              "dir-v4 invalid: ino=%" PRIuFAST32 " size/header mismatch size=%" PRIiFAST64
-              " record_bytes=%u\n",
-              ino, (int64_t)size, (unsigned)record_bytes);
-      fsck_log_inode_brief(ino, inoent);
-      fsck_log_dir_head_sample(ctx, inoent, ino);
+      fsck_dir_v4_report_bad_header(ctx, ino, inoent, &hdr, size);
       stats->invalid_dirs++;
       continue;
     }
 
     char *buf = NULL;
-    if (size > 0)
-    {
-      buf = (char *)malloc((size_t)size);
-      if (!buf)
-        return -ENOMEM;
-      ssize_t dir_read = fsck_inode_pread(ctx, inoent, buf, size, 0);
-      if (dir_read != (ssize_t)size)
-      {
-        free(buf);
-        return -EIO;
-      }
-    }
+    int rc = fsck_dir_v4_load_file(ctx, inoent, size, &buf);
+    if (rc != 0)
+      return rc;
 
-    uint32_t live_count = 0;
-    uint32_t tombstone_count = 0;
-    uint32_t dotdot_live = 0;
-    size_t off = sizeof(kafs_sdir_v4_hdr_t);
-    int malformed = 0;
-    size_t bad_off = 0;
-    uint16_t bad_rec_len = 0;
-    uint16_t bad_flags = 0;
-    kafs_inocnt_t bad_dino = KAFS_INO_NONE;
-    kafs_filenamelen_t bad_namelen = 0;
-    while (off < (size_t)size)
+    struct fsck_dir_v4_scan_result scan;
+    if (fsck_dir_v4_scan_records(ctx, buf, size, inocnt, &scan) != 0)
     {
-      if ((size_t)size - off < sizeof(kafs_sdirent_v4_t))
-      {
-        malformed = 1;
-        bad_off = off;
-        break;
-      }
-      kafs_sdirent_v4_t rec;
-      memcpy(&rec, buf + off, sizeof(rec));
-      uint16_t rec_len = kafs_dirent_v4_rec_len_get(&rec);
-      uint16_t flags = kafs_dirent_v4_flags_get(&rec);
-      kafs_inocnt_t dino = kafs_dirent_v4_ino_get(&rec);
-      kafs_filenamelen_t namelen = kafs_dirent_v4_filenamelen_get(&rec);
-      bad_off = off;
-      bad_rec_len = rec_len;
-      bad_flags = flags;
-      bad_dino = dino;
-      bad_namelen = namelen;
-      if (rec_len < sizeof(kafs_sdirent_v4_t) || off + rec_len > (size_t)size || namelen == 0 ||
-          namelen >= FILENAME_MAX || (size_t)namelen > rec_len - sizeof(kafs_sdirent_v4_t) ||
-          (flags & ~KAFS_DIRENT_FLAG_TOMBSTONE) != 0u)
-      {
-        malformed = 1;
-        break;
-      }
-      const char *name = buf + off + sizeof(kafs_sdirent_v4_t);
-      if ((flags & KAFS_DIRENT_FLAG_TOMBSTONE) != 0)
-      {
-        tombstone_count++;
-      }
-      else
-      {
-        if (dino == KAFS_INO_NONE || dino >= inocnt ||
-            !kafs_ino_get_usage(kafs_ctx_inode(ctx, dino)))
-        {
-          malformed = 1;
-          break;
-        }
-        live_count++;
-        if (namelen == 2 && memcmp(name, "..", 2) == 0)
-          dotdot_live++;
-      }
-      off += rec_len;
-    }
-    if (malformed)
-    {
-      fprintf(stderr,
-              "dir-v4 invalid: ino=%" PRIuFAST32
-              " malformed record stream off=%zu rec_len=%u flags=%u dino=%" PRIuFAST32
-              " namelen=%" PRIuFAST16 "\n",
-              ino, bad_off, (unsigned)bad_rec_len, (unsigned)bad_flags, bad_dino,
-              (uint_fast16_t)bad_namelen);
-      fsck_log_inode_brief(ino, inoent);
-      fsck_log_dir_head_sample(ctx, inoent, ino);
-      if (buf && bad_off < (size_t)size)
-      {
-        size_t remain = (size_t)size - bad_off;
-        size_t sample_len = remain < 32u ? remain : 32u;
-        fprintf(stderr, "  bad-record-head: off=%zu bytes[%zu]=", bad_off, sample_len);
-        fsck_dump_bytes_hex(stderr, buf + bad_off, sample_len);
-        fprintf(stderr, " ascii='");
-        fsck_dump_bytes_ascii(stderr, buf + bad_off, sample_len);
-        fprintf(stderr, "'\n");
-      }
+      fsck_dir_v4_report_malformed(ctx, ino, inoent, buf, size, &scan);
       free(buf);
       stats->invalid_dirs++;
       continue;
     }
 
     free(buf);
-
-    int bad_counts = 0;
-    if (live_count != kafs_dir_v4_hdr_live_count_get(&hdr) ||
-        tombstone_count != kafs_dir_v4_hdr_tombstone_count_get(&hdr))
-      bad_counts = 1;
-    if (ino == KAFS_INO_ROOTDIR)
-    {
-      if (dotdot_live != 0)
-        bad_counts = 1;
-    }
-    else if (dotdot_live != 1)
-    {
-      bad_counts = 1;
-    }
-
-    if (!bad_counts)
+    if (!fsck_dir_v4_has_bad_counts(ino, &hdr, &scan))
       continue;
 
-    fprintf(stderr,
-            "dir-v4 mismatch: ino=%" PRIuFAST32
-            " hdr_live=%u calc_live=%u hdr_tomb=%u calc_tomb=%u dotdot=%u\n",
-            ino, (unsigned)kafs_dir_v4_hdr_live_count_get(&hdr), (unsigned)live_count,
-            (unsigned)kafs_dir_v4_hdr_tombstone_count_get(&hdr), (unsigned)tombstone_count,
-            (unsigned)dotdot_live);
-    fsck_log_inode_brief(ino, inoent);
-    fsck_log_dir_head_sample(ctx, inoent, ino);
+    fsck_dir_v4_report_count_mismatch(ctx, ino, inoent, &hdr, &scan);
     stats->invalid_dirs++;
     (void)do_fix;
   }
 
   return 0;
+}
+
+static int fsck_tailmeta_read_region_header(int fd, uint64_t region_off, uint64_t region_size,
+                                            kafs_tailmeta_region_hdr_t *region_hdr)
+{
+  if (pread_all(fd, region_hdr, sizeof(*region_hdr), (off_t)region_off) != 0)
+  {
+    fprintf(stderr, "failed to read tailmeta header\n");
+    return -1;
+  }
+
+  int rc = kafs_tailmeta_region_hdr_validate(region_hdr, region_size);
+  if (rc != 0)
+  {
+    fprintf(stderr, "tailmeta header invalid: magic=0x%08" PRIx32 " version=%u flags=%u rc=%d\n",
+            kafs_u32_stoh(region_hdr->tr_magic),
+            (unsigned)kafs_tailmeta_region_hdr_version_get(region_hdr),
+            (unsigned)kafs_tailmeta_region_hdr_flags_get(region_hdr), rc);
+    return -1;
+  }
+
+  return 0;
+}
+
+static kafs_tailmeta_container_hdr_t *
+fsck_tailmeta_load_containers(int fd, uint64_t region_off,
+                              const kafs_tailmeta_region_hdr_t *region_hdr)
+{
+  uint32_t table_off = kafs_tailmeta_region_hdr_container_table_off_get(region_hdr);
+  uint32_t table_bytes = kafs_tailmeta_region_hdr_container_table_bytes_get(region_hdr);
+  kafs_tailmeta_container_hdr_t *containers =
+      (kafs_tailmeta_container_hdr_t *)malloc((size_t)table_bytes);
+  {
+    fprintf(stderr, "tailmeta container table alloc failed\n");
+    return NULL;
+  }
+  if (pread_all(fd, containers, (size_t)table_bytes, (off_t)(region_off + table_off)) != 0)
+  {
+    fprintf(stderr, "failed to read tailmeta container table\n");
+    free(containers);
+    return NULL;
+  }
+  return containers;
+}
+
+static kafs_tailmeta_slot_desc_t *
+fsck_tailmeta_load_slots(int fd, uint64_t region_off, uint32_t index,
+                         const kafs_tailmeta_container_hdr_t *container)
+{
+  uint32_t slot_table_off = kafs_tailmeta_container_hdr_slot_table_off_get(container);
+  uint32_t slot_table_bytes = kafs_tailmeta_container_hdr_slot_table_bytes_get(container);
+  kafs_tailmeta_slot_desc_t *slots = (kafs_tailmeta_slot_desc_t *)malloc((size_t)slot_table_bytes);
+  if (!slots)
+  {
+    fprintf(stderr, "tailmeta slot table alloc failed for container[%u]\n", index);
+    return NULL;
+  }
+  if (pread_all(fd, slots, (size_t)slot_table_bytes, (off_t)(region_off + slot_table_off)) != 0)
+  {
+    fprintf(stderr, "failed to read tailmeta slot table for container[%u]\n", index);
+    free(slots);
+    return NULL;
+  }
+  return slots;
+}
+
+static int fsck_tailmeta_validate_slots(int fd, const kafs_ssuperblock_t *sb, uint64_t file_size,
+                                        uint64_t inode_table_off, uint32_t index,
+                                        const kafs_tailmeta_container_hdr_t *container,
+                                        const kafs_tailmeta_slot_desc_t *slots)
+{
+  uint16_t slot_count = kafs_tailmeta_container_hdr_slot_count_get(container);
+  uint16_t class_bytes = kafs_tailmeta_container_hdr_class_bytes_get(container);
+  uint16_t live_slots = 0;
+  int failed = 0;
+
+  for (uint16_t slot_index = 0; slot_index < slot_count; ++slot_index)
+  {
+    int rc = kafs_tailmeta_slot_validate(&slots[slot_index], class_bytes);
+    if (rc != 0)
+    {
+      fprintf(stderr,
+              "tailmeta container[%u] slot[%u] invalid: owner=%" PRIuFAST32
+              " len=%u flags=%u rc=%d\n",
+              index, slot_index, kafs_tailmeta_slot_owner_ino_get(&slots[slot_index]),
+              (unsigned)kafs_tailmeta_slot_len_get(&slots[slot_index]),
+              (unsigned)kafs_tailmeta_slot_flags_get(&slots[slot_index]), rc);
+      failed = 1;
+      continue;
+    }
+    if (kafs_tailmeta_slot_owner_ino_get(&slots[slot_index]) != KAFS_INO_NONE)
+    {
+      if (check_tailmeta_live_slot_owner(fd, sb, file_size, inode_table_off, index, slot_index,
+                                         &slots[slot_index]) != 0)
+        failed = 1;
+      live_slots++;
+    }
+  }
+
+  if (live_slots != kafs_tailmeta_container_hdr_live_count_get(container))
+  {
+    fprintf(stderr, "tailmeta container[%u] live slot mismatch: header=%u actual=%u\n", index,
+            (unsigned)kafs_tailmeta_container_hdr_live_count_get(container), (unsigned)live_slots);
+    failed = 1;
+  }
+
+  return failed ? -1 : 0;
+}
+
+static int fsck_tailmeta_validate_container(int fd, const kafs_ssuperblock_t *sb,
+                                            uint64_t file_size, uint64_t region_off,
+                                            uint64_t region_size, uint64_t inode_table_off,
+                                            uint16_t slot_desc_bytes, uint32_t index,
+                                            const kafs_tailmeta_container_hdr_t *container)
+{
+  int rc = kafs_tailmeta_container_hdr_validate(container, region_size, slot_desc_bytes);
+  if (rc != 0)
+  {
+    fprintf(stderr, "tailmeta container[%u] invalid: class=%u slots=%u live=%u free=%u rc=%d\n",
+            index, (unsigned)kafs_tailmeta_container_hdr_class_bytes_get(container),
+            (unsigned)kafs_tailmeta_container_hdr_slot_count_get(container),
+            (unsigned)kafs_tailmeta_container_hdr_live_count_get(container),
+            (unsigned)kafs_tailmeta_container_hdr_free_bytes_get(container), rc);
+    return -1;
+  }
+
+  if (kafs_tailmeta_container_hdr_slot_count_get(container) == 0)
+    return 0;
+
+  kafs_tailmeta_slot_desc_t *slots = fsck_tailmeta_load_slots(fd, region_off, index, container);
+  if (!slots)
+    return -1;
+  rc = fsck_tailmeta_validate_slots(fd, sb, file_size, inode_table_off, index, container, slots);
+  free(slots);
+  return rc;
 }
 
 struct hrl_scan_ctx
@@ -1381,113 +2259,26 @@ static int check_tailmeta_region(int fd, const kafs_ssuperblock_t *sb, uint64_t 
     return -1;
 
   kafs_tailmeta_region_hdr_t region_hdr;
-  if (pread_all(fd, &region_hdr, sizeof(region_hdr), (off_t)region_off) != 0)
-  {
-    fprintf(stderr, "failed to read tailmeta header\n");
+  if (fsck_tailmeta_read_region_header(fd, region_off, region_size, &region_hdr) != 0)
     return -1;
-  }
-  int rc = kafs_tailmeta_region_hdr_validate(&region_hdr, region_size);
-  if (rc != 0)
-  {
-    fprintf(stderr, "tailmeta header invalid: magic=0x%08" PRIx32 " version=%u flags=%u rc=%d\n",
-            kafs_u32_stoh(region_hdr.tr_magic),
-            (unsigned)kafs_tailmeta_region_hdr_version_get(&region_hdr),
-            (unsigned)kafs_tailmeta_region_hdr_flags_get(&region_hdr), rc);
-    return -1;
-  }
 
   uint32_t container_count = kafs_tailmeta_region_hdr_container_count_get(&region_hdr);
   if (container_count == 0)
     return 0;
 
-  uint32_t table_off = kafs_tailmeta_region_hdr_container_table_off_get(&region_hdr);
-  uint32_t table_bytes = kafs_tailmeta_region_hdr_container_table_bytes_get(&region_hdr);
   kafs_tailmeta_container_hdr_t *containers =
-      (kafs_tailmeta_container_hdr_t *)malloc((size_t)table_bytes);
+      fsck_tailmeta_load_containers(fd, region_off, &region_hdr);
   if (!containers)
-  {
-    fprintf(stderr, "tailmeta container table alloc failed\n");
     return -1;
-  }
-  if (pread_all(fd, containers, (size_t)table_bytes, (off_t)(region_off + table_off)) != 0)
-  {
-    fprintf(stderr, "failed to read tailmeta container table\n");
-    free(containers);
-    return -1;
-  }
 
   int failed = 0;
   uint16_t slot_desc_bytes = kafs_tailmeta_region_hdr_slot_desc_bytes_get(&region_hdr);
   for (uint32_t index = 0; index < container_count; ++index)
   {
-    const kafs_tailmeta_container_hdr_t *container = &containers[index];
-    rc = kafs_tailmeta_container_hdr_validate(container, region_size, slot_desc_bytes);
-    if (rc != 0)
-    {
-      fprintf(stderr, "tailmeta container[%u] invalid: class=%u slots=%u live=%u free=%u rc=%d\n",
-              index, (unsigned)kafs_tailmeta_container_hdr_class_bytes_get(container),
-              (unsigned)kafs_tailmeta_container_hdr_slot_count_get(container),
-              (unsigned)kafs_tailmeta_container_hdr_live_count_get(container),
-              (unsigned)kafs_tailmeta_container_hdr_free_bytes_get(container), rc);
+    if (fsck_tailmeta_validate_container(fd, sb, file_size, region_off, region_size,
+                                         inode_table_off, slot_desc_bytes, index,
+                                         &containers[index]) != 0)
       failed = 1;
-      continue;
-    }
-
-    uint16_t slot_count = kafs_tailmeta_container_hdr_slot_count_get(container);
-    if (slot_count == 0)
-      continue;
-
-    uint16_t class_bytes = kafs_tailmeta_container_hdr_class_bytes_get(container);
-    uint32_t slot_table_off = kafs_tailmeta_container_hdr_slot_table_off_get(container);
-    uint32_t slot_table_bytes = kafs_tailmeta_container_hdr_slot_table_bytes_get(container);
-    kafs_tailmeta_slot_desc_t *slots =
-        (kafs_tailmeta_slot_desc_t *)malloc((size_t)slot_table_bytes);
-    if (!slots)
-    {
-      fprintf(stderr, "tailmeta slot table alloc failed for container[%u]\n", index);
-      failed = 1;
-      continue;
-    }
-    if (pread_all(fd, slots, (size_t)slot_table_bytes, (off_t)(region_off + slot_table_off)) != 0)
-    {
-      fprintf(stderr, "failed to read tailmeta slot table for container[%u]\n", index);
-      free(slots);
-      failed = 1;
-      continue;
-    }
-
-    uint16_t live_slots = 0;
-    for (uint16_t slot_index = 0; slot_index < slot_count; ++slot_index)
-    {
-      rc = kafs_tailmeta_slot_validate(&slots[slot_index], class_bytes);
-      if (rc != 0)
-      {
-        fprintf(stderr,
-                "tailmeta container[%u] slot[%u] invalid: owner=%" PRIuFAST32
-                " len=%u flags=%u rc=%d\n",
-                index, slot_index, kafs_tailmeta_slot_owner_ino_get(&slots[slot_index]),
-                (unsigned)kafs_tailmeta_slot_len_get(&slots[slot_index]),
-                (unsigned)kafs_tailmeta_slot_flags_get(&slots[slot_index]), rc);
-        failed = 1;
-        continue;
-      }
-      if (kafs_tailmeta_slot_owner_ino_get(&slots[slot_index]) != KAFS_INO_NONE)
-      {
-        if (check_tailmeta_live_slot_owner(fd, sb, file_size, inode_table_off, index, slot_index,
-                                           &slots[slot_index]) != 0)
-          failed = 1;
-        live_slots++;
-      }
-    }
-
-    if (live_slots != kafs_tailmeta_container_hdr_live_count_get(container))
-    {
-      fprintf(stderr, "tailmeta container[%u] live slot mismatch: header=%u actual=%u\n", index,
-              (unsigned)kafs_tailmeta_container_hdr_live_count_get(container),
-              (unsigned)live_slots);
-      failed = 1;
-    }
-    free(slots);
   }
 
   free(containers);
@@ -1496,737 +2287,42 @@ static int check_tailmeta_region(int fd, const kafs_ssuperblock_t *sb, uint64_t 
 
 int main(int argc, char **argv)
 {
-  int do_journal_reset = 0; // repair: journal layer
-  int do_check_dirent_ino_orphans = 0;
-  int do_repair_dirent_ino_orphans = 0;
-  int do_check_hrl_blo_refcounts = 0;
-  int do_repair_hrl_blo_refcounts = 0;
-  int do_check_inode_block_counts = 0;
-  int do_repair_inode_block_counts = 0;
-  int do_replay_journal = 0;
-  int do_punch_hole_unreferenced_data_blocks = 0;
-  int do_trim_free_data_blocks = 0;
-  int do_check_journal = 1;
-
-  int has_preset_mode = 0;
-  int has_low_level_mode = 0;
-  fsck_mode_t mode = FSCK_MODE_UNSET;
-
+  struct fsck_options opts;
+  struct fsck_image_info info;
   int exit_code = 0;
-  const char *img = NULL;
+
+  fsck_options_init(&opts);
   if (kafs_cli_exit_if_help(argc, argv, usage, argv[0]) == 0)
     return 0;
-
-  for (int i = 1; i < argc; ++i)
-  {
-    if (strcmp(argv[i], "--full-check") == 0)
-    {
-      has_preset_mode = 1;
-      mode = FSCK_MODE_FULL_CHECK;
-    }
-    else if (strcmp(argv[i], "--full-repair") == 0)
-    {
-      has_preset_mode = 1;
-      mode = FSCK_MODE_FULL_REPAIR;
-    }
-    else if (strcmp(argv[i], "--balanced-check") == 0)
-    {
-      has_preset_mode = 1;
-      mode = FSCK_MODE_BALANCED_CHECK;
-    }
-    else if (strcmp(argv[i], "--check") == 0)
-    {
-      has_preset_mode = 1;
-      mode = FSCK_MODE_BALANCED_CHECK;
-    }
-    else if (strcmp(argv[i], "--balanced-repair") == 0)
-    {
-      has_preset_mode = 1;
-      mode = FSCK_MODE_BALANCED_REPAIR;
-    }
-    else if (strcmp(argv[i], "--repair") == 0)
-    {
-      has_preset_mode = 1;
-      mode = FSCK_MODE_BALANCED_REPAIR;
-    }
-    else if (strcmp(argv[i], "--fast-check") == 0)
-    {
-      has_preset_mode = 1;
-      mode = FSCK_MODE_FAST_CHECK;
-    }
-    else if (strcmp(argv[i], "--fast-repair") == 0)
-    {
-      has_preset_mode = 1;
-      mode = FSCK_MODE_FAST_REPAIR;
-    }
-    else if (strcmp(argv[i], "--check-journal") == 0)
-    {
-      // no-op: default behavior is journal validation
-      has_low_level_mode = 1;
-    }
-    else if (strcmp(argv[i], "--repair-journal-reset") == 0)
-    {
-      do_journal_reset = 1;
-      has_low_level_mode = 1;
-    }
-    else if (strcmp(argv[i], "--repair-dirent-ino-orphans") == 0)
-    {
-      do_repair_dirent_ino_orphans = 1;
-      has_low_level_mode = 1;
-    }
-    else if (strcmp(argv[i], "--check-dirent-ino-orphans") == 0)
-    {
-      do_check_dirent_ino_orphans = 1;
-      has_low_level_mode = 1;
-    }
-    else if (strcmp(argv[i], "--check-hrl-blo-refcounts") == 0)
-    {
-      do_check_hrl_blo_refcounts = 1;
-      has_low_level_mode = 1;
-    }
-    else if (strcmp(argv[i], "--repair-hrl-blo-refcounts") == 0)
-    {
-      do_repair_hrl_blo_refcounts = 1;
-      has_low_level_mode = 1;
-    }
-    else if (strcmp(argv[i], "--check-inode-block-counts") == 0)
-    {
-      do_check_inode_block_counts = 1;
-      has_low_level_mode = 1;
-    }
-    else if (strcmp(argv[i], "--repair-inode-block-counts") == 0)
-    {
-      do_repair_inode_block_counts = 1;
-      has_low_level_mode = 1;
-    }
-    else if (strcmp(argv[i], "--replay-journal") == 0)
-    {
-      do_replay_journal = 1;
-      has_low_level_mode = 1;
-    }
-    else if (strcmp(argv[i], "--punch-hole-unreferenced-data-blocks") == 0)
-    {
-      do_punch_hole_unreferenced_data_blocks = 1;
-      has_low_level_mode = 1;
-    }
-    else if (strcmp(argv[i], "--trim-free-data-blocks") == 0)
-    {
-      do_trim_free_data_blocks = 1;
-      has_low_level_mode = 1;
-    }
-    else if (argv[i][0] != '-' && !img)
-    {
-      img = argv[i];
-    }
-    else
-    {
-      usage(argv[0]);
-      return FSCK_EXIT_USAGE;
-    }
-  }
-  if (!img)
+  if (fsck_parse_args(argc, argv, &opts) != 0)
   {
     usage(argv[0]);
     return FSCK_EXIT_USAGE;
   }
-
-  if (has_preset_mode && has_low_level_mode)
-  {
-    fprintf(stderr, "fsck.kafs: preset mode and low-level flags cannot be mixed\n");
-    usage(argv[0]);
-    return FSCK_EXIT_USAGE;
-  }
-
-  if (has_preset_mode)
-  {
-    do_check_journal = 1;
-    do_journal_reset = 0;
-    do_check_dirent_ino_orphans = 0;
-    do_repair_dirent_ino_orphans = 0;
-    do_check_hrl_blo_refcounts = 0;
-    do_repair_hrl_blo_refcounts = 0;
-
-    switch (mode)
-    {
-    case FSCK_MODE_FAST_CHECK:
-      break;
-    case FSCK_MODE_FAST_REPAIR:
-      do_journal_reset = 1;
-      break;
-    case FSCK_MODE_BALANCED_CHECK:
-      do_check_dirent_ino_orphans = 1;
-      break;
-    case FSCK_MODE_BALANCED_REPAIR:
-      do_journal_reset = 1;
-      do_repair_dirent_ino_orphans = 1;
-      break;
-    case FSCK_MODE_FULL_CHECK:
-      do_check_dirent_ino_orphans = 1;
-      do_check_hrl_blo_refcounts = 1;
-      break;
-    case FSCK_MODE_FULL_REPAIR:
-      do_journal_reset = 1;
-      do_repair_dirent_ino_orphans = 1;
-      do_check_hrl_blo_refcounts = 1;
-      do_repair_hrl_blo_refcounts = 1;
-      break;
-    case FSCK_MODE_UNSET:
-    default:
-      break;
-    }
-  }
-  else if (!has_low_level_mode)
-  {
-    // default: balanced check
-    do_check_journal = 1;
-    do_check_dirent_ino_orphans = 1;
-  }
-
-  int want_write = do_journal_reset || do_repair_dirent_ino_orphans ||
-                   do_repair_hrl_blo_refcounts || do_repair_inode_block_counts;
-  if (do_replay_journal || do_punch_hole_unreferenced_data_blocks || do_trim_free_data_blocks)
-    want_write = 1;
-  int fd = open(img, want_write ? O_RDWR : O_RDONLY);
-  if (fd < 0)
-  {
-    perror("open");
+  fsck_apply_mode_defaults(&opts);
+  int want_write = fsck_want_write(&opts);
+  if (fsck_open_image(&opts, want_write, &info) != 0)
     return 1;
-  }
 
-  // read superblock
-  kafs_ssuperblock_t sb;
-  if (pread_all(fd, &sb, sizeof(sb), 0) != 0)
+  int rc = fsck_validate_regions(&info);
+  if (rc != 0)
   {
-    perror("pread superblock");
-    close(fd);
-    return 1;
+    close(info.fd);
+    return rc;
   }
-
-  struct stat st;
-  if (fstat(fd, &st) != 0)
+  rc = fsck_handle_offline_ops(info.fd, want_write, &opts, &exit_code, &info.sb);
+  if (rc != 0)
   {
-    perror("fstat");
-    close(fd);
-    return 1;
+    close(info.fd);
+    return rc;
   }
-  uint64_t file_size = 0;
-  if (S_ISREG(st.st_mode))
+  if (!opts.do_check_journal)
   {
-    file_size = (uint64_t)st.st_size;
-  }
-  else if (S_ISBLK(st.st_mode))
-  {
-#ifdef __linux__
-    if (ioctl(fd, BLKGETSIZE64, &file_size) != 0)
-    {
-      perror("ioctl(BLKGETSIZE64)");
-      close(fd);
-      return 1;
-    }
-#else
-    fprintf(stderr, "block devices are not supported on this platform\n");
-    close(fd);
-    return 1;
-#endif
-  }
-  else
-  {
-    fprintf(stderr, "unsupported file type\n");
-    close(fd);
-    return 1;
-  }
-
-  if (check_region_bounds("allocator", kafs_sb_allocator_offset_get(&sb),
-                          kafs_sb_allocator_size_get(&sb), file_size) != 0)
-  {
-    close(fd);
-    return 3;
-  }
-  if (check_region_bounds("pendinglog", kafs_sb_pendinglog_offset_get(&sb),
-                          kafs_sb_pendinglog_size_get(&sb), file_size) != 0)
-  {
-    close(fd);
-    return FSCK_EXIT_JOURNAL_CHECK_FAILED;
-  }
-  {
-    uint64_t tail_off = kafs_sb_tailmeta_offset_get(&sb);
-    uint64_t tail_size = kafs_sb_tailmeta_size_get(&sb);
-    uint64_t feature_flags = kafs_sb_feature_flags_get(&sb);
-    if ((feature_flags & KAFS_FEATURE_TAIL_META_REGION) != 0 || tail_off != 0 || tail_size != 0)
-    {
-      if (check_region_bounds("tailmeta", tail_off, tail_size, file_size) != 0)
-      {
-        close(fd);
-        return 3;
-      }
-    }
-  }
-  if (check_tailmeta_region(fd, &sb, file_size) != 0)
-  {
-    close(fd);
-    return FSCK_EXIT_TAILMETA_INCONSISTENT;
-  }
-
-  if (do_check_dirent_ino_orphans || do_repair_dirent_ino_orphans || do_check_hrl_blo_refcounts ||
-      do_repair_hrl_blo_refcounts || do_check_inode_block_counts || do_repair_inode_block_counts ||
-      do_replay_journal || do_punch_hole_unreferenced_data_blocks || do_trim_free_data_blocks)
-  {
-    kafs_context_t ctx;
-    memset(&ctx, 0, sizeof(ctx));
-    ctx.c_fd = fd;
-
-    // layout and full-image mmap (matches kafs.c)
-    kafs_logblksize_t log_blksize = kafs_sb_log_blksize_get(&sb);
-    kafs_blksize_t blksize = 1u << log_blksize;
-    kafs_blksize_t blksizemask = blksize - 1u;
-    kafs_inocnt_t inocnt = kafs_inocnt_stoh(sb.s_inocnt);
-    kafs_blkcnt_t r_blkcnt = kafs_blkcnt_stoh(sb.s_r_blkcnt);
-
-    off_t mapsize = 0;
-    mapsize += sizeof(kafs_ssuperblock_t);
-    mapsize = (mapsize + blksizemask) & ~blksizemask;
-    void *blkmask_off = (void *)mapsize;
-    mapsize += (r_blkcnt + 7) >> 3;
-    mapsize = (mapsize + 7) & ~7;
-    mapsize = (mapsize + blksizemask) & ~blksizemask;
-    void *inotbl_off = (void *)mapsize;
-    mapsize += (off_t)kafs_inode_table_bytes_for_format(kafs_sb_format_version_get(&sb), inocnt);
-    mapsize = (mapsize + blksizemask) & ~blksizemask;
-
-    off_t imgsize = (off_t)r_blkcnt << log_blksize;
-    {
-      uint64_t idx_off = kafs_sb_hrl_index_offset_get(&sb);
-      uint64_t idx_size = kafs_sb_hrl_index_size_get(&sb);
-      uint64_t ent_off = kafs_sb_hrl_entry_offset_get(&sb);
-      uint64_t ent_cnt = kafs_sb_hrl_entry_cnt_get(&sb);
-      uint64_t ent_size = ent_cnt * (uint64_t)sizeof(kafs_hrl_entry_t);
-      uint64_t j_off = kafs_sb_journal_offset_get(&sb);
-      uint64_t j_size = kafs_sb_journal_size_get(&sb);
-      uint64_t end1 = (idx_off && idx_size) ? (idx_off + idx_size) : 0;
-      uint64_t end2 = (ent_off && ent_size) ? (ent_off + ent_size) : 0;
-      uint64_t end3 = (j_off && j_size) ? (j_off + j_size) : 0;
-      uint64_t max_end = end1;
-      if (end2 > max_end)
-        max_end = end2;
-      if (end3 > max_end)
-        max_end = end3;
-      if ((off_t)max_end > imgsize)
-        imgsize = (off_t)max_end;
-      imgsize = (imgsize + blksizemask) & ~blksizemask;
-    }
-
-    int prot = want_write ? (PROT_READ | PROT_WRITE) : PROT_READ;
-    ctx.c_img_base = mmap(NULL, (size_t)imgsize, prot, MAP_SHARED, fd, 0);
-    if (ctx.c_img_base == MAP_FAILED)
-    {
-      perror("mmap");
-      close(fd);
-      return 1;
-    }
-    ctx.c_img_size = (size_t)imgsize;
-    ctx.c_superblock = (kafs_ssuperblock_t *)ctx.c_img_base;
-    ctx.c_mapsize = (size_t)mapsize;
-    ctx.c_blkmasktbl = (void *)((char *)ctx.c_superblock + (intptr_t)blkmask_off);
-    ctx.c_inotbl = (void *)((char *)ctx.c_superblock + (intptr_t)inotbl_off);
-    ctx.c_blo_search = 0;
-    ctx.c_ino_search = 0;
-
-    if (do_replay_journal)
-    {
-      int rrc = kafs_journal_replay(&ctx, NULL, NULL);
-      if (rrc != 0)
-      {
-        munmap(ctx.c_img_base, ctx.c_img_size);
-        close(fd);
-        return FSCK_EXIT_JOURNAL_REPLAY_FAILED;
-      }
-      fprintf(stderr, "Journal replay: applied pending metadata and cleared ring.\n");
-    }
-
-    if (do_check_dirent_ino_orphans || do_repair_dirent_ino_orphans)
-    {
-      struct orphan_stats ost;
-      memset(&ost, 0, sizeof(ost));
-      struct dir_v4_stats dst;
-      memset(&dst, 0, sizeof(dst));
-
-      int drc = fsck_check_or_repair_dir_v4(&ctx, do_repair_dirent_ino_orphans, &dst);
-      if (drc != 0)
-      {
-        if (do_repair_dirent_ino_orphans)
-          (void)kafs_hrl_close(&ctx);
-        munmap(ctx.c_img_base, ctx.c_img_size);
-        close(fd);
-        return 1;
-      }
-      if (dst.invalid_dirs > 0)
-      {
-        fprintf(stderr,
-                "Dir-v4 summary: checked=%" PRIu64 " invalid=%" PRIu64 " repaired=%" PRIu64 "\n",
-                dst.dirs_checked, dst.invalid_dirs, dst.repaired_dirs);
-        if (do_repair_dirent_ino_orphans)
-        {
-          if (dst.invalid_dirs != dst.repaired_dirs)
-            exit_code = FSCK_EXIT_DIRENT_FORMAT_INCONSISTENT;
-        }
-        else
-        {
-          exit_code = FSCK_EXIT_DIRENT_FORMAT_INCONSISTENT;
-        }
-      }
-
-      if (do_repair_dirent_ino_orphans)
-        (void)kafs_hrl_open(&ctx);
-
-      int found = orphan_reclaim(&ctx, do_repair_dirent_ino_orphans, &ost);
-      if (found < 0)
-      {
-        if (do_repair_dirent_ino_orphans)
-          (void)kafs_hrl_close(&ctx);
-        munmap(ctx.c_img_base, ctx.c_img_size);
-        close(fd);
-        return 1;
-      }
-
-      if (do_repair_dirent_ino_orphans)
-      {
-        (void)kafs_hrl_close(&ctx);
-        fprintf(stderr,
-                "Dirent->ino orphan repair summary: found=%" PRIu64 " dec_attempted=%" PRIu64
-                " dec_failed=%" PRIu64 "\n",
-                ost.found, ost.dec_attempted, ost.dec_failed);
-        if (ost.dec_failed > 0)
-          exit_code = FSCK_EXIT_DIRENT_INO_REPAIR_PARTIAL;
-      }
-      else if (ost.found > 0)
-      {
-        exit_code = FSCK_EXIT_DIRENT_INO_INCONSISTENT;
-      }
-    }
-
-    if (do_repair_hrl_blo_refcounts)
-    {
-      struct hrl_repair_stats rst;
-      memset(&rst, 0, sizeof(rst));
-
-      int ohrc = kafs_hrl_open(&ctx);
-      if (ohrc != 0)
-      {
-        munmap(ctx.c_img_base, ctx.c_img_size);
-        close(fd);
-        return 1;
-      }
-
-      int rrc = repair_hrl_blo_refcounts(&ctx, &rst);
-      (void)kafs_hrl_close(&ctx);
-      if (rrc != 0)
-      {
-        munmap(ctx.c_img_base, ctx.c_img_size);
-        close(fd);
-        return 1;
-      }
-
-      fprintf(stderr,
-              "HRL->BLO repair summary: inc_attempted=%" PRIu64 " inc_failed=%" PRIu64
-              " dec_attempted=%" PRIu64 " dec_failed=%" PRIu64 "\n",
-              rst.inc_attempted, rst.inc_failed, rst.dec_attempted, rst.dec_failed);
-
-      if ((rst.inc_failed > 0 || rst.dec_failed > 0) && exit_code == 0)
-        exit_code = FSCK_EXIT_HRL_BLO_INCONSISTENT;
-    }
-
-    if (do_check_hrl_blo_refcounts)
-    {
-      struct hrl_refcheck_stats hst;
-      memset(&hst, 0, sizeof(hst));
-      int hrc = check_hrl_blo_refcounts(&ctx, &hst);
-      if (hrc != 0)
-      {
-        munmap(ctx.c_img_base, ctx.c_img_size);
-        close(fd);
-        return 1;
-      }
-
-      fprintf(stderr,
-              "HRL->BLO check summary: inode_refs=%" PRIu64 " pending_refs=%" PRIu64
-              " invalid_refs=%" PRIu64 " live_entries=%" PRIu64 " invalid_entries=%" PRIu64
-              " mismatches=%" PRIu64 "\n",
-              hst.inode_refs, hst.pending_refs, hst.invalid_refs, hst.live_entries,
-              hst.hrl_invalid_entries, hst.mismatch_entries);
-
-      if (hst.mismatch_entries > 0 || hst.pending_refs > 0 || hst.invalid_refs > 0 ||
-          hst.hrl_invalid_entries > 0)
-      {
-        if (exit_code == 0)
-          exit_code = FSCK_EXIT_HRL_BLO_INCONSISTENT;
-      }
-    }
-
-    if (do_check_inode_block_counts || do_repair_inode_block_counts)
-    {
-      struct inode_blocks_stats ibs;
-      memset(&ibs, 0, sizeof(ibs));
-
-      int irc = check_or_repair_inode_block_counts(&ctx, do_repair_inode_block_counts, &ibs);
-      if (irc != 0)
-      {
-        munmap(ctx.c_img_base, ctx.c_img_size);
-        close(fd);
-        return 1;
-      }
-
-      fprintf(stderr,
-              "inode block-count %s summary: checked=%" PRIu64 " mismatches=%" PRIu64
-              " repaired=%" PRIu64 "\n",
-              do_repair_inode_block_counts ? "repair" : "check", ibs.checked, ibs.mismatches,
-              ibs.repaired);
-
-      if (!do_repair_inode_block_counts && ibs.mismatches > 0 && exit_code == 0)
-        exit_code = FSCK_EXIT_INODE_BLOCKS_INCONSISTENT;
-    }
-
-    if (do_punch_hole_unreferenced_data_blocks)
-    {
-      struct punch_stats pst;
-      memset(&pst, 0, sizeof(pst));
-      int prc = punch_unreferenced_data_blocks(&ctx, fd, &pst);
-      if (prc != 0)
-      {
-        munmap(ctx.c_img_base, ctx.c_img_size);
-        close(fd);
-        return 1;
-      }
-
-      fprintf(stderr,
-              "Punch-hole summary: candidates=%" PRIu64 " already_free=%" PRIu64 " punched=%" PRIu64
-              " punch_failed=%" PRIu64 " mark_failed=%" PRIu64 "\n",
-              pst.candidates, pst.already_free, pst.punched, pst.punch_failed, pst.mark_failed);
-
-      if ((pst.punch_failed > 0 || pst.mark_failed > 0) && exit_code == 0)
-        exit_code = FSCK_EXIT_PUNCH_HOLE_PARTIAL;
-    }
-
-    if (do_trim_free_data_blocks)
-    {
-      struct punch_stats tst;
-      int trc = trim_free_data_blocks(&ctx, fd, &tst);
-      if (trc != 0)
-      {
-        munmap(ctx.c_img_base, ctx.c_img_size);
-        close(fd);
-        return 1;
-      }
-
-      fprintf(stderr,
-              "Trim-free summary: candidates=%" PRIu64 " punched=%" PRIu64 " punch_failed=%" PRIu64
-              "\n",
-              tst.candidates, tst.punched, tst.punch_failed);
-
-      if (tst.punch_failed > 0 && exit_code == 0)
-        exit_code = FSCK_EXIT_PUNCH_HOLE_PARTIAL;
-    }
-
-    if (want_write)
-    {
-      (void)msync(ctx.c_img_base, ctx.c_img_size, MS_SYNC);
-      (void)fsync(fd);
-    }
-    munmap(ctx.c_img_base, ctx.c_img_size);
-  }
-
-  if (!do_check_journal)
-  {
-    close(fd);
+    close(info.fd);
     return exit_code;
   }
 
-  uint64_t joff = kafs_sb_journal_offset_get(&sb);
-  uint64_t jsize = kafs_sb_journal_size_get(&sb);
-  if (check_region_bounds("journal", joff, jsize, file_size) != 0)
-  {
-    close(fd);
-    return FSCK_EXIT_JOURNAL_CHECK_FAILED;
-  }
-  if (joff == 0 || jsize < 4096)
-  {
-    fprintf(stderr, "No in-image journal: off=%" PRIu64 " size=%" PRIu64 "\n", joff, jsize);
-    close(fd);
-    return exit_code;
-  }
-
-  size_t hsz = kj_header_size();
-  uint64_t data_off = joff + hsz;
-  uint64_t area_size = (jsize > hsz) ? (jsize - hsz) : 0;
-  if (area_size == 0)
-  {
-    fprintf(stderr, "Invalid journal area size 0\n");
-    close(fd);
-    return 1;
-  }
-
-  kj_header_t hdr;
-  if (pread_all(fd, &hdr, sizeof(hdr), (off_t)joff) != 0)
-  {
-    perror("pread journal header");
-    close(fd);
-    return 1;
-  }
-
-  int header_ok = 1;
-  int ok = 1;
-  if (hdr.magic != KJ_MAGIC)
-  {
-    fprintf(stderr, "Journal: bad magic\n");
-    header_ok = 0;
-  }
-  if (hdr.version != KJ_VER)
-  {
-    fprintf(stderr, "Journal: bad version (%u)\n", hdr.version);
-    header_ok = 0;
-  }
-  if (hdr.area_size != area_size)
-  {
-    fprintf(stderr, "Journal: area_size mismatch (sb=%" PRIu64 ", hdr=%" PRIu64 ")\n", area_size,
-            (uint64_t)hdr.area_size);
-    header_ok = 0;
-  }
-  {
-    kj_header_t tmp = hdr;
-    tmp.header_crc = 0;
-    uint32_t c = kj_crc32(&tmp, sizeof(tmp));
-    if (c != hdr.header_crc)
-    {
-      fprintf(stderr, "Journal: header CRC mismatch\n");
-      header_ok = 0;
-    }
-  }
-
-  ok = header_ok;
-
-  if (!ok && !do_journal_reset)
-  {
-    close(fd);
-    return FSCK_EXIT_JOURNAL_CHECK_FAILED;
-  }
-
-  // scan records up to write_off
-  if (ok)
-  {
-    uint64_t pos = 0;
-    while (pos + sizeof(kj_rec_hdr_t) <= hdr.write_off)
-    {
-      kj_rec_hdr_t rh;
-      if (pread_all(fd, &rh, sizeof(rh), (off_t)(data_off + pos)) != 0)
-      {
-        perror("pread rec hdr");
-        ok = 0;
-        break;
-      }
-      pos += sizeof(rh);
-      if (rh.tag == KJ_TAG_WRAP)
-      {
-        pos = 0;
-        continue;
-      }
-      if (pos + rh.size > hdr.write_off)
-      {
-        fprintf(stderr, "Journal: partial tail\n");
-        ok = 0;
-        break;
-      }
-      char *pl = NULL;
-      if (rh.size)
-      {
-        pl = (char *)malloc((size_t)rh.size);
-        if (!pl)
-        {
-          perror("malloc");
-          ok = 0;
-          break;
-        }
-        if (pread_all(fd, pl, rh.size, (off_t)(data_off + pos)) != 0)
-        {
-          perror("pread rec payload");
-          free(pl);
-          ok = 0;
-          break;
-        }
-      }
-      // CRC check
-      kj_rec_hdr_t rh2 = rh;
-      rh2.crc32 = 0;
-      uint32_t c = kj_crc32_update(0, (const uint8_t *)&rh2, sizeof(rh2));
-      if (rh.size && pl)
-        c = kj_crc32_update(c, (const uint8_t *)pl, rh.size);
-      if (pl)
-        free(pl);
-      if (c != rh.crc32)
-      {
-        fprintf(stderr, "Journal: record CRC mismatch at off=%" PRIu64 "\n",
-                (uint64_t)(pos - sizeof(rh)));
-        ok = 0;
-        break;
-      }
-      pos += rh.size;
-    }
-  }
-
-  if (!ok && do_journal_reset)
-  {
-    // Reset ring: zero data area and write fresh header with write_off=0 (seq preserved if hdr
-    // valid) zero data area in chunks
-    const size_t chunk = 4096;
-    char z[chunk];
-    memset(z, 0, sizeof(z));
-    uint64_t rem = area_size;
-    uint64_t off = 0;
-    while (rem)
-    {
-      size_t n = rem > chunk ? chunk : (size_t)rem;
-      if (pwrite_all(fd, z, n, (off_t)(data_off + off)) != 0)
-      {
-        perror("pwrite zero");
-        close(fd);
-        return FSCK_EXIT_JOURNAL_RESET_FAILED;
-      }
-      off += n;
-      rem -= n;
-    }
-    kj_header_t nh = {
-        .magic = KJ_MAGIC,
-        .version = KJ_VER,
-        .flags = 0,
-        .area_size = area_size,
-        .write_off = 0,
-        .seq = (header_ok ? hdr.seq : 0),
-        .reserved0 = 0,
-        .header_crc = 0,
-    };
-    nh.header_crc = kj_crc32(&nh, sizeof(nh));
-    if (pwrite_all(fd, &nh, sizeof(nh), (off_t)joff) != 0)
-    {
-      perror("pwrite header");
-      close(fd);
-      return FSCK_EXIT_JOURNAL_RESET_FAILED;
-    }
-    if (fsync(fd) != 0)
-    {
-      perror("fsync");
-      close(fd);
-      return FSCK_EXIT_JOURNAL_RESET_FAILED;
-    }
-    fprintf(stderr, "Journal cleared.\n");
-    close(fd);
-    return exit_code;
-  }
-
-  if (!ok)
-  {
-    fprintf(stderr, "Journal check: FAIL\n");
-    close(fd);
-    return FSCK_EXIT_JOURNAL_CHECK_FAILED;
-  }
-  fprintf(stderr, "Journal check: OK\n");
-  close(fd);
-  return exit_code;
+  rc = fsck_validate_or_reset_journal(&opts, &info, exit_code);
+  close(info.fd);
+  return rc;
 }

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -325,31 +325,31 @@ static void kafs_diag_note_create_event(struct kafs_context *ctx, kafs_inocnt_t 
                     slot[0] ? slot : "(null)");
 }
 
-static void kafs_diag_log_first_pwrite_after_create(struct kafs_context *ctx, kafs_sinode_t *inoent,
-                                                    const void *buf, kafs_off_t size,
-                                                    kafs_off_t offset)
+static int kafs_diag_should_log_first_pwrite(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                             const void *buf, kafs_off_t size,
+                                             kafs_inocnt_t *ino_out)
 {
   if (!ctx || !inoent || !buf || size <= 0 || !ctx->c_superblock || !ctx->c_diag_create_seq ||
       !ctx->c_diag_create_mode || !ctx->c_diag_create_first_write_seen ||
       !ctx->c_diag_create_paths || !kafs_extra_diag_enabled())
-    return;
+    return 0;
 
   kafs_inocnt_t ino = kafs_ctx_ino_no(ctx, inoent);
   if (ino >= kafs_sb_inocnt_get(ctx->c_superblock))
-    return;
+    return 0;
   if (ctx->c_diag_create_first_write_seen[ino])
-    return;
+    return 0;
 
-  uint64_t seq = ctx->c_diag_create_seq[ino];
-  if (seq == 0)
-    return;
-  ctx->c_diag_create_first_write_seen[ino] = 1u;
+  *ino_out = ino;
+  return 1;
+}
 
-  char hex_sample[3 * 16 + 1];
-  char ascii_sample[16 + 1];
-  kafs_diag_format_sample(buf, (size_t)size, hex_sample, sizeof(hex_sample), ascii_sample,
-                          sizeof(ascii_sample));
-
+static void kafs_diag_emit_first_pwrite_after_create(struct kafs_context *ctx,
+                                                     kafs_sinode_t *inoent, kafs_inocnt_t ino,
+                                                     uint64_t seq, kafs_off_t size,
+                                                     kafs_off_t offset, const char *hex_sample,
+                                                     const char *ascii_sample)
+{
   char *slot = ctx->c_diag_create_paths + ((size_t)ino * KAFS_DIAG_CREATE_PATH_MAX);
   kafs_log(KAFS_LOG_WARNING,
            "%s: seq=%" PRIuFAST64 " ino=%" PRIuFAST32 " expected_mode=%o current_mode=%o "
@@ -366,6 +366,27 @@ static void kafs_diag_log_first_pwrite_after_create(struct kafs_context *ctx, ka
                     (unsigned)ctx->c_diag_create_mode[ino], (unsigned)kafs_ino_mode_get(inoent),
                     (uint_fast64_t)size, (uint_fast64_t)offset, slot[0] ? slot : "(null)",
                     hex_sample[0] ? hex_sample : "-", ascii_sample[0] ? ascii_sample : "-");
+}
+
+static void kafs_diag_log_first_pwrite_after_create(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                                    const void *buf, kafs_off_t size,
+                                                    kafs_off_t offset)
+{
+  kafs_inocnt_t ino = 0;
+  if (!kafs_diag_should_log_first_pwrite(ctx, inoent, buf, size, &ino))
+    return;
+
+  uint64_t seq = ctx->c_diag_create_seq[ino];
+  if (seq == 0)
+    return;
+  ctx->c_diag_create_first_write_seen[ino] = 1u;
+
+  char hex_sample[3 * 16 + 1];
+  char ascii_sample[16 + 1];
+  kafs_diag_format_sample(buf, (size_t)size, hex_sample, sizeof(hex_sample), ascii_sample,
+                          sizeof(ascii_sample));
+  kafs_diag_emit_first_pwrite_after_create(ctx, inoent, ino, seq, size, offset, hex_sample,
+                                           ascii_sample);
 }
 
 #else

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -10206,154 +10206,148 @@ static void kafs_main_apply_optional_bool_env(const char *value, kafs_bool_t *ou
     *out = KAFS_TRUE;
 }
 
-static int kafs_main_apply_env_overrides(kafs_main_options_t *opts)
+static const char *kafs_main_getenv_fallback(const char *primary, const char *fallback)
 {
-  const char *wbc_env = getenv("KAFS_WRITEBACK_CACHE");
-  const char *trim_env = getenv("KAFS_TRIM_ON_FREE");
+  const char *value = getenv(primary);
+  if (value && *value)
+    return value;
+  return getenv(fallback);
+}
+
+static int kafs_main_parse_nice_env(const char *name, const char *value, int *out)
+{
+  if (!value || !*value)
+    return 0;
+
+  char *endp = NULL;
+  long v = strtol(value, &endp, 10);
+  if (!endp || *endp != '\0' || v < 0 || v > 19)
+  {
+    fprintf(stderr, "invalid %s: '%s'\n", name, value);
+    return 2;
+  }
+  *out = (int)v;
+  return 0;
+}
+
+static int kafs_main_parse_u32_env(const char *name, const char *value, uint32_t min_value,
+                                   uint32_t max_value, uint32_t *out)
+{
+  if (!value || !*value)
+    return 0;
+  if (kafs_parse_u32_range(value, min_value, max_value, out) != 0)
+  {
+    fprintf(stderr, "invalid %s: '%s'\n", name, value);
+    return 2;
+  }
+  return 0;
+}
+
+static int kafs_main_apply_pending_env_overrides(kafs_main_options_t *opts)
+{
   const char *pprio = getenv("KAFS_PENDING_WORKER_PRIO");
-  const char *pnice = getenv("KAFS_PENDING_WORKER_NICE");
-  const char *pttl_soft = getenv("KAFS_PENDING_TTL_SOFT_MS");
-  const char *pttl_hard = getenv("KAFS_PENDING_TTL_HARD_MS");
-  const char *pcap_initial = getenv("KAFS_PENDINGLOG_CAP_INITIAL");
-  const char *pcap_min = getenv("KAFS_PENDINGLOG_CAP_MIN");
-  const char *pcap_max = getenv("KAFS_PENDINGLOG_CAP_MAX");
-  const char *bg_scan = getenv("KAFS_BG_DEDUP_SCAN");
-  const char *bg_interval = getenv("KAFS_BG_DEDUP_INTERVAL_MS");
-  const char *bg_quiet_interval = getenv("KAFS_BG_DEDUP_QUIET_INTERVAL_MS");
-  const char *bg_pressure_interval = getenv("KAFS_BG_DEDUP_PRESSURE_INTERVAL_MS");
-  const char *bg_start_pct = getenv("KAFS_BG_DEDUP_START_USED_PCT");
-  const char *bg_pressure_pct = getenv("KAFS_BG_DEDUP_PRESSURE_USED_PCT");
-  const char *bg_prio = getenv("KAFS_BG_DEDUP_WORKER_PRIO");
-  const char *bg_nice = getenv("KAFS_BG_DEDUP_WORKER_NICE");
-  const char *fsp = getenv("KAFS_FSYNC_POLICY");
-  const char *mt = getenv("KAFS_MT");
-
-  kafs_main_apply_optional_bool_env(wbc_env, &opts->writeback_cache_enabled);
-  kafs_main_apply_optional_bool_env(trim_env, &opts->trim_on_free_enabled);
-  opts->enable_mt = (mt && strcmp(mt, "1") == 0) ? KAFS_TRUE : KAFS_FALSE;
-
   if (pprio && *pprio &&
       kafs_pending_worker_prio_mode_parse(pprio, &opts->pending_worker_prio_mode) != 0)
   {
     fprintf(stderr, "invalid KAFS_PENDING_WORKER_PRIO: '%s'\n", pprio);
     return 2;
   }
-
-  if (pnice && *pnice)
-  {
-    char *endp = NULL;
-    long v = strtol(pnice, &endp, 10);
-    if (!endp || *endp != '\0' || v < 0 || v > 19)
-    {
-      fprintf(stderr, "invalid KAFS_PENDING_WORKER_NICE: '%s'\n", pnice);
-      return 2;
-    }
-    opts->pending_worker_nice = (int)v;
-  }
-
-  if (pttl_soft && *pttl_soft &&
-      kafs_parse_u32_range(pttl_soft, 0, 3600000u, &opts->pending_ttl_soft_ms) != 0)
-  {
-    fprintf(stderr, "invalid KAFS_PENDING_TTL_SOFT_MS: '%s'\n", pttl_soft);
+  if (kafs_main_parse_nice_env("KAFS_PENDING_WORKER_NICE", getenv("KAFS_PENDING_WORKER_NICE"),
+                               &opts->pending_worker_nice) != 0)
     return 2;
-  }
-  if (pttl_hard && *pttl_hard &&
-      kafs_parse_u32_range(pttl_hard, 0, 3600000u, &opts->pending_ttl_hard_ms) != 0)
-  {
-    fprintf(stderr, "invalid KAFS_PENDING_TTL_HARD_MS: '%s'\n", pttl_hard);
+  if (kafs_main_parse_u32_env("KAFS_PENDING_TTL_SOFT_MS", getenv("KAFS_PENDING_TTL_SOFT_MS"), 0,
+                              3600000u, &opts->pending_ttl_soft_ms) != 0)
     return 2;
-  }
+  return kafs_main_parse_u32_env("KAFS_PENDING_TTL_HARD_MS", getenv("KAFS_PENDING_TTL_HARD_MS"), 0,
+                                 3600000u, &opts->pending_ttl_hard_ms);
+}
 
-  if ((!pcap_initial || !*pcap_initial) && getenv("KAFS_PENDING_CAP_INITIAL"))
-    pcap_initial = getenv("KAFS_PENDING_CAP_INITIAL");
-  if (pcap_initial && *pcap_initial &&
-      kafs_parse_u32_range(pcap_initial, 0, 1000000000u, &opts->pending_cap_initial) != 0)
-  {
-    fprintf(stderr, "invalid KAFS_PENDINGLOG_CAP_INITIAL: '%s'\n", pcap_initial);
+static int kafs_main_apply_pending_cap_env_overrides(kafs_main_options_t *opts)
+{
+  if (kafs_main_parse_u32_env(
+          "KAFS_PENDINGLOG_CAP_INITIAL",
+          kafs_main_getenv_fallback("KAFS_PENDINGLOG_CAP_INITIAL", "KAFS_PENDING_CAP_INITIAL"), 0,
+          1000000000u, &opts->pending_cap_initial) != 0)
     return 2;
-  }
-
-  if ((!pcap_min || !*pcap_min) && getenv("KAFS_PENDING_CAP_MIN"))
-    pcap_min = getenv("KAFS_PENDING_CAP_MIN");
-  if (pcap_min && *pcap_min &&
-      kafs_parse_u32_range(pcap_min, 0, 1000000000u, &opts->pending_cap_min) != 0)
-  {
-    fprintf(stderr, "invalid KAFS_PENDINGLOG_CAP_MIN: '%s'\n", pcap_min);
+  if (kafs_main_parse_u32_env(
+          "KAFS_PENDINGLOG_CAP_MIN",
+          kafs_main_getenv_fallback("KAFS_PENDINGLOG_CAP_MIN", "KAFS_PENDING_CAP_MIN"), 0,
+          1000000000u, &opts->pending_cap_min) != 0)
     return 2;
-  }
+  return kafs_main_parse_u32_env(
+      "KAFS_PENDINGLOG_CAP_MAX",
+      kafs_main_getenv_fallback("KAFS_PENDINGLOG_CAP_MAX", "KAFS_PENDING_CAP_MAX"), 0, 1000000000u,
+      &opts->pending_cap_max);
+}
 
-  if ((!pcap_max || !*pcap_max) && getenv("KAFS_PENDING_CAP_MAX"))
-    pcap_max = getenv("KAFS_PENDING_CAP_MAX");
-  if (pcap_max && *pcap_max &&
-      kafs_parse_u32_range(pcap_max, 0, 1000000000u, &opts->pending_cap_max) != 0)
-  {
-    fprintf(stderr, "invalid KAFS_PENDINGLOG_CAP_MAX: '%s'\n", pcap_max);
-    return 2;
-  }
-
+static int kafs_main_apply_bg_dedup_env_overrides(kafs_main_options_t *opts)
+{
+  const char *bg_scan = getenv("KAFS_BG_DEDUP_SCAN");
   if (bg_scan && *bg_scan && kafs_parse_onoff(bg_scan, &opts->bg_dedup_scan_enabled) != 0)
   {
     fprintf(stderr, "invalid KAFS_BG_DEDUP_SCAN: '%s'\n", bg_scan);
     return 2;
   }
-  if (bg_interval && *bg_interval &&
-      kafs_parse_u32_range(bg_interval, KAFS_BG_DEDUP_INTERVAL_MS_MIN,
-                           KAFS_BG_DEDUP_INTERVAL_MS_MAX, &opts->bg_dedup_interval_ms) != 0)
-  {
-    fprintf(stderr, "invalid KAFS_BG_DEDUP_INTERVAL_MS: '%s'\n", bg_interval);
+  if (kafs_main_parse_u32_env("KAFS_BG_DEDUP_INTERVAL_MS", getenv("KAFS_BG_DEDUP_INTERVAL_MS"),
+                              KAFS_BG_DEDUP_INTERVAL_MS_MIN, KAFS_BG_DEDUP_INTERVAL_MS_MAX,
+                              &opts->bg_dedup_interval_ms) != 0)
     return 2;
-  }
-  if (bg_quiet_interval && *bg_quiet_interval &&
-      kafs_parse_u32_range(bg_quiet_interval, KAFS_BG_DEDUP_INTERVAL_MS_MIN,
-                           KAFS_BG_DEDUP_INTERVAL_MS_MAX, &opts->bg_dedup_quiet_interval_ms) != 0)
-  {
-    fprintf(stderr, "invalid KAFS_BG_DEDUP_QUIET_INTERVAL_MS: '%s'\n", bg_quiet_interval);
+  if (kafs_main_parse_u32_env("KAFS_BG_DEDUP_QUIET_INTERVAL_MS",
+                              getenv("KAFS_BG_DEDUP_QUIET_INTERVAL_MS"),
+                              KAFS_BG_DEDUP_INTERVAL_MS_MIN, KAFS_BG_DEDUP_INTERVAL_MS_MAX,
+                              &opts->bg_dedup_quiet_interval_ms) != 0)
     return 2;
-  }
-  if (bg_pressure_interval && *bg_pressure_interval &&
-      kafs_parse_u32_range(bg_pressure_interval, KAFS_BG_DEDUP_INTERVAL_MS_MIN,
-                           KAFS_BG_DEDUP_INTERVAL_MS_MAX,
-                           &opts->bg_dedup_pressure_interval_ms) != 0)
-  {
-    fprintf(stderr, "invalid KAFS_BG_DEDUP_PRESSURE_INTERVAL_MS: '%s'\n", bg_pressure_interval);
+  if (kafs_main_parse_u32_env("KAFS_BG_DEDUP_PRESSURE_INTERVAL_MS",
+                              getenv("KAFS_BG_DEDUP_PRESSURE_INTERVAL_MS"),
+                              KAFS_BG_DEDUP_INTERVAL_MS_MIN, KAFS_BG_DEDUP_INTERVAL_MS_MAX,
+                              &opts->bg_dedup_pressure_interval_ms) != 0)
     return 2;
-  }
-  if (bg_start_pct && *bg_start_pct &&
-      kafs_parse_u32_range(bg_start_pct, 0, 100u, &opts->bg_dedup_start_used_pct) != 0)
-  {
-    fprintf(stderr, "invalid KAFS_BG_DEDUP_START_USED_PCT: '%s'\n", bg_start_pct);
+  if (kafs_main_parse_u32_env("KAFS_BG_DEDUP_START_USED_PCT",
+                              getenv("KAFS_BG_DEDUP_START_USED_PCT"), 0, 100u,
+                              &opts->bg_dedup_start_used_pct) != 0)
     return 2;
-  }
-  if (bg_pressure_pct && *bg_pressure_pct &&
-      kafs_parse_u32_range(bg_pressure_pct, 0, 100u, &opts->bg_dedup_pressure_used_pct) != 0)
-  {
-    fprintf(stderr, "invalid KAFS_BG_DEDUP_PRESSURE_USED_PCT: '%s'\n", bg_pressure_pct);
+  if (kafs_main_parse_u32_env("KAFS_BG_DEDUP_PRESSURE_USED_PCT",
+                              getenv("KAFS_BG_DEDUP_PRESSURE_USED_PCT"), 0, 100u,
+                              &opts->bg_dedup_pressure_used_pct) != 0)
     return 2;
-  }
+
+  const char *bg_prio = getenv("KAFS_BG_DEDUP_WORKER_PRIO");
   if (bg_prio && *bg_prio &&
       kafs_pending_worker_prio_mode_parse(bg_prio, &opts->bg_dedup_worker_prio_mode) != 0)
   {
     fprintf(stderr, "invalid KAFS_BG_DEDUP_WORKER_PRIO: '%s'\n", bg_prio);
     return 2;
   }
-  if (bg_nice && *bg_nice)
-  {
-    char *endp = NULL;
-    long v = strtol(bg_nice, &endp, 10);
-    if (!endp || *endp != '\0' || v < 0 || v > 19)
-    {
-      fprintf(stderr, "invalid KAFS_BG_DEDUP_WORKER_NICE: '%s'\n", bg_nice);
-      return 2;
-    }
-    opts->bg_dedup_worker_nice = (int)v;
-  }
+  return kafs_main_parse_nice_env("KAFS_BG_DEDUP_WORKER_NICE", getenv("KAFS_BG_DEDUP_WORKER_NICE"),
+                                  &opts->bg_dedup_worker_nice);
+}
+
+static int kafs_main_apply_misc_env_overrides(kafs_main_options_t *opts)
+{
+  const char *fsp = getenv("KAFS_FSYNC_POLICY");
   if (fsp && *fsp && kafs_fsync_policy_parse(fsp, &opts->fsync_policy) != 0)
   {
     fprintf(stderr, "invalid KAFS_FSYNC_POLICY: '%s'\n", fsp);
     return 2;
   }
 
+  const char *mt = getenv("KAFS_MT");
+  opts->enable_mt = (mt && strcmp(mt, "1") == 0) ? KAFS_TRUE : KAFS_FALSE;
   return 0;
+}
+
+static int kafs_main_apply_env_overrides(kafs_main_options_t *opts)
+{
+  kafs_main_apply_optional_bool_env(getenv("KAFS_WRITEBACK_CACHE"), &opts->writeback_cache_enabled);
+  kafs_main_apply_optional_bool_env(getenv("KAFS_TRIM_ON_FREE"), &opts->trim_on_free_enabled);
+
+  if (kafs_main_apply_pending_env_overrides(opts) != 0)
+    return 2;
+  if (kafs_main_apply_pending_cap_env_overrides(opts) != 0)
+    return 2;
+  if (kafs_main_apply_bg_dedup_env_overrides(opts) != 0)
+    return 2;
+  return kafs_main_apply_misc_env_overrides(opts);
 }
 
 static int kafs_main_collect_args(int argc, char **argv, const char *prog,

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -5834,6 +5834,57 @@ static int kafs_dirent_add(struct kafs_context *ctx, kafs_sinode_t *inoent_dir, 
   return rc;
 }
 
+static int kafs_dirent_remove_prepare_snapshot(struct kafs_context *ctx, kafs_sinode_t *inoent_dir,
+                                               const char *filename,
+                                               kafs_filenamelen_t *filenamelen, char **old,
+                                               size_t *old_len, kafs_dir_snapshot_meta_t *meta,
+                                               uint32_t *target_hash)
+{
+  if (!S_ISDIR(kafs_ino_mode_get(inoent_dir)))
+    return -ENOTDIR;
+
+  *filenamelen = (kafs_filenamelen_t)strlen(filename);
+  if (*filenamelen == 0 || *filenamelen >= FILENAME_MAX)
+    return -EINVAL;
+
+  int rc = kafs_dir_snapshot(ctx, inoent_dir, old, old_len);
+  if (rc < 0)
+    return rc;
+
+  __atomic_add_fetch(&ctx->c_stat_dir_snapshot_meta_load_calls, 1u, __ATOMIC_RELAXED);
+  rc = kafs_dir_snapshot_meta_load(*old, *old_len, meta);
+  if (rc < 0)
+  {
+    free(*old);
+    *old = NULL;
+    return rc;
+  }
+
+  *target_hash = kafs_dirent_name_hash(filename, *filenamelen);
+  return 0;
+}
+
+static int kafs_dirent_remove_mark_tombstone(struct kafs_context *ctx, kafs_sinode_t *inoent_dir,
+                                             const kafs_dir_snapshot_meta_t *meta,
+                                             const kafs_dirent_view_t *view, kafs_inocnt_t *out_ino)
+{
+  kafs_sdir_v4_hdr_t hdr = meta->hdr;
+  uint32_t live_count = kafs_dir_v4_hdr_live_count_get(&hdr);
+  uint32_t tombstone_count = kafs_dir_v4_hdr_tombstone_count_get(&hdr);
+  int rc = kafs_dir_v4_write_record_head(ctx, inoent_dir, view->record_off,
+                                         (uint16_t)view->record_len, KAFS_DIRENT_FLAG_TOMBSTONE,
+                                         view->ino, view->name_len, view->name_hash);
+  if (rc == 0)
+  {
+    kafs_dir_v4_hdr_live_count_set(&hdr, live_count - 1u);
+    kafs_dir_v4_hdr_tombstone_count_set(&hdr, tombstone_count + 1u);
+    rc = kafs_dir_v4_write_header(ctx, inoent_dir, &hdr);
+  }
+  if (rc == 0 && out_ino)
+    *out_ino = view->ino;
+  return rc;
+}
+
 // NOTE: caller holds dir inode lock.
 static int kafs_dirent_remove_nolink(struct kafs_context *ctx, kafs_sinode_t *inoent_dir,
                                      const char *filename, kafs_inocnt_t *out_ino)
@@ -5843,29 +5894,16 @@ static int kafs_dirent_remove_nolink(struct kafs_context *ctx, kafs_sinode_t *in
   assert(filename != NULL);
   if (out_ino)
     *out_ino = KAFS_INO_NONE;
-  if (!S_ISDIR(kafs_ino_mode_get(inoent_dir)))
-    return -ENOTDIR;
 
-  kafs_filenamelen_t filenamelen = (kafs_filenamelen_t)strlen(filename);
-  if (filenamelen == 0 || filenamelen >= FILENAME_MAX)
-    return -EINVAL;
-
+  kafs_filenamelen_t filenamelen;
   char *old = NULL;
   size_t old_len = 0;
-  int rc = kafs_dir_snapshot(ctx, inoent_dir, &old, &old_len);
-  if (rc < 0)
-    return rc;
-
   kafs_dir_snapshot_meta_t meta;
-  __atomic_add_fetch(&ctx->c_stat_dir_snapshot_meta_load_calls, 1u, __ATOMIC_RELAXED);
-  rc = kafs_dir_snapshot_meta_load(old, old_len, &meta);
+  uint32_t target_hash;
+  int rc = kafs_dirent_remove_prepare_snapshot(ctx, inoent_dir, filename, &filenamelen, &old,
+                                               &old_len, &meta, &target_hash);
   if (rc < 0)
-  {
-    free(old);
     return rc;
-  }
-
-  uint32_t target_hash = kafs_dirent_name_hash(filename, filenamelen);
 
   size_t off = 0;
   while (1)
@@ -5883,20 +5921,7 @@ static int kafs_dirent_remove_nolink(struct kafs_context *ctx, kafs_sinode_t *in
     if ((view.flags & KAFS_DIRENT_FLAG_TOMBSTONE) == 0 && view.name_hash == target_hash &&
         view.name_len == filenamelen && memcmp(view.name, filename, filenamelen) == 0)
     {
-      kafs_sdir_v4_hdr_t hdr = meta.hdr;
-      uint32_t live_count = kafs_dir_v4_hdr_live_count_get(&hdr);
-      uint32_t tombstone_count = kafs_dir_v4_hdr_tombstone_count_get(&hdr);
-      rc = kafs_dir_v4_write_record_head(ctx, inoent_dir, view.record_off,
-                                         (uint16_t)view.record_len, KAFS_DIRENT_FLAG_TOMBSTONE,
-                                         view.ino, view.name_len, view.name_hash);
-      if (rc == 0)
-      {
-        kafs_dir_v4_hdr_live_count_set(&hdr, live_count - 1u);
-        kafs_dir_v4_hdr_tombstone_count_set(&hdr, tombstone_count + 1u);
-        rc = kafs_dir_v4_write_header(ctx, inoent_dir, &hdr);
-      }
-      if (rc == 0 && out_ino)
-        *out_ino = view.ino;
+      rc = kafs_dirent_remove_mark_tombstone(ctx, inoent_dir, &meta, &view, out_ino);
       free(old);
       return rc;
     }

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -7362,6 +7362,121 @@ static int kafs_procfd_to_kafs_path(kafs_context_t *ctx, pid_t pid, int fd, char
 }
 #endif
 
+static int kafs_reflink_snapshot_source(kafs_context_t *ctx, kafs_sinode_t *src,
+                                        kafs_off_t *size_out, char *inline_buf, int *is_inline_out,
+                                        kafs_blkcnt_t **blos_out, kafs_iblkcnt_t *iblocnt_out)
+{
+  *size_out = 0;
+  *is_inline_out = 0;
+  *blos_out = NULL;
+  *iblocnt_out = 0;
+
+  uint32_t ino_src = kafs_ctx_ino_no(ctx, src);
+  kafs_inode_lock(ctx, ino_src);
+  kafs_off_t size = kafs_ino_size_get(src);
+  if (size <= (kafs_off_t)KAFS_INODE_DIRECT_BYTES)
+  {
+    memcpy(inline_buf, (void *)src->i_blkreftbl, (size_t)size);
+    kafs_inode_unlock(ctx, ino_src);
+    *size_out = size;
+    *is_inline_out = 1;
+    return 0;
+  }
+
+  kafs_blksize_t bs = kafs_sb_blksize_get(ctx->c_superblock);
+  kafs_iblkcnt_t iblocnt = (kafs_iblkcnt_t)((size + (kafs_off_t)bs - 1) / (kafs_off_t)bs);
+  kafs_blkcnt_t *blos =
+      (kafs_blkcnt_t *)calloc((size_t)iblocnt ? (size_t)iblocnt : 1u, sizeof(*blos));
+  if (!blos)
+  {
+    kafs_inode_unlock(ctx, ino_src);
+    return -ENOMEM;
+  }
+
+  for (kafs_iblkcnt_t i = 0; i < iblocnt; ++i)
+  {
+    kafs_blkcnt_t b = KAFS_BLO_NONE;
+    int rc = kafs_ino_ibrk_run(ctx, src, i, &b, KAFS_IBLKREF_FUNC_GET);
+    if (rc < 0)
+    {
+      free(blos);
+      kafs_inode_unlock(ctx, ino_src);
+      return rc;
+    }
+    blos[i] = b;
+  }
+
+  kafs_inode_unlock(ctx, ino_src);
+  *size_out = size;
+  *blos_out = blos;
+  *iblocnt_out = iblocnt;
+  return 0;
+}
+
+static int kafs_reflink_prepare_destination(kafs_context_t *ctx, kafs_sinode_t *dst)
+{
+  uint32_t ino_dst = kafs_ctx_ino_no(ctx, dst);
+  kafs_inode_lock(ctx, ino_dst);
+  int trc = kafs_truncate(ctx, dst, 0);
+  if (trc < 0)
+  {
+    kafs_inode_unlock(ctx, ino_dst);
+    return trc;
+  }
+  memset(dst->i_blkreftbl, 0, sizeof(dst->i_blkreftbl));
+  return 0;
+}
+
+static int kafs_reflink_apply_inline_locked(kafs_context_t *ctx, kafs_sinode_t *dst,
+                                            kafs_off_t size, const char *inline_buf)
+{
+  uint32_t ino_dst = kafs_ctx_ino_no(ctx, dst);
+  kafs_ino_size_set(dst, size);
+  memcpy((void *)dst->i_blkreftbl, inline_buf, (size_t)size);
+  kafs_time_t now = kafs_now();
+  kafs_ino_mtime_set(dst, now);
+  kafs_ino_ctime_set(dst, now);
+  kafs_inode_unlock(ctx, ino_dst);
+  return 0;
+}
+
+static int kafs_reflink_apply_blocks_locked(kafs_context_t *ctx, kafs_sinode_t *dst,
+                                            kafs_off_t size, kafs_blkcnt_t *blos,
+                                            kafs_iblkcnt_t iblocnt)
+{
+  uint32_t ino_dst = kafs_ctx_ino_no(ctx, dst);
+  kafs_ino_size_set(dst, size);
+  for (kafs_iblkcnt_t i = 0; i < iblocnt; ++i)
+  {
+    kafs_blkcnt_t b = blos[i];
+    if (b == KAFS_BLO_NONE)
+      continue;
+
+    int irc = kafs_hrl_inc_ref_by_blo(ctx, b);
+    if (irc != 0)
+    {
+      (void)kafs_truncate(ctx, dst, 0);
+      kafs_inode_unlock(ctx, ino_dst);
+      return (irc == -ENOENT || irc == -ENOSYS) ? -EOPNOTSUPP : irc;
+    }
+
+    int s = kafs_ino_ibrk_run(ctx, dst, i, &b, KAFS_IBLKREF_FUNC_SET);
+    if (s < 0)
+    {
+      (void)kafs_truncate(ctx, dst, 0);
+      kafs_inode_unlock(ctx, ino_dst);
+      (void)kafs_inode_release_hrl_ref(ctx, b);
+      return s;
+    }
+  }
+
+  kafs_time_t now = kafs_now();
+  kafs_ino_mtime_set(dst, now);
+  kafs_ino_ctime_set(dst, now);
+  kafs_inode_unlock(ctx, ino_dst);
+  return 0;
+}
+
 static int kafs_reflink_clone(kafs_context_t *ctx, kafs_sinode_t *src, kafs_sinode_t *dst)
 {
   if (!ctx || !src || !dst)
@@ -7376,101 +7491,27 @@ static int kafs_reflink_clone(kafs_context_t *ctx, kafs_sinode_t *src, kafs_sino
   if (!S_ISREG(sm) || !S_ISREG(dm))
     return -EINVAL;
 
-  kafs_off_t size;
+  kafs_off_t size = 0;
   char inline_buf[KAFS_INODE_DIRECT_BYTES];
   int is_inline = 0;
-
-  uint32_t ino_src = kafs_ctx_ino_no(ctx, src);
-  kafs_inode_lock(ctx, ino_src);
-  size = kafs_ino_size_get(src);
-  if (size <= (kafs_off_t)KAFS_INODE_DIRECT_BYTES)
-  {
-    memcpy(inline_buf, (void *)src->i_blkreftbl, (size_t)size);
-    is_inline = 1;
-  }
-
   kafs_blkcnt_t *blos = NULL;
   kafs_iblkcnt_t iblocnt = 0;
-  if (!is_inline)
+  int rc = kafs_reflink_snapshot_source(ctx, src, &size, inline_buf, &is_inline, &blos, &iblocnt);
+  if (rc < 0)
+    return rc;
+  rc = kafs_reflink_prepare_destination(ctx, dst);
+  if (rc < 0)
   {
-    kafs_blksize_t bs = kafs_sb_blksize_get(ctx->c_superblock);
-    iblocnt = (kafs_iblkcnt_t)((size + (kafs_off_t)bs - 1) / (kafs_off_t)bs);
-    blos = (kafs_blkcnt_t *)calloc((size_t)iblocnt ? (size_t)iblocnt : 1u, sizeof(*blos));
-    if (!blos)
-    {
-      kafs_inode_unlock(ctx, ino_src);
-      return -ENOMEM;
-    }
-    for (kafs_iblkcnt_t i = 0; i < iblocnt; ++i)
-    {
-      kafs_blkcnt_t b = KAFS_BLO_NONE;
-      int rc = kafs_ino_ibrk_run(ctx, src, i, &b, KAFS_IBLKREF_FUNC_GET);
-      if (rc < 0)
-      {
-        free(blos);
-        kafs_inode_unlock(ctx, ino_src);
-        return rc;
-      }
-      blos[i] = b;
-    }
-  }
-  kafs_inode_unlock(ctx, ino_src);
-
-  uint32_t ino_dst = kafs_ctx_ino_no(ctx, dst);
-  kafs_inode_lock(ctx, ino_dst);
-  int trc = kafs_truncate(ctx, dst, 0);
-  if (trc < 0)
-  {
-    kafs_inode_unlock(ctx, ino_dst);
     free(blos);
-    return trc;
+    return rc;
   }
-  memset(dst->i_blkreftbl, 0, sizeof(dst->i_blkreftbl));
 
   if (is_inline)
-  {
-    kafs_ino_size_set(dst, size);
-    memcpy((void *)dst->i_blkreftbl, inline_buf, (size_t)size);
-    kafs_time_t now = kafs_now();
-    kafs_ino_mtime_set(dst, now);
-    kafs_ino_ctime_set(dst, now);
-    kafs_inode_unlock(ctx, ino_dst);
-    return 0;
-  }
+    return kafs_reflink_apply_inline_locked(ctx, dst, size, inline_buf);
 
-  kafs_ino_size_set(dst, size);
-  for (kafs_iblkcnt_t i = 0; i < iblocnt; ++i)
-  {
-    kafs_blkcnt_t b = blos[i];
-    if (b == KAFS_BLO_NONE)
-      continue;
-
-    int irc = kafs_hrl_inc_ref_by_blo(ctx, b);
-    if (irc != 0)
-    {
-      (void)kafs_truncate(ctx, dst, 0);
-      kafs_inode_unlock(ctx, ino_dst);
-      free(blos);
-      return (irc == -ENOENT || irc == -ENOSYS) ? -EOPNOTSUPP : irc;
-    }
-
-    int s = kafs_ino_ibrk_run(ctx, dst, i, &b, KAFS_IBLKREF_FUNC_SET);
-    if (s < 0)
-    {
-      (void)kafs_truncate(ctx, dst, 0);
-      kafs_inode_unlock(ctx, ino_dst);
-      free(blos);
-      (void)kafs_inode_release_hrl_ref(ctx, b);
-      return s;
-    }
-  }
-
-  kafs_time_t now = kafs_now();
-  kafs_ino_mtime_set(dst, now);
-  kafs_ino_ctime_set(dst, now);
-  kafs_inode_unlock(ctx, ino_dst);
+  rc = kafs_reflink_apply_blocks_locked(ctx, dst, size, blos, iblocnt);
   free(blos);
-  return 0;
+  return rc;
 }
 
 static int kafs_copy_share_one_iblk_locked(kafs_context_t *ctx, kafs_sinode_t *src,

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -11314,6 +11314,221 @@ static void kafs_main_log_runtime_options(kafs_context_t *ctx, kafs_bool_t write
   }
 }
 
+static void kafs_main_open_runtime_context(kafs_context_t *ctx, const char *image_path,
+                                           kafs_bool_t auto_migrate, kafs_bool_t migrate_yes)
+{
+  ctx->c_fd = open(image_path, O_RDWR, 0666);
+  if (ctx->c_fd < 0)
+  {
+    perror("open image");
+    fprintf(stderr, "image not found. run mkfs.kafs first.\n");
+    exit(2);
+  }
+  ctx->c_blo_search = 0;
+  ctx->c_ino_search = 0;
+
+  kafs_ssuperblock_t sbdisk;
+  ssize_t r = pread(ctx->c_fd, &sbdisk, sizeof(sbdisk), 0);
+  if (r != (ssize_t)sizeof(sbdisk))
+  {
+    perror("pread superblock");
+    exit(2);
+  }
+  if (kafs_sb_magic_get(&sbdisk) != KAFS_MAGIC)
+  {
+    fprintf(stderr, "invalid magic. run mkfs.kafs to format.\n");
+    exit(2);
+  }
+
+  uint32_t fmt_ver = kafs_sb_format_version_get(&sbdisk);
+  if (fmt_ver != KAFS_FORMAT_VERSION)
+  {
+    if (fmt_ver == KAFS_FORMAT_VERSION_V2 || fmt_ver == KAFS_FORMAT_VERSION_V3)
+    {
+      if (auto_migrate)
+      {
+        int mrc = kafs_core_migrate_image(image_path, migrate_yes ? 1 : 0);
+        if (mrc == 0)
+        {
+          fprintf(stderr, "migration completed. please restart mount.\n");
+          exit(0);
+        }
+        if (mrc == 1)
+        {
+          fprintf(stderr, "image already v%u; continue normal mount without --migrate.\n",
+                  (unsigned)KAFS_FORMAT_VERSION);
+          exit(0);
+        }
+        if (mrc == -EPROTONOSUPPORT)
+          fprintf(stderr, "offline migration supports only v2/v3 images.\n");
+        else if (mrc == -ECANCELED)
+          fprintf(stderr, "migration canceled by user.\n");
+        else
+          fprintf(stderr, "migration failed rc=%d.\n", mrc);
+        exit(2);
+      }
+      fprintf(stderr,
+              "unsupported format version: v%u.\n"
+              "Run kafsctl migrate <image> or kafs --migrate before mounting.\n",
+              (unsigned)fmt_ver);
+      exit(2);
+    }
+    if (fmt_ver != KAFS_FORMAT_VERSION_V5)
+    {
+      fprintf(stderr, "unsupported format version: %u (expected %u).\n", fmt_ver,
+              (unsigned)KAFS_FORMAT_VERSION);
+      exit(2);
+    }
+  }
+
+  kafs_logblksize_t log_blksize = kafs_sb_log_blksize_get(&sbdisk);
+  kafs_blksize_t blksize = 1u << log_blksize;
+  kafs_blksize_t blksizemask = blksize - 1u;
+  kafs_inocnt_t inocnt = kafs_inocnt_stoh(sbdisk.s_inocnt);
+  kafs_blkcnt_t r_blkcnt = kafs_blkcnt_stoh(sbdisk.s_r_blkcnt);
+
+  off_t mapsize = 0;
+  mapsize += sizeof(kafs_ssuperblock_t);
+  mapsize = (mapsize + blksizemask) & ~blksizemask;
+  void *blkmask_off = (void *)mapsize;
+  assert(sizeof(kafs_blkmask_t) <= 8);
+  mapsize += (r_blkcnt + 7) >> 3;
+  mapsize = (mapsize + 7) & ~7;
+  mapsize = (mapsize + blksizemask) & ~blksizemask;
+  void *inotbl_off = (void *)mapsize;
+  mapsize += (off_t)kafs_inode_table_bytes_for_format(kafs_sb_format_version_get(&sbdisk), inocnt);
+  mapsize = (mapsize + blksizemask) & ~blksizemask;
+
+  off_t imgsize = (off_t)r_blkcnt << log_blksize;
+  {
+    uint64_t idx_off = kafs_sb_hrl_index_offset_get(&sbdisk);
+    uint64_t idx_size = kafs_sb_hrl_index_size_get(&sbdisk);
+    uint64_t ent_off = kafs_sb_hrl_entry_offset_get(&sbdisk);
+    uint64_t ent_cnt = kafs_sb_hrl_entry_cnt_get(&sbdisk);
+    uint64_t ent_size = ent_cnt * (uint64_t)sizeof(kafs_hrl_entry_t);
+    uint64_t j_off = kafs_sb_journal_offset_get(&sbdisk);
+    uint64_t j_size = kafs_sb_journal_size_get(&sbdisk);
+    uint64_t p_off = kafs_sb_pendinglog_offset_get(&sbdisk);
+    uint64_t p_size = kafs_sb_pendinglog_size_get(&sbdisk);
+    uint64_t end1 = (idx_off && idx_size) ? (idx_off + idx_size) : 0;
+    uint64_t end2 = (ent_off && ent_size) ? (ent_off + ent_size) : 0;
+    uint64_t end3 = (j_off && j_size) ? (j_off + j_size) : 0;
+    uint64_t end4 = (p_off && p_size) ? (p_off + p_size) : 0;
+    uint64_t max_end = end1;
+    if (end2 > max_end)
+      max_end = end2;
+    if (end3 > max_end)
+      max_end = end3;
+    if (end4 > max_end)
+      max_end = end4;
+    if ((off_t)max_end > imgsize)
+      imgsize = (off_t)max_end;
+    imgsize = (imgsize + blksizemask) & ~blksizemask;
+  }
+
+  ctx->c_img_base = mmap(NULL, imgsize, PROT_READ | PROT_WRITE, MAP_SHARED, ctx->c_fd, 0);
+  if (ctx->c_img_base == MAP_FAILED)
+  {
+    perror("mmap");
+    exit(2);
+  }
+  ctx->c_img_size = (size_t)imgsize;
+  ctx->c_superblock = (kafs_ssuperblock_t *)ctx->c_img_base;
+  ctx->c_mapsize = (size_t)mapsize;
+  ctx->c_blkmasktbl = (void *)ctx->c_superblock + (intptr_t)blkmask_off;
+  ctx->c_inotbl = (void *)ctx->c_superblock + (intptr_t)inotbl_off;
+  if (!kafs_ctx_runtime_mount_supported(ctx))
+  {
+    fprintf(stderr, "unsupported format version: %u (runtime admission failed).\n", fmt_ver);
+    exit(2);
+  }
+  if (kafs_ctx_validate_runtime_mount_state(ctx) != 0)
+  {
+    fprintf(stderr, "invalid v5 tail metadata region; refusing runtime mount.\n");
+    exit(2);
+  }
+
+  ctx->c_diag_log_fd = -1;
+  ctx->c_ino_epoch = calloc((size_t)inocnt, sizeof(uint32_t));
+  if (ctx->c_ino_epoch)
+  {
+    for (kafs_inocnt_t i = 0; i < inocnt; ++i)
+      ctx->c_ino_epoch[i] = 1u;
+  }
+  if (kafs_extra_diag_enabled())
+  {
+    ctx->c_diag_create_seq = calloc((size_t)inocnt, sizeof(uint64_t));
+    ctx->c_diag_create_mode = calloc((size_t)inocnt, sizeof(uint16_t));
+    ctx->c_diag_create_first_write_seen = calloc((size_t)inocnt, sizeof(uint8_t));
+    ctx->c_diag_create_paths = calloc((size_t)inocnt, KAFS_DIAG_CREATE_PATH_MAX);
+    if (!ctx->c_diag_create_seq || !ctx->c_diag_create_mode ||
+        !ctx->c_diag_create_first_write_seen || !ctx->c_diag_create_paths)
+    {
+      free(ctx->c_diag_create_seq);
+      free(ctx->c_diag_create_mode);
+      free(ctx->c_diag_create_first_write_seen);
+      free(ctx->c_diag_create_paths);
+      ctx->c_diag_create_seq = NULL;
+      ctx->c_diag_create_mode = NULL;
+      ctx->c_diag_create_first_write_seen = NULL;
+      ctx->c_diag_create_paths = NULL;
+    }
+    ctx->c_diag_create_seq_next = 0;
+  }
+  kafs_diag_log_open(ctx, image_path);
+  ctx->c_alloc_v3_summary_dirty = 1;
+
+  (void)kafs_hrl_open(ctx);
+  (void)kafs_journal_init(ctx, image_path);
+  ctx->c_meta_delta_enabled = (uint32_t)kafs_journal_is_enabled(ctx);
+  if (ctx->c_meta_delta_enabled)
+  {
+    size_t bits = sizeof(kafs_blkmask_t) * 8u;
+    size_t words = ((size_t)r_blkcnt + bits - 1u) / bits;
+    ctx->c_meta_bitmap_words = calloc(words, sizeof(kafs_blkmask_t));
+    ctx->c_meta_bitmap_dirty = calloc(words, sizeof(uint8_t));
+    if (!ctx->c_meta_bitmap_words || !ctx->c_meta_bitmap_dirty)
+    {
+      free(ctx->c_meta_bitmap_words);
+      free(ctx->c_meta_bitmap_dirty);
+      ctx->c_meta_bitmap_words = NULL;
+      ctx->c_meta_bitmap_dirty = NULL;
+      ctx->c_meta_bitmap_wordcnt = 0;
+      ctx->c_meta_bitmap_dirty_count = 0;
+      ctx->c_meta_bitmap_words_enabled = 0;
+      ctx->c_meta_delta_enabled = 0;
+    }
+    else
+    {
+      memcpy(ctx->c_meta_bitmap_words, ctx->c_blkmasktbl, words * sizeof(kafs_blkmask_t));
+      ctx->c_meta_bitmap_wordcnt = words;
+      ctx->c_meta_bitmap_dirty_count = 0;
+      ctx->c_meta_bitmap_words_enabled = 1u;
+    }
+  }
+
+  (void)kafs_journal_replay(ctx, NULL, NULL);
+  (void)kafs_pendinglog_init_or_load(ctx);
+  if (ctx->c_pendinglog_enabled)
+  {
+    (void)kafs_pendinglog_replay_mount(ctx);
+    kafs_journal_note(ctx, "PENDINGLOG", "loaded entries=%u cap=%u", kafs_pendinglog_count(ctx),
+                      ctx->c_pendinglog_capacity);
+  }
+
+  struct flock lk = {0};
+  lk.l_type = F_WRLCK;
+  lk.l_whence = SEEK_SET;
+  lk.l_start = 0;
+  lk.l_len = 0;
+  if (fcntl(ctx->c_fd, F_SETLK, &lk) == -1)
+  {
+    perror("fcntl(F_SETLK)");
+    fprintf(stderr, "image '%s' is busy (already mounted?).\n", image_path);
+    exit(2);
+  }
+}
+
 static int kafs_main_cleanup(kafs_context_t *ctx, char *hotplug_uds_path, int rc)
 {
   kafs_bg_dedup_worker_stop(ctx);
@@ -11410,223 +11625,7 @@ int main(int argc, char **argv)
   if (kafs_main_start_hotplug(&ctx, image_path, hotplug_uds, hotplug_back_bin, hotplug_uds_path,
                               sizeof(hotplug_uds_path)) != 0)
     return 2;
-
-  ctx.c_fd = open(image_path, O_RDWR, 0666);
-  if (ctx.c_fd < 0)
-  {
-    perror("open image");
-    fprintf(stderr, "image not found. run mkfs.kafs first.\n");
-    exit(2);
-  }
-  ctx.c_blo_search = 0;
-  ctx.c_ino_search = 0;
-
-  // まずスーパーブロックだけ読み出してレイアウトを決定
-  kafs_ssuperblock_t sbdisk;
-  ssize_t r = pread(ctx.c_fd, &sbdisk, sizeof(sbdisk), 0);
-  if (r != (ssize_t)sizeof(sbdisk))
-  {
-    perror("pread superblock");
-    exit(2);
-  }
-  if (kafs_sb_magic_get(&sbdisk) != KAFS_MAGIC)
-  {
-    fprintf(stderr, "invalid magic. run mkfs.kafs to format.\n");
-    exit(2);
-  }
-  uint32_t fmt_ver = kafs_sb_format_version_get(&sbdisk);
-  if (fmt_ver != KAFS_FORMAT_VERSION)
-  {
-    if (fmt_ver == KAFS_FORMAT_VERSION_V2 || fmt_ver == KAFS_FORMAT_VERSION_V3)
-    {
-      if (auto_migrate)
-      {
-        int mrc = kafs_core_migrate_image(image_path, migrate_yes ? 1 : 0);
-        if (mrc == 0)
-        {
-          fprintf(stderr, "migration completed. please restart mount.\n");
-          exit(0);
-        }
-        if (mrc == 1)
-        {
-          fprintf(stderr, "image already v%u; continue normal mount without --migrate.\n",
-                  (unsigned)KAFS_FORMAT_VERSION);
-          exit(0);
-        }
-        if (mrc == -EPROTONOSUPPORT)
-          fprintf(stderr, "offline migration supports only v2/v3 images.\n");
-        else if (mrc == -ECANCELED)
-          fprintf(stderr, "migration canceled by user.\n");
-        else
-          fprintf(stderr, "migration failed rc=%d.\n", mrc);
-        exit(2);
-      }
-      fprintf(stderr,
-              "unsupported format version: v%u.\n"
-              "Run kafsctl migrate <image> or kafs --migrate before mounting.\n",
-              (unsigned)fmt_ver);
-      exit(2);
-    }
-    else if (fmt_ver != KAFS_FORMAT_VERSION_V5)
-    {
-      fprintf(stderr, "unsupported format version: %u (expected %u).\n", fmt_ver,
-              (unsigned)KAFS_FORMAT_VERSION);
-      exit(2);
-    }
-  }
-  // 読み出し値からレイアウト計算
-  kafs_logblksize_t log_blksize = kafs_sb_log_blksize_get(&sbdisk);
-  kafs_blksize_t blksize = 1u << log_blksize;
-  kafs_blksize_t blksizemask = blksize - 1u;
-  kafs_inocnt_t inocnt = kafs_inocnt_stoh(sbdisk.s_inocnt);
-  kafs_blkcnt_t r_blkcnt = kafs_blkcnt_stoh(sbdisk.s_r_blkcnt);
-
-  off_t mapsize = 0;
-  mapsize += sizeof(kafs_ssuperblock_t);
-  mapsize = (mapsize + blksizemask) & ~blksizemask;
-  void *blkmask_off = (void *)mapsize;
-  assert(sizeof(kafs_blkmask_t) <= 8);
-  mapsize += (r_blkcnt + 7) >> 3;
-  mapsize = (mapsize + 7) & ~7;
-  mapsize = (mapsize + blksizemask) & ~blksizemask;
-  void *inotbl_off = (void *)mapsize;
-  mapsize += (off_t)kafs_inode_table_bytes_for_format(kafs_sb_format_version_get(&sbdisk), inocnt);
-  mapsize = (mapsize + blksizemask) & ~blksizemask;
-  // Full-image mapping size: use r_blkcnt * blksize (and ensure it also covers HRL/journal)
-  off_t imgsize = (off_t)r_blkcnt << log_blksize;
-  {
-    uint64_t idx_off = kafs_sb_hrl_index_offset_get(&sbdisk);
-    uint64_t idx_size = kafs_sb_hrl_index_size_get(&sbdisk);
-    uint64_t ent_off = kafs_sb_hrl_entry_offset_get(&sbdisk);
-    uint64_t ent_cnt = kafs_sb_hrl_entry_cnt_get(&sbdisk);
-    uint64_t ent_size = ent_cnt * (uint64_t)sizeof(kafs_hrl_entry_t);
-    uint64_t j_off = kafs_sb_journal_offset_get(&sbdisk);
-    uint64_t j_size = kafs_sb_journal_size_get(&sbdisk);
-    uint64_t p_off = kafs_sb_pendinglog_offset_get(&sbdisk);
-    uint64_t p_size = kafs_sb_pendinglog_size_get(&sbdisk);
-    uint64_t end1 = (idx_off && idx_size) ? (idx_off + idx_size) : 0;
-    uint64_t end2 = (ent_off && ent_size) ? (ent_off + ent_size) : 0;
-    uint64_t end3 = (j_off && j_size) ? (j_off + j_size) : 0;
-    uint64_t end4 = (p_off && p_size) ? (p_off + p_size) : 0;
-    uint64_t max_end = end1;
-    if (end2 > max_end)
-      max_end = end2;
-    if (end3 > max_end)
-      max_end = end3;
-    if (end4 > max_end)
-      max_end = end4;
-    if ((off_t)max_end > imgsize)
-      imgsize = (off_t)max_end;
-    imgsize = (imgsize + blksizemask) & ~blksizemask;
-  }
-
-  ctx.c_img_base = mmap(NULL, imgsize, PROT_READ | PROT_WRITE, MAP_SHARED, ctx.c_fd, 0);
-  if (ctx.c_img_base == MAP_FAILED)
-  {
-    perror("mmap");
-    exit(2);
-  }
-  ctx.c_img_size = (size_t)imgsize;
-
-  // Keep existing pointers for metadata access
-  ctx.c_superblock = (kafs_ssuperblock_t *)ctx.c_img_base;
-  ctx.c_mapsize = (size_t)mapsize; // metadata region length (subset of img)
-  ctx.c_blkmasktbl = (void *)ctx.c_superblock + (intptr_t)blkmask_off;
-  ctx.c_inotbl = (void *)ctx.c_superblock + (intptr_t)inotbl_off;
-  if (!kafs_ctx_runtime_mount_supported(&ctx))
-  {
-    fprintf(stderr, "unsupported format version: %u (runtime admission failed).\n", fmt_ver);
-    exit(2);
-  }
-  if (kafs_ctx_validate_runtime_mount_state(&ctx) != 0)
-  {
-    fprintf(stderr, "invalid v5 tail metadata region; refusing runtime mount.\n");
-    exit(2);
-  }
-  ctx.c_diag_log_fd = -1;
-  ctx.c_ino_epoch = calloc((size_t)inocnt, sizeof(uint32_t));
-  if (ctx.c_ino_epoch)
-  {
-    for (kafs_inocnt_t i = 0; i < inocnt; ++i)
-      ctx.c_ino_epoch[i] = 1u;
-  }
-  if (kafs_extra_diag_enabled())
-  {
-    ctx.c_diag_create_seq = calloc((size_t)inocnt, sizeof(uint64_t));
-    ctx.c_diag_create_mode = calloc((size_t)inocnt, sizeof(uint16_t));
-    ctx.c_diag_create_first_write_seen = calloc((size_t)inocnt, sizeof(uint8_t));
-    ctx.c_diag_create_paths = calloc((size_t)inocnt, KAFS_DIAG_CREATE_PATH_MAX);
-    if (!ctx.c_diag_create_seq || !ctx.c_diag_create_mode || !ctx.c_diag_create_first_write_seen ||
-        !ctx.c_diag_create_paths)
-    {
-      free(ctx.c_diag_create_seq);
-      free(ctx.c_diag_create_mode);
-      free(ctx.c_diag_create_first_write_seen);
-      free(ctx.c_diag_create_paths);
-      ctx.c_diag_create_seq = NULL;
-      ctx.c_diag_create_mode = NULL;
-      ctx.c_diag_create_first_write_seen = NULL;
-      ctx.c_diag_create_paths = NULL;
-    }
-    ctx.c_diag_create_seq_next = 0;
-  }
-  kafs_diag_log_open(&ctx, image_path);
-  ctx.c_alloc_v3_summary_dirty = 1;
-
-  // HRL オープン
-  (void)kafs_hrl_open(&ctx);
-
-  // Journal 初期化（KAFS_JOURNAL=0/1/パス）
-  (void)kafs_journal_init(&ctx, image_path);
-  ctx.c_meta_delta_enabled = (uint32_t)kafs_journal_is_enabled(&ctx);
-  if (ctx.c_meta_delta_enabled)
-  {
-    size_t bits = sizeof(kafs_blkmask_t) * 8u;
-    size_t words = ((size_t)r_blkcnt + bits - 1u) / bits;
-    ctx.c_meta_bitmap_words = calloc(words, sizeof(kafs_blkmask_t));
-    ctx.c_meta_bitmap_dirty = calloc(words, sizeof(uint8_t));
-    if (!ctx.c_meta_bitmap_words || !ctx.c_meta_bitmap_dirty)
-    {
-      free(ctx.c_meta_bitmap_words);
-      free(ctx.c_meta_bitmap_dirty);
-      ctx.c_meta_bitmap_words = NULL;
-      ctx.c_meta_bitmap_dirty = NULL;
-      ctx.c_meta_bitmap_wordcnt = 0;
-      ctx.c_meta_bitmap_dirty_count = 0;
-      ctx.c_meta_bitmap_words_enabled = 0;
-      ctx.c_meta_delta_enabled = 0;
-    }
-    else
-    {
-      memcpy(ctx.c_meta_bitmap_words, ctx.c_blkmasktbl, words * sizeof(kafs_blkmask_t));
-      ctx.c_meta_bitmap_wordcnt = words;
-      ctx.c_meta_bitmap_dirty_count = 0;
-      ctx.c_meta_bitmap_words_enabled = 1u;
-    }
-  }
-
-  // 起動時リプレイ（in-image のみ対象）。致命的ではなくベストエフォート。
-  (void)kafs_journal_replay(&ctx, NULL, NULL);
-  (void)kafs_pendinglog_init_or_load(&ctx);
-  if (ctx.c_pendinglog_enabled)
-  {
-    (void)kafs_pendinglog_replay_mount(&ctx);
-    kafs_journal_note(&ctx, "PENDINGLOG", "loaded entries=%u cap=%u", kafs_pendinglog_count(&ctx),
-                      ctx.c_pendinglog_capacity);
-  }
-
-  // 画像ファイルに排他ロック（複数プロセスによる同時RW起動を防止）
-  struct flock lk = {0};
-  lk.l_type = F_WRLCK;
-  lk.l_whence = SEEK_SET;
-  lk.l_start = 0;
-  lk.l_len = 0; // whole file
-  if (fcntl(ctx.c_fd, F_SETLK, &lk) == -1)
-  {
-    perror("fcntl(F_SETLK)");
-    fprintf(stderr, "image '%s' is busy (already mounted?).\n", image_path);
-    exit(2);
-  }
+  kafs_main_open_runtime_context(&ctx, image_path, auto_migrate, migrate_yes);
 
   char *argv_fuse[argc_clean + 10];
   char mt_opt_buf[64];

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -10217,6 +10217,9 @@ static int kafs_op_symlink(const char *target, const char *linkpath)
   return 0;
 }
 
+static int kafs_split_parent_basename(const char *path, char *path_copy, const char **dir,
+                                      char **base);
+
 static void kafs_invalidate_path_best_effort(struct fuse_context *fctx, const char *path)
 {
   if (!fctx || !fctx->fuse || !path || path[0] == '\0')
@@ -10224,6 +10227,61 @@ static void kafs_invalidate_path_best_effort(struct fuse_context *fctx, const ch
   int rc = fuse_invalidate_path(fctx->fuse, path);
   if (rc != 0 && rc != -ENOENT)
     kafs_dlog(1, "%s: fuse_invalidate_path(%s) rc=%d\n", __func__, path, rc);
+}
+
+static int kafs_link_validate_source(struct fuse_context *fctx, struct kafs_context *ctx,
+                                     const char *from, kafs_sinode_t **inoent_src)
+{
+  KAFS_CALL(kafs_access, fctx, ctx, from, NULL, F_OK, inoent_src);
+
+  kafs_mode_t src_mode = kafs_ino_mode_get(*inoent_src);
+  if (S_ISDIR(src_mode))
+    return -EPERM;
+  if (!S_ISREG(src_mode) && !S_ISLNK(src_mode))
+    return -EOPNOTSUPP;
+
+  return 0;
+}
+
+static int kafs_link_prepare_destination(struct fuse_context *fctx, struct kafs_context *ctx,
+                                         const char *to, char *to_copy, const char **to_dir,
+                                         char **to_base)
+{
+  int ex = kafs_access(fctx, ctx, to, NULL, F_OK, NULL);
+  if (ex == 0)
+    return -EEXIST;
+  if (ex != -ENOENT)
+    return ex;
+
+  return kafs_split_parent_basename(to, to_copy, to_dir, to_base);
+}
+
+static int kafs_link_apply(struct kafs_context *ctx, kafs_sinode_t *inoent_src,
+                           kafs_sinode_t *inoent_dir, const char *to_base)
+{
+  uint32_t ino_src = (uint32_t)kafs_ctx_ino_no(ctx, inoent_src);
+  uint32_t ino_dir = (uint32_t)kafs_ctx_ino_no(ctx, inoent_dir);
+
+  kafs_inode_lock(ctx, ino_src);
+  kafs_ino_linkcnt_incr(inoent_src);
+  kafs_inode_unlock(ctx, ino_src);
+
+  kafs_inode_lock(ctx, ino_dir);
+  int rc = kafs_dirent_add_nolink(ctx, inoent_dir, (kafs_inocnt_t)ino_src, to_base);
+  kafs_inode_unlock(ctx, ino_dir);
+
+  if (rc < 0)
+  {
+    kafs_inode_lock(ctx, ino_src);
+    (void)kafs_ino_linkcnt_decr(inoent_src);
+    kafs_inode_unlock(ctx, ino_src);
+    return rc;
+  }
+
+  kafs_inode_lock(ctx, ino_src);
+  kafs_ino_ctime_set(inoent_src, kafs_now());
+  kafs_inode_unlock(ctx, ino_src);
+  return 0;
 }
 
 static int kafs_op_link(const char *from, const char *to)
@@ -10239,29 +10297,16 @@ static int kafs_op_link(const char *from, const char *to)
   struct kafs_context *ctx = fctx->private_data;
 
   kafs_sinode_t *inoent_src;
-  KAFS_CALL(kafs_access, fctx, ctx, from, NULL, F_OK, &inoent_src);
-  kafs_mode_t src_mode = kafs_ino_mode_get(inoent_src);
-  if (S_ISDIR(src_mode))
-    return -EPERM;
-  if (!S_ISREG(src_mode) && !S_ISLNK(src_mode))
-    return -EOPNOTSUPP;
-
-  int ex = kafs_access(fctx, ctx, to, NULL, F_OK, NULL);
-  if (ex == 0)
-    return -EEXIST;
-  if (ex != -ENOENT)
-    return ex;
+  int rc = kafs_link_validate_source(fctx, ctx, from, &inoent_src);
+  if (rc < 0)
+    return rc;
 
   char to_copy[strlen(to) + 1];
-  strcpy(to_copy, to);
-  const char *to_dir = to_copy;
-  char *to_base = strrchr(to_copy, '/');
-  if (to_dir == to_base)
-    to_dir = "/";
-  *to_base = '\0';
-  to_base++;
-  if (to_base[0] == '\0' || strcmp(to_base, ".") == 0 || strcmp(to_base, "..") == 0)
-    return -EINVAL;
+  const char *to_dir;
+  char *to_base;
+  rc = kafs_link_prepare_destination(fctx, ctx, to, to_copy, &to_dir, &to_base);
+  if (rc < 0)
+    return rc;
 
   uint64_t jseq = kafs_journal_begin(ctx, "LINK", "from=%s to=%s", from, to);
 
@@ -10273,28 +10318,12 @@ static int kafs_op_link(const char *from, const char *to)
     return arc;
   }
 
-  uint32_t ino_src = (uint32_t)kafs_ctx_ino_no(ctx, inoent_src);
-  uint32_t ino_dir = (uint32_t)kafs_ctx_ino_no(ctx, inoent_dir);
-  kafs_inode_lock(ctx, ino_src);
-  kafs_ino_linkcnt_incr(inoent_src);
-  kafs_inode_unlock(ctx, ino_src);
-
-  kafs_inode_lock(ctx, ino_dir);
-  int rc = kafs_dirent_add_nolink(ctx, inoent_dir, (kafs_inocnt_t)ino_src, to_base);
-  kafs_inode_unlock(ctx, ino_dir);
-
+  rc = kafs_link_apply(ctx, inoent_src, inoent_dir, to_base);
   if (rc < 0)
   {
-    kafs_inode_lock(ctx, ino_src);
-    (void)kafs_ino_linkcnt_decr(inoent_src);
-    kafs_inode_unlock(ctx, ino_src);
     kafs_journal_abort(ctx, jseq, "dirent_add=%d", rc);
     return rc;
   }
-
-  kafs_inode_lock(ctx, ino_src);
-  kafs_ino_ctime_set(inoent_src, kafs_now());
-  kafs_inode_unlock(ctx, ino_src);
 
   kafs_journal_commit(ctx, jseq);
   kafs_invalidate_path_best_effort(fctx, from);

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -9023,6 +9023,57 @@ static int kafs_op_read(const char *path, char *buf, size_t size, off_t offset,
   return rr;
 }
 
+static int kafs_op_write_ctl(struct kafs_context *ctx, struct fuse_file_info *fi, const char *buf,
+                             size_t size, off_t offset)
+{
+  kafs_ctl_session_t *sess = (kafs_ctl_session_t *)(uintptr_t)fi->fh;
+  if (!sess)
+    return -EIO;
+  if (offset != 0)
+    return -EINVAL;
+  if (size > KAFS_CTL_MAX_REQ)
+    return -EMSGSIZE;
+
+  int rc = kafs_ctl_handle_request(ctx, sess, (const unsigned char *)buf, size);
+  return (rc < 0) ? rc : (int)size;
+}
+
+static int kafs_op_write_fallback(struct kafs_context *ctx, const char *path, const char *buf,
+                                  size_t size, off_t offset, kafs_inocnt_t ino)
+{
+  kafs_inode_lock(ctx, (uint32_t)ino);
+  kafs_sinode_t *inoent = kafs_ctx_inode(ctx, ino);
+  kafs_mode_t mode = kafs_ino_mode_get(inoent);
+  if (S_ISDIR(mode))
+  {
+    kafs_inode_unlock(ctx, (uint32_t)ino);
+    kafs_log(KAFS_LOG_ERR,
+             "%s: rejecting write to directory path=%s ino=%" PRIuFAST32
+             " size=%zu off=%" PRIuFAST64 " mode=%o\n",
+             __func__, path ? path : "(null)", (uint32_t)ino, size, (uint64_t)offset,
+             (unsigned)mode);
+    return -EISDIR;
+  }
+
+  kafs_diag_write_scope_t write_scope =
+      kafs_diag_write_scope_enter(path ? path : "(null)", (uint32_t)ino);
+  int rc_write = kafs_pwrite(ctx, inoent, buf, size, offset);
+  kafs_diag_write_scope_leave(write_scope);
+  kafs_inode_unlock(ctx, (uint32_t)ino);
+
+  if (rc_write < 0)
+  {
+    kafs_log(KAFS_LOG_WARNING,
+             "%s: pwrite failed path=%s ino=%" PRIuFAST32 " size=%zu off=%" PRIuFAST64 " rc=%d\n",
+             __func__, path ? path : "(null)", (uint32_t)ino, size, (uint64_t)offset, rc_write);
+  }
+  kafs_dlog(2,
+            "%s: exit rc=%d path=%s ino=%" PRIuFAST32 " size=%zu off=%" PRIuFAST64
+            " hotplug=fallback\n",
+            __func__, rc_write, path ? path : "(null)", (uint32_t)ino, size, (uint64_t)offset);
+  return rc_write;
+}
+
 static int kafs_op_write(const char *path, const char *buf, size_t size, off_t offset,
                          struct fuse_file_info *fi)
 {
@@ -9031,17 +9082,7 @@ static int kafs_op_write(const char *path, const char *buf, size_t size, off_t o
   struct fuse_context *fctx = fuse_get_context();
   struct kafs_context *ctx = fctx->private_data;
   if (kafs_is_ctl_path(path))
-  {
-    kafs_ctl_session_t *sess = (kafs_ctl_session_t *)(uintptr_t)fi->fh;
-    if (!sess)
-      return -EIO;
-    if (offset != 0)
-      return -EINVAL;
-    if (size > KAFS_CTL_MAX_REQ)
-      return -EMSGSIZE;
-    int rc = kafs_ctl_handle_request(ctx, sess, (const unsigned char *)buf, size);
-    return (rc < 0) ? rc : (int)size;
-  }
+    return kafs_op_write_ctl(ctx, fi, buf, size, offset);
   kafs_inocnt_t ino = fi->fh;
   if ((fi->flags & O_ACCMODE) == O_RDONLY)
   {
@@ -9069,35 +9110,7 @@ static int kafs_op_write(const char *path, const char *buf, size_t size, off_t o
         __func__, rc_hp, path ? path : "(null)", ino, size, (uint64_t)offset);
     return (int)rc_hp;
   }
-  kafs_inode_lock(ctx, (uint32_t)ino);
-  kafs_sinode_t *inoent = kafs_ctx_inode(ctx, ino);
-  kafs_mode_t mode = kafs_ino_mode_get(inoent);
-  if (S_ISDIR(mode))
-  {
-    kafs_inode_unlock(ctx, (uint32_t)ino);
-    kafs_log(KAFS_LOG_ERR,
-             "%s: rejecting write to directory path=%s ino=%" PRIuFAST32
-             " size=%zu off=%" PRIuFAST64 " mode=%o\n",
-             __func__, path ? path : "(null)", (uint32_t)ino, size, (uint64_t)offset,
-             (unsigned)mode);
-    return -EISDIR;
-  }
-  kafs_diag_write_scope_t write_scope =
-      kafs_diag_write_scope_enter(path ? path : "(null)", (uint32_t)ino);
-  int rc_write = kafs_pwrite(ctx, inoent, buf, size, offset);
-  kafs_diag_write_scope_leave(write_scope);
-  kafs_inode_unlock(ctx, (uint32_t)ino);
-  if (rc_write < 0)
-  {
-    kafs_log(KAFS_LOG_WARNING,
-             "%s: pwrite failed path=%s ino=%" PRIuFAST32 " size=%zu off=%" PRIuFAST64 " rc=%d\n",
-             __func__, path ? path : "(null)", (uint32_t)ino, size, (uint64_t)offset, rc_write);
-  }
-  kafs_dlog(2,
-            "%s: exit rc=%d path=%s ino=%" PRIuFAST32 " size=%zu off=%" PRIuFAST64
-            " hotplug=fallback\n",
-            __func__, rc_write, path ? path : "(null)", (uint32_t)ino, size, (uint64_t)offset);
-  return rc_write;
+  return kafs_op_write_fallback(ctx, path, buf, size, offset, ino);
 }
 
 static int kafs_op_utimens(const char *path, const struct timespec tv[2], struct fuse_file_info *fi)

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -7362,6 +7362,81 @@ static int kafs_copy_share_one_iblk_locked(kafs_context_t *ctx, kafs_sinode_t *s
                                            kafs_sinode_t *dst, kafs_iblkcnt_t src_iblo,
                                            kafs_iblkcnt_t dst_iblo, uint32_t ino_dst);
 
+static int kafs_copy_regular_try_share_locked(kafs_context_t *ctx, kafs_sinode_t *ino_in,
+                                              kafs_sinode_t *ino_out, uint32_t ino_dst,
+                                              off_t offset_in, off_t offset_out,
+                                              kafs_off_t dst_size, int *dst_is_block_backed,
+                                              int *dst_empty_converted,
+                                              kafs_logblksize_t log_blksize, kafs_blksize_t blksize,
+                                              kafs_off_t max, kafs_off_t *done)
+{
+  kafs_off_t src_off = (kafs_off_t)offset_in + *done;
+  kafs_off_t dst_off = (kafs_off_t)offset_out + *done;
+  kafs_off_t remain = max - *done;
+
+  if (ctx->c_hrl_bucket_cnt == 0 || remain < (kafs_off_t)blksize ||
+      (src_off & ((kafs_off_t)blksize - 1)) != 0 || (dst_off & ((kafs_off_t)blksize - 1)) != 0)
+  {
+    __atomic_add_fetch(&ctx->c_stat_copy_share_skip_unaligned, 1u, __ATOMIC_RELAXED);
+    return 0;
+  }
+
+  if (!*dst_is_block_backed)
+  {
+    if (dst_size == 0 && (kafs_off_t)offset_out == 0)
+    {
+      memset(ino_out->i_blkreftbl, 0, sizeof(ino_out->i_blkreftbl));
+      *dst_is_block_backed = 1;
+      *dst_empty_converted = 1;
+    }
+    else
+    {
+      __atomic_add_fetch(&ctx->c_stat_copy_share_skip_dst_inline, 1u, __ATOMIC_RELAXED);
+      return 0;
+    }
+  }
+
+  size_t blocks = (size_t)(remain >> log_blksize);
+  __atomic_add_fetch(&ctx->c_stat_copy_share_attempt_blocks, (uint64_t)blocks, __ATOMIC_RELAXED);
+  size_t copied_blocks = 0;
+  for (size_t i = 0; i < blocks; ++i)
+  {
+    kafs_iblkcnt_t src_iblo = (kafs_iblkcnt_t)(src_off >> log_blksize) + (kafs_iblkcnt_t)i;
+    kafs_iblkcnt_t dst_iblo = (kafs_iblkcnt_t)(dst_off >> log_blksize) + (kafs_iblkcnt_t)i;
+    int frc = kafs_copy_share_one_iblk_locked(ctx, ino_in, ino_out, src_iblo, dst_iblo, ino_dst);
+    if (frc == -EAGAIN)
+      break;
+    if (frc < 0)
+      return frc;
+    copied_blocks++;
+    *done += (kafs_off_t)blksize;
+  }
+
+  if (copied_blocks > 0)
+  {
+    kafs_off_t end = (kafs_off_t)offset_out + *done;
+    if (kafs_ino_size_get(ino_out) < end)
+      kafs_ino_size_set(ino_out, end);
+    return 1;
+  }
+
+  if (*dst_empty_converted)
+    memset(ino_out->i_blkreftbl, 0, sizeof(ino_out->i_blkreftbl));
+  return 0;
+}
+
+static ssize_t kafs_copy_regular_buffered_step(kafs_context_t *ctx, kafs_sinode_t *ino_in,
+                                               kafs_sinode_t *ino_out, char *buf, size_t bufsz,
+                                               off_t offset_in, off_t offset_out, kafs_off_t max,
+                                               kafs_off_t done)
+{
+  size_t want = (size_t)((max - done) < (kafs_off_t)bufsz ? (max - done) : (kafs_off_t)bufsz);
+  ssize_t r = kafs_pread(ctx, ino_in, buf, (kafs_off_t)want, (kafs_off_t)offset_in + done);
+  if (r <= 0)
+    return r;
+  return kafs_pwrite(ctx, ino_out, buf, (kafs_off_t)r, (kafs_off_t)offset_out + done);
+}
+
 static ssize_t kafs_copy_regular_range(kafs_context_t *ctx, kafs_sinode_t *ino_in,
                                        kafs_sinode_t *ino_out, off_t offset_in, off_t offset_out,
                                        size_t size)
@@ -7412,82 +7487,21 @@ static ssize_t kafs_copy_regular_range(kafs_context_t *ctx, kafs_sinode_t *ino_i
   kafs_off_t done = 0;
   while (done < max)
   {
-    kafs_off_t src_off = (kafs_off_t)offset_in + done;
-    kafs_off_t dst_off = (kafs_off_t)offset_out + done;
-    kafs_off_t remain = max - done;
-
-    if (ctx->c_hrl_bucket_cnt != 0 && remain >= (kafs_off_t)blksize &&
-        ((src_off & ((kafs_off_t)blksize - 1)) == 0) &&
-        ((dst_off & ((kafs_off_t)blksize - 1)) == 0))
-    {
-      if (!dst_is_block_backed)
-      {
-        if (dst_size == 0 && (kafs_off_t)offset_out == 0)
-        {
-          memset(ino_out->i_blkreftbl, 0, sizeof(ino_out->i_blkreftbl));
-          dst_is_block_backed = 1;
-          dst_empty_converted = 1;
-        }
-        else
-        {
-          __atomic_add_fetch(&ctx->c_stat_copy_share_skip_dst_inline, 1u, __ATOMIC_RELAXED);
-        }
-      }
-
-      if (dst_is_block_backed)
-      {
-        size_t blocks = (size_t)(remain >> log_blksize);
-        __atomic_add_fetch(&ctx->c_stat_copy_share_attempt_blocks, (uint64_t)blocks,
-                           __ATOMIC_RELAXED);
-        size_t copied_blocks = 0;
-        for (size_t i = 0; i < blocks; ++i)
-        {
-          kafs_iblkcnt_t src_iblo = (kafs_iblkcnt_t)(src_off >> log_blksize) + (kafs_iblkcnt_t)i;
-          kafs_iblkcnt_t dst_iblo = (kafs_iblkcnt_t)(dst_off >> log_blksize) + (kafs_iblkcnt_t)i;
-          int frc =
-              kafs_copy_share_one_iblk_locked(ctx, ino_in, ino_out, src_iblo, dst_iblo, ino_dst);
-          if (frc == -EAGAIN)
-            break;
-          if (frc < 0)
-          {
-            free(buf);
-            kafs_inode_unlock(ctx, ino_src);
-            kafs_inode_unlock(ctx, ino_dst);
-            return frc;
-          }
-          copied_blocks++;
-          done += (kafs_off_t)blksize;
-        }
-
-        if (copied_blocks > 0)
-        {
-          kafs_off_t end = (kafs_off_t)offset_out + done;
-          if (kafs_ino_size_get(ino_out) < end)
-            kafs_ino_size_set(ino_out, end);
-          continue;
-        }
-
-        if (dst_empty_converted)
-          memset(ino_out->i_blkreftbl, 0, sizeof(ino_out->i_blkreftbl));
-      }
-    }
-    else
-    {
-      __atomic_add_fetch(&ctx->c_stat_copy_share_skip_unaligned, 1u, __ATOMIC_RELAXED);
-    }
-
-    size_t want = (size_t)((max - done) < (kafs_off_t)bufsz ? (max - done) : (kafs_off_t)bufsz);
-    ssize_t r = kafs_pread(ctx, ino_in, buf, (kafs_off_t)want, (kafs_off_t)offset_in + done);
-    if (r < 0)
+    int src = kafs_copy_regular_try_share_locked(
+        ctx, ino_in, ino_out, ino_dst, offset_in, offset_out, dst_size, &dst_is_block_backed,
+        &dst_empty_converted, log_blksize, blksize, max, &done);
+    if (src < 0)
     {
       free(buf);
       kafs_inode_unlock(ctx, ino_src);
       kafs_inode_unlock(ctx, ino_dst);
-      return r;
+      return src;
     }
-    if (r == 0)
-      break;
-    ssize_t w = kafs_pwrite(ctx, ino_out, buf, (kafs_off_t)r, (kafs_off_t)offset_out + done);
+    if (src > 0)
+      continue;
+
+    ssize_t w = kafs_copy_regular_buffered_step(ctx, ino_in, ino_out, buf, bufsz, offset_in,
+                                                offset_out, max, done);
     if (w < 0)
     {
       free(buf);
@@ -7495,6 +7509,8 @@ static ssize_t kafs_copy_regular_range(kafs_context_t *ctx, kafs_sinode_t *ino_i
       kafs_inode_unlock(ctx, ino_dst);
       return w;
     }
+    if (w == 0)
+      break;
     done += w;
   }
 

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -27,6 +27,7 @@
 #include <sys/mman.h>
 #include <sys/statvfs.h>
 #include <sys/resource.h>
+
 #include <sys/time.h>
 #include <sys/un.h>
 #include <stdlib.h>
@@ -11314,78 +11315,58 @@ static void kafs_main_log_runtime_options(kafs_context_t *ctx, kafs_bool_t write
   }
 }
 
-static void kafs_main_open_runtime_context(kafs_context_t *ctx, const char *image_path,
-                                           kafs_bool_t auto_migrate, kafs_bool_t migrate_yes)
+static void kafs_main_validate_image_format(const char *image_path, uint32_t fmt_ver,
+                                            kafs_bool_t auto_migrate, kafs_bool_t migrate_yes)
 {
-  ctx->c_fd = open(image_path, O_RDWR, 0666);
-  if (ctx->c_fd < 0)
+  if (fmt_ver == KAFS_FORMAT_VERSION)
+    return;
+  if (fmt_ver == KAFS_FORMAT_VERSION_V2 || fmt_ver == KAFS_FORMAT_VERSION_V3)
   {
-    perror("open image");
-    fprintf(stderr, "image not found. run mkfs.kafs first.\n");
-    exit(2);
-  }
-  ctx->c_blo_search = 0;
-  ctx->c_ino_search = 0;
-
-  kafs_ssuperblock_t sbdisk;
-  ssize_t r = pread(ctx->c_fd, &sbdisk, sizeof(sbdisk), 0);
-  if (r != (ssize_t)sizeof(sbdisk))
-  {
-    perror("pread superblock");
-    exit(2);
-  }
-  if (kafs_sb_magic_get(&sbdisk) != KAFS_MAGIC)
-  {
-    fprintf(stderr, "invalid magic. run mkfs.kafs to format.\n");
-    exit(2);
-  }
-
-  uint32_t fmt_ver = kafs_sb_format_version_get(&sbdisk);
-  if (fmt_ver != KAFS_FORMAT_VERSION)
-  {
-    if (fmt_ver == KAFS_FORMAT_VERSION_V2 || fmt_ver == KAFS_FORMAT_VERSION_V3)
+    if (auto_migrate)
     {
-      if (auto_migrate)
+      int mrc = kafs_core_migrate_image(image_path, migrate_yes ? 1 : 0);
+      if (mrc == 0)
       {
-        int mrc = kafs_core_migrate_image(image_path, migrate_yes ? 1 : 0);
-        if (mrc == 0)
-        {
-          fprintf(stderr, "migration completed. please restart mount.\n");
-          exit(0);
-        }
-        if (mrc == 1)
-        {
-          fprintf(stderr, "image already v%u; continue normal mount without --migrate.\n",
-                  (unsigned)KAFS_FORMAT_VERSION);
-          exit(0);
-        }
-        if (mrc == -EPROTONOSUPPORT)
-          fprintf(stderr, "offline migration supports only v2/v3 images.\n");
-        else if (mrc == -ECANCELED)
-          fprintf(stderr, "migration canceled by user.\n");
-        else
-          fprintf(stderr, "migration failed rc=%d.\n", mrc);
-        exit(2);
+        fprintf(stderr, "migration completed. please restart mount.\n");
+        exit(0);
       }
-      fprintf(stderr,
-              "unsupported format version: v%u.\n"
-              "Run kafsctl migrate <image> or kafs --migrate before mounting.\n",
-              (unsigned)fmt_ver);
+      if (mrc == 1)
+      {
+        fprintf(stderr, "image already v%u; continue normal mount without --migrate.\n",
+                (unsigned)KAFS_FORMAT_VERSION);
+        exit(0);
+      }
+      if (mrc == -EPROTONOSUPPORT)
+        fprintf(stderr, "offline migration supports only v2/v3 images.\n");
+      else if (mrc == -ECANCELED)
+        fprintf(stderr, "migration canceled by user.\n");
+      else
+        fprintf(stderr, "migration failed rc=%d.\n", mrc);
       exit(2);
     }
-    if (fmt_ver != KAFS_FORMAT_VERSION_V5)
-    {
-      fprintf(stderr, "unsupported format version: %u (expected %u).\n", fmt_ver,
-              (unsigned)KAFS_FORMAT_VERSION);
-      exit(2);
-    }
+    fprintf(stderr,
+            "unsupported format version: v%u.\n"
+            "Run kafsctl migrate <image> or kafs --migrate before mounting.\n",
+            (unsigned)fmt_ver);
+    exit(2);
   }
+  if (fmt_ver != KAFS_FORMAT_VERSION_V5)
+  {
+    fprintf(stderr, "unsupported format version: %u (expected %u).\n", fmt_ver,
+            (unsigned)KAFS_FORMAT_VERSION);
+    exit(2);
+  }
+}
 
-  kafs_logblksize_t log_blksize = kafs_sb_log_blksize_get(&sbdisk);
+static void kafs_main_map_runtime_image(kafs_context_t *ctx, const kafs_ssuperblock_t *sbdisk,
+                                        uint32_t fmt_ver, kafs_inocnt_t *inocnt_out,
+                                        kafs_blkcnt_t *r_blkcnt_out)
+{
+  kafs_logblksize_t log_blksize = kafs_sb_log_blksize_get(sbdisk);
   kafs_blksize_t blksize = 1u << log_blksize;
   kafs_blksize_t blksizemask = blksize - 1u;
-  kafs_inocnt_t inocnt = kafs_inocnt_stoh(sbdisk.s_inocnt);
-  kafs_blkcnt_t r_blkcnt = kafs_blkcnt_stoh(sbdisk.s_r_blkcnt);
+  kafs_inocnt_t inocnt = kafs_inocnt_stoh(sbdisk->s_inocnt);
+  kafs_blkcnt_t r_blkcnt = kafs_blkcnt_stoh(sbdisk->s_r_blkcnt);
 
   off_t mapsize = 0;
   mapsize += sizeof(kafs_ssuperblock_t);
@@ -11396,20 +11377,20 @@ static void kafs_main_open_runtime_context(kafs_context_t *ctx, const char *imag
   mapsize = (mapsize + 7) & ~7;
   mapsize = (mapsize + blksizemask) & ~blksizemask;
   void *inotbl_off = (void *)mapsize;
-  mapsize += (off_t)kafs_inode_table_bytes_for_format(kafs_sb_format_version_get(&sbdisk), inocnt);
+  mapsize += (off_t)kafs_inode_table_bytes_for_format(kafs_sb_format_version_get(sbdisk), inocnt);
   mapsize = (mapsize + blksizemask) & ~blksizemask;
 
   off_t imgsize = (off_t)r_blkcnt << log_blksize;
   {
-    uint64_t idx_off = kafs_sb_hrl_index_offset_get(&sbdisk);
-    uint64_t idx_size = kafs_sb_hrl_index_size_get(&sbdisk);
-    uint64_t ent_off = kafs_sb_hrl_entry_offset_get(&sbdisk);
-    uint64_t ent_cnt = kafs_sb_hrl_entry_cnt_get(&sbdisk);
+    uint64_t idx_off = kafs_sb_hrl_index_offset_get(sbdisk);
+    uint64_t idx_size = kafs_sb_hrl_index_size_get(sbdisk);
+    uint64_t ent_off = kafs_sb_hrl_entry_offset_get(sbdisk);
+    uint64_t ent_cnt = kafs_sb_hrl_entry_cnt_get(sbdisk);
     uint64_t ent_size = ent_cnt * (uint64_t)sizeof(kafs_hrl_entry_t);
-    uint64_t j_off = kafs_sb_journal_offset_get(&sbdisk);
-    uint64_t j_size = kafs_sb_journal_size_get(&sbdisk);
-    uint64_t p_off = kafs_sb_pendinglog_offset_get(&sbdisk);
-    uint64_t p_size = kafs_sb_pendinglog_size_get(&sbdisk);
+    uint64_t j_off = kafs_sb_journal_offset_get(sbdisk);
+    uint64_t j_size = kafs_sb_journal_size_get(sbdisk);
+    uint64_t p_off = kafs_sb_pendinglog_offset_get(sbdisk);
+    uint64_t p_size = kafs_sb_pendinglog_size_get(sbdisk);
     uint64_t end1 = (idx_off && idx_size) ? (idx_off + idx_size) : 0;
     uint64_t end2 = (ent_off && ent_size) ? (ent_off + ent_size) : 0;
     uint64_t end3 = (j_off && j_size) ? (j_off + j_size) : 0;
@@ -11448,6 +11429,13 @@ static void kafs_main_open_runtime_context(kafs_context_t *ctx, const char *imag
     exit(2);
   }
 
+  *inocnt_out = inocnt;
+  *r_blkcnt_out = r_blkcnt;
+}
+
+static void kafs_main_init_runtime_diag(kafs_context_t *ctx, const char *image_path,
+                                        kafs_inocnt_t inocnt)
+{
   ctx->c_diag_log_fd = -1;
   ctx->c_ino_epoch = calloc((size_t)inocnt, sizeof(uint32_t));
   if (ctx->c_ino_epoch)
@@ -11477,7 +11465,11 @@ static void kafs_main_open_runtime_context(kafs_context_t *ctx, const char *imag
   }
   kafs_diag_log_open(ctx, image_path);
   ctx->c_alloc_v3_summary_dirty = 1;
+}
 
+static void kafs_main_init_runtime_journal(kafs_context_t *ctx, const char *image_path,
+                                           kafs_blkcnt_t r_blkcnt)
+{
   (void)kafs_hrl_open(ctx);
   (void)kafs_journal_init(ctx, image_path);
   ctx->c_meta_delta_enabled = (uint32_t)kafs_journal_is_enabled(ctx);
@@ -11515,7 +11507,10 @@ static void kafs_main_open_runtime_context(kafs_context_t *ctx, const char *imag
     kafs_journal_note(ctx, "PENDINGLOG", "loaded entries=%u cap=%u", kafs_pendinglog_count(ctx),
                       ctx->c_pendinglog_capacity);
   }
+}
 
+static void kafs_main_lock_runtime_image(kafs_context_t *ctx, const char *image_path)
+{
   struct flock lk = {0};
   lk.l_type = F_WRLCK;
   lk.l_whence = SEEK_SET;
@@ -11527,6 +11522,42 @@ static void kafs_main_open_runtime_context(kafs_context_t *ctx, const char *imag
     fprintf(stderr, "image '%s' is busy (already mounted?).\n", image_path);
     exit(2);
   }
+}
+
+static void kafs_main_open_runtime_context(kafs_context_t *ctx, const char *image_path,
+                                           kafs_bool_t auto_migrate, kafs_bool_t migrate_yes)
+{
+  ctx->c_fd = open(image_path, O_RDWR, 0666);
+  if (ctx->c_fd < 0)
+  {
+    perror("open image");
+    fprintf(stderr, "image not found. run mkfs.kafs first.\n");
+    exit(2);
+  }
+  ctx->c_blo_search = 0;
+  ctx->c_ino_search = 0;
+
+  kafs_ssuperblock_t sbdisk;
+  ssize_t r = pread(ctx->c_fd, &sbdisk, sizeof(sbdisk), 0);
+  if (r != (ssize_t)sizeof(sbdisk))
+  {
+    perror("pread superblock");
+    exit(2);
+  }
+  if (kafs_sb_magic_get(&sbdisk) != KAFS_MAGIC)
+  {
+    fprintf(stderr, "invalid magic. run mkfs.kafs to format.\n");
+    exit(2);
+  }
+
+  uint32_t fmt_ver = kafs_sb_format_version_get(&sbdisk);
+  kafs_inocnt_t inocnt = 0;
+  kafs_blkcnt_t r_blkcnt = 0;
+  kafs_main_validate_image_format(image_path, fmt_ver, auto_migrate, migrate_yes);
+  kafs_main_map_runtime_image(ctx, &sbdisk, fmt_ver, &inocnt, &r_blkcnt);
+  kafs_main_init_runtime_diag(ctx, image_path, inocnt);
+  kafs_main_init_runtime_journal(ctx, image_path, r_blkcnt);
+  kafs_main_lock_runtime_image(ctx, image_path);
 }
 
 static int kafs_main_cleanup(kafs_context_t *ctx, char *hotplug_uds_path, int rc)
@@ -11572,8 +11603,6 @@ int main(int argc, char **argv)
       kafs_main_collect_args(argc, argv, argv[0], &opts, argv_clean, &argc_clean) != 0)
     return 2;
 
-  // mount(8) helper compatibility: allow "kafs <image> <mountpoint> [FUSE options...]"
-  // When invoked via mount -t fuse.kafs, the image path is typically passed as the first argument.
   if (opts.image_path == NULL && argc_clean >= 3 && argv_clean[1][0] != '-')
   {
     opts.image_path = argv_clean[1];
@@ -11625,6 +11654,7 @@ int main(int argc, char **argv)
   if (kafs_main_start_hotplug(&ctx, image_path, hotplug_uds, hotplug_back_bin, hotplug_uds_path,
                               sizeof(hotplug_uds_path)) != 0)
     return 2;
+
   kafs_main_open_runtime_context(&ctx, image_path, auto_migrate, migrate_yes);
 
   char *argv_fuse[argc_clean + 10];

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -9082,30 +9082,82 @@ static int kafs_fallocate_zero_right_edge(struct kafs_context *ctx, kafs_sinode_
   return kafs_ino_iblk_write(ctx, inoent, iblo, wbuf);
 }
 
-static int kafs_op_fallocate(const char *path, int mode, off_t offset, off_t length,
-                             struct fuse_file_info *fi)
+static int kafs_fallocate_validate_request(const char *path, off_t offset, off_t length,
+                                           kafs_off_t *end_req)
 {
-  struct fuse_context *fctx = fuse_get_context();
-  struct kafs_context *ctx = fctx->private_data;
   if (kafs_is_ctl_path(path))
     return -EACCES;
   if (offset < 0 || length < 0)
     return -EINVAL;
   if (length == 0)
-    return 0;
+    return 1;
 
-  kafs_off_t end_req = (kafs_off_t)offset + (kafs_off_t)length;
-  if (end_req < (kafs_off_t)offset)
+  *end_req = (kafs_off_t)offset + (kafs_off_t)length;
+  if (*end_req < (kafs_off_t)offset)
     return -EOVERFLOW;
 
+  return 0;
+}
+
+static int kafs_fallocate_validate_mode(int mode)
+{
 #ifdef FALLOC_FL_PUNCH_HOLE
   const int supported = FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE;
   if ((mode & ~supported) != 0)
     return -EOPNOTSUPP;
+  return 0;
 #else
   (void)mode;
   return -EOPNOTSUPP;
 #endif
+}
+
+static int kafs_fallocate_punch_locked(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                       uint32_t ino, kafs_off_t offset, kafs_off_t end_req)
+{
+  int rc = 0;
+  kafs_inode_lock(ctx, ino);
+
+  kafs_off_t filesize = kafs_ino_size_get(inoent);
+  if (offset >= filesize)
+    goto fallocate_unlock;
+
+  kafs_off_t end = end_req;
+  if (end > filesize)
+    end = filesize;
+
+  kafs_blksize_t blksize = kafs_sb_blksize_get(ctx->c_superblock);
+  kafs_logblksize_t log_blksize = kafs_sb_log_blksize_get(ctx->c_superblock);
+  rc = kafs_fallocate_zero_left_edge(ctx, inoent, offset, end, blksize, log_blksize);
+  if (rc < 0)
+    goto fallocate_unlock;
+
+  kafs_iblkcnt_t first_full = (kafs_iblkcnt_t)((offset + blksize - 1) >> log_blksize);
+  kafs_iblkcnt_t last_full_excl = (kafs_iblkcnt_t)(end >> log_blksize);
+  rc = kafs_fallocate_release_full_blocks(ctx, inoent, filesize, first_full, last_full_excl);
+  if (rc < 0)
+    goto fallocate_unlock;
+
+  rc = kafs_fallocate_zero_right_edge(ctx, inoent, offset, end, filesize, blksize, log_blksize);
+
+fallocate_unlock:
+  kafs_inode_unlock(ctx, ino);
+  return rc;
+}
+
+static int kafs_op_fallocate(const char *path, int mode, off_t offset, off_t length,
+                             struct fuse_file_info *fi)
+{
+  struct fuse_context *fctx = fuse_get_context();
+  struct kafs_context *ctx = fctx->private_data;
+  kafs_off_t end_req;
+  int rc = kafs_fallocate_validate_request(path, offset, length, &end_req);
+  if (rc != 0)
+    return rc > 0 ? 0 : rc;
+
+  rc = kafs_fallocate_validate_mode(mode);
+  if (rc != 0)
+    return rc;
 
   kafs_sinode_t *inoent;
   KAFS_CALL(kafs_access, fctx, ctx, path, fi, F_OK, &inoent);
@@ -9125,37 +9177,7 @@ static int kafs_op_fallocate(const char *path, int mode, off_t offset, off_t len
     return -EOPNOTSUPP;
 #endif
 
-  kafs_inode_lock(ctx, ino);
-  int rc = 0;
-  kafs_off_t filesize = kafs_ino_size_get(inoent);
-  if ((kafs_off_t)offset >= filesize)
-  {
-    kafs_inode_unlock(ctx, ino);
-    return 0;
-  }
-
-  kafs_off_t end = end_req;
-  if (end > filesize)
-    end = filesize;
-
-  kafs_blksize_t blksize = kafs_sb_blksize_get(ctx->c_superblock);
-  kafs_logblksize_t log_blksize = kafs_sb_log_blksize_get(ctx->c_superblock);
-  rc = kafs_fallocate_zero_left_edge(ctx, inoent, (kafs_off_t)offset, end, blksize, log_blksize);
-  if (rc < 0)
-    goto fallocate_unlock;
-
-  kafs_iblkcnt_t first_full = (kafs_iblkcnt_t)(((kafs_off_t)offset + blksize - 1) >> log_blksize);
-  kafs_iblkcnt_t last_full_excl = (kafs_iblkcnt_t)(end >> log_blksize);
-  rc = kafs_fallocate_release_full_blocks(ctx, inoent, filesize, first_full, last_full_excl);
-  if (rc < 0)
-    goto fallocate_unlock;
-
-  rc = kafs_fallocate_zero_right_edge(ctx, inoent, (kafs_off_t)offset, end, filesize, blksize,
-                                      log_blksize);
-
-fallocate_unlock:
-  kafs_inode_unlock(ctx, ino);
-  return rc;
+  return kafs_fallocate_punch_locked(ctx, inoent, ino, (kafs_off_t)offset, end_req);
 }
 
 static off_t kafs_lseek_find_data_locked(kafs_context_t *ctx, kafs_sinode_t *inoent, uint32_t ino,

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -11059,6 +11059,257 @@ static int kafs_main_validate_options(const kafs_main_options_t *opts)
   return 0;
 }
 
+static void kafs_main_set_mountpoint(kafs_context_t *ctx, const char *mount_arg, char *mnt_abs,
+                                     size_t mnt_abs_size)
+{
+  if (mount_arg && mount_arg[0] == '/')
+  {
+    snprintf(mnt_abs, mnt_abs_size, "%s", mount_arg);
+    ctx->c_mountpoint = mnt_abs;
+    return;
+  }
+
+  char cwd[PATH_MAX];
+  if (getcwd(cwd, sizeof(cwd)) != NULL && mount_arg && mount_arg[0] != '\0')
+  {
+    if ((size_t)snprintf(mnt_abs, mnt_abs_size, "%s/%s", cwd, mount_arg) < mnt_abs_size)
+    {
+      ctx->c_mountpoint = mnt_abs;
+      return;
+    }
+  }
+
+  ctx->c_mountpoint = mount_arg;
+}
+
+static void kafs_main_init_context(kafs_context_t *ctx, const kafs_main_options_t *opts,
+                                   const char *mount_arg, char *mnt_abs, size_t mnt_abs_size)
+{
+  memset(ctx, 0, sizeof(*ctx));
+  kafs_main_set_mountpoint(ctx, mount_arg, mnt_abs, mnt_abs_size);
+
+  ctx->c_hotplug_fd = -1;
+  ctx->c_hotplug_state = KAFS_HOTPLUG_STATE_DISABLED;
+  ctx->c_hotplug_wait_queue_limit = KAFS_HOTPLUG_WAIT_QUEUE_LIMIT_DEFAULT;
+  ctx->c_hotplug_wait_timeout_ms = KAFS_HOTPLUG_WAIT_TIMEOUT_MS_DEFAULT;
+  ctx->c_hotplug_data_mode = KAFS_RPC_DATA_INLINE;
+  ctx->c_hotplug_front_major = KAFS_RPC_HELLO_MAJOR;
+  ctx->c_hotplug_front_minor = KAFS_RPC_HELLO_MINOR;
+  ctx->c_hotplug_front_features = KAFS_RPC_HELLO_FEATURES;
+  ctx->c_hotplug_compat_result = KAFS_HOTPLUG_COMPAT_UNKNOWN;
+
+  ctx->c_pending_worker_prio_mode = opts->pending_worker_prio_mode;
+  ctx->c_pending_worker_nice = opts->pending_worker_nice;
+  ctx->c_pending_worker_prio_base_mode = opts->pending_worker_prio_mode;
+  ctx->c_pending_worker_nice_base = opts->pending_worker_nice;
+  ctx->c_pending_worker_prio_dirty = 1;
+  ctx->c_pending_ttl_soft_ms = opts->pending_ttl_soft_ms;
+  ctx->c_pending_ttl_hard_ms = opts->pending_ttl_hard_ms;
+  ctx->c_pendinglog_capacity = opts->pending_cap_initial;
+  ctx->c_pendinglog_capacity_min = opts->pending_cap_min;
+  ctx->c_pendinglog_capacity_max = opts->pending_cap_max;
+  ctx->c_tombstone_gc_cursor = KAFS_INO_ROOTDIR + 1u;
+
+  ctx->c_bg_dedup_enabled = opts->bg_dedup_scan_enabled;
+  ctx->c_bg_dedup_interval_ms = opts->bg_dedup_interval_ms;
+  ctx->c_bg_dedup_quiet_interval_ms = opts->bg_dedup_quiet_interval_ms;
+  ctx->c_bg_dedup_pressure_interval_ms = opts->bg_dedup_pressure_interval_ms;
+  ctx->c_bg_dedup_start_used_pct = opts->bg_dedup_start_used_pct;
+  ctx->c_bg_dedup_pressure_used_pct = opts->bg_dedup_pressure_used_pct;
+  ctx->c_bg_dedup_worker_prio_mode = opts->bg_dedup_worker_prio_mode;
+  ctx->c_bg_dedup_worker_nice = opts->bg_dedup_worker_nice;
+  ctx->c_bg_dedup_worker_prio_base_mode = opts->bg_dedup_worker_prio_mode;
+  ctx->c_bg_dedup_worker_nice_base = opts->bg_dedup_worker_nice;
+  ctx->c_bg_dedup_worker_prio_dirty = 1;
+  ctx->c_bg_dedup_mode = KAFS_BG_DEDUP_MODE_COLD;
+
+  ctx->c_fsync_policy = opts->fsync_policy;
+}
+
+static void kafs_main_apply_hotplug_env(kafs_context_t *ctx)
+{
+  const char *data_mode = getenv("KAFS_HOTPLUG_DATA_MODE");
+  if (data_mode)
+  {
+    if (strcmp(data_mode, "inline") == 0)
+      ctx->c_hotplug_data_mode = KAFS_RPC_DATA_INLINE;
+    else if (strcmp(data_mode, "plan_only") == 0)
+      ctx->c_hotplug_data_mode = KAFS_RPC_DATA_PLAN_ONLY;
+    else if (strcmp(data_mode, "shm") == 0)
+      ctx->c_hotplug_data_mode = KAFS_RPC_DATA_SHM;
+  }
+
+  const char *wait_timeout_env = getenv("KAFS_HOTPLUG_WAIT_TIMEOUT_MS");
+  if (wait_timeout_env && *wait_timeout_env)
+  {
+    char *endp = NULL;
+    unsigned long v = strtoul(wait_timeout_env, &endp, 10);
+    if (endp && *endp == '\0')
+      ctx->c_hotplug_wait_timeout_ms = (uint32_t)v;
+  }
+
+  const char *wait_limit_env = getenv("KAFS_HOTPLUG_WAIT_QUEUE_LIMIT");
+  if (wait_limit_env && *wait_limit_env)
+  {
+    char *endp = NULL;
+    unsigned long v = strtoul(wait_limit_env, &endp, 10);
+    if (endp && *endp == '\0')
+      ctx->c_hotplug_wait_queue_limit = (uint32_t)v;
+  }
+}
+
+static int kafs_main_start_hotplug(kafs_context_t *ctx, const char *image_path,
+                                   const char *hotplug_uds, const char *hotplug_back_bin,
+                                   char *hotplug_uds_path, size_t hotplug_uds_path_size)
+{
+  if (!hotplug_uds)
+    return 0;
+
+  ctx->c_hotplug_state = KAFS_HOTPLUG_STATE_WAITING;
+  snprintf(ctx->c_hotplug_uds_path, sizeof(ctx->c_hotplug_uds_path), "%s", hotplug_uds);
+  (void)kafs_hotplug_env_set(ctx, "KAFS_HOTPLUG_UDS", hotplug_uds);
+  if (image_path && *image_path)
+    (void)kafs_hotplug_env_set(ctx, "KAFS_IMAGE", image_path);
+  if (hotplug_back_bin && *hotplug_back_bin)
+    (void)kafs_hotplug_env_set(ctx, "KAFS_HOTPLUG_BACK_BIN", hotplug_back_bin);
+
+  if (!ctx->c_hotplug_wait_lock_init)
+  {
+    if (pthread_mutex_init(&ctx->c_hotplug_wait_lock, NULL) == 0 &&
+        pthread_cond_init(&ctx->c_hotplug_wait_cond, NULL) == 0)
+      ctx->c_hotplug_wait_lock_init = 1;
+  }
+
+  if (snprintf(hotplug_uds_path, hotplug_uds_path_size, "%s", hotplug_uds) >=
+      (int)hotplug_uds_path_size)
+  {
+    ctx->c_hotplug_state = KAFS_HOTPLUG_STATE_ERROR;
+    ctx->c_hotplug_last_error = -ENAMETOOLONG;
+    fprintf(stderr, "hotplug: uds path too long\n");
+    return 2;
+  }
+
+  int rc_hp = kafs_hotplug_wait_for_back(ctx, hotplug_uds_path, -1);
+  if (rc_hp != 0)
+  {
+    ctx->c_hotplug_state = KAFS_HOTPLUG_STATE_ERROR;
+    ctx->c_hotplug_last_error = rc_hp;
+    fprintf(stderr, "hotplug: failed to accept back rc=%d\n", rc_hp);
+    return 2;
+  }
+  return 0;
+}
+
+static void kafs_main_build_fuse_argv(char **argv_clean, int argc_clean, kafs_bool_t *enable_mt,
+                                      int saw_max_threads, unsigned mt_cnt_override,
+                                      int mt_cnt_override_set, char **argv_fuse, int *argc_fuse,
+                                      char *mt_opt_buf, size_t mt_opt_buf_size)
+{
+  int saw_single = 0;
+  for (int i = 0; i < argc_clean; ++i)
+  {
+    if (strcmp(argv_clean[i], "-s") == 0)
+    {
+      saw_single = 1;
+      break;
+    }
+    argv_fuse[i] = argv_clean[i];
+  }
+
+  *argc_fuse = argc_clean;
+  if (!*enable_mt && !saw_single)
+    argv_fuse[(*argc_fuse)++] = "-s";
+  if (*enable_mt && saw_single)
+    *enable_mt = KAFS_FALSE;
+  if (kafs_debug_level() >= 3)
+    argv_fuse[(*argc_fuse)++] = "-d";
+
+  if (*enable_mt && !saw_max_threads)
+  {
+    unsigned mt_cnt = 8;
+    if (mt_cnt_override_set)
+    {
+      mt_cnt = mt_cnt_override;
+    }
+    else
+    {
+      const char *mt_env = getenv("KAFS_MAX_THREADS");
+      if (mt_env && *mt_env)
+      {
+        char *endp = NULL;
+        unsigned long v = strtoul(mt_env, &endp, 10);
+        if (endp && *endp == '\0')
+          mt_cnt = (unsigned)v;
+      }
+      if (mt_cnt < 1)
+        mt_cnt = 1;
+      if (mt_cnt > 100000)
+        mt_cnt = 100000;
+    }
+
+    snprintf(mt_opt_buf, mt_opt_buf_size, "max_threads=%u", mt_cnt);
+    argv_fuse[(*argc_fuse)++] = "-o";
+    argv_fuse[(*argc_fuse)++] = mt_opt_buf;
+    kafs_log(KAFS_LOG_INFO, "kafs: enabling multithread with -o %s\n", mt_opt_buf);
+  }
+
+  argv_fuse[*argc_fuse] = NULL;
+}
+
+static void kafs_main_log_runtime_options(kafs_context_t *ctx, kafs_bool_t writeback_cache_enabled,
+                                          kafs_bool_t writeback_cache_explicit,
+                                          kafs_bool_t trim_on_free_enabled,
+                                          kafs_bool_t trim_on_free_explicit, int argc_fuse,
+                                          char **argv_fuse)
+{
+  g_kafs_writeback_cache_enabled = writeback_cache_enabled ? 1 : 0;
+  ctx->c_trim_on_free = trim_on_free_enabled ? 1u : 0u;
+
+  kafs_log(KAFS_LOG_INFO, "kafs: writeback_cache %s (%s)\n",
+           writeback_cache_enabled ? "enabled" : "disabled",
+           writeback_cache_explicit ? "explicit" : "default");
+  kafs_log(KAFS_LOG_INFO, "kafs: trim_on_free %s (%s)\n",
+           trim_on_free_enabled ? "enabled" : "disabled",
+           trim_on_free_explicit ? "explicit" : "default");
+
+  if (kafs_debug_level() >= 1)
+  {
+    kafs_log(KAFS_LOG_INFO, "kafs: fuse argv (%d):\n", argc_fuse);
+    for (int i = 0; i < argc_fuse; ++i)
+      kafs_log(KAFS_LOG_INFO, "  argv[%d]=%s\n", i, argv_fuse[i]);
+  }
+}
+
+static int kafs_main_cleanup(kafs_context_t *ctx, char *hotplug_uds_path, int rc)
+{
+  kafs_bg_dedup_worker_stop(ctx);
+  kafs_pending_worker_stop(ctx);
+  kafs_journal_shutdown(ctx);
+  if (ctx->c_hotplug_fd >= 0)
+    close(ctx->c_hotplug_fd);
+  ctx->c_hotplug_active = 0;
+  if (hotplug_uds_path[0] != '\0')
+    unlink(hotplug_uds_path);
+  if (ctx->c_hotplug_lock_init)
+    pthread_mutex_destroy(&ctx->c_hotplug_lock);
+  if (ctx->c_hotplug_wait_lock_init)
+  {
+    pthread_cond_destroy(&ctx->c_hotplug_wait_cond);
+    pthread_mutex_destroy(&ctx->c_hotplug_wait_lock);
+  }
+  free(ctx->c_meta_bitmap_words);
+  free(ctx->c_meta_bitmap_dirty);
+  free(ctx->c_ino_epoch);
+  free(ctx->c_diag_create_seq);
+  free(ctx->c_diag_create_mode);
+  free(ctx->c_diag_create_first_write_seen);
+  free(ctx->c_diag_create_paths);
+  kafs_diag_log_close(ctx);
+  if (ctx->c_img_base && ctx->c_img_base != MAP_FAILED)
+    munmap(ctx->c_img_base, ctx->c_img_size);
+  return rc;
+}
+
 #ifndef KAFS_NO_MAIN
 int main(int argc, char **argv)
 {
@@ -11108,22 +11359,6 @@ int main(int argc, char **argv)
   unsigned mt_cnt_override = opts.mt_cnt_override;
   int mt_cnt_override_set = opts.mt_cnt_override_set;
   int saw_max_threads = opts.saw_max_threads;
-  uint32_t pending_worker_prio_mode = opts.pending_worker_prio_mode;
-  int pending_worker_nice = opts.pending_worker_nice;
-  uint32_t pending_ttl_soft_ms = opts.pending_ttl_soft_ms;
-  uint32_t pending_ttl_hard_ms = opts.pending_ttl_hard_ms;
-  uint32_t pending_cap_initial = opts.pending_cap_initial;
-  uint32_t pending_cap_min = opts.pending_cap_min;
-  uint32_t pending_cap_max = opts.pending_cap_max;
-  uint32_t bg_dedup_scan_enabled = opts.bg_dedup_scan_enabled;
-  uint32_t bg_dedup_interval_ms = opts.bg_dedup_interval_ms;
-  uint32_t bg_dedup_quiet_interval_ms = opts.bg_dedup_quiet_interval_ms;
-  uint32_t bg_dedup_pressure_interval_ms = opts.bg_dedup_pressure_interval_ms;
-  uint32_t bg_dedup_start_used_pct = opts.bg_dedup_start_used_pct;
-  uint32_t bg_dedup_pressure_used_pct = opts.bg_dedup_pressure_used_pct;
-  uint32_t bg_dedup_worker_prio_mode = opts.bg_dedup_worker_prio_mode;
-  int bg_dedup_worker_nice = opts.bg_dedup_worker_nice;
-  uint32_t fsync_policy = opts.fsync_policy;
   char *hotplug_uds_opt = opts.hotplug_uds_opt;
   char *hotplug_back_bin_opt = opts.hotplug_back_bin_opt;
 
@@ -11131,156 +11366,16 @@ int main(int argc, char **argv)
   static char mnt_abs[PATH_MAX];
   char hotplug_uds_path[sizeof(((struct sockaddr_un *)0)->sun_path)];
   hotplug_uds_path[0] = '\0';
-  // Store mountpoint as an absolute path for /proc fd resolution (FICLONE).
-  if (argv_clean[1] && argv_clean[1][0] == '/')
-  {
-    snprintf(mnt_abs, sizeof(mnt_abs), "%s", argv_clean[1]);
-    ctx.c_mountpoint = mnt_abs;
-  }
-  else
-  {
-    char cwd[PATH_MAX];
-    if (getcwd(cwd, sizeof(cwd)) != NULL && argv_clean[1] && argv_clean[1][0] != '\0')
-    {
-      if ((size_t)snprintf(mnt_abs, sizeof(mnt_abs), "%s/%s", cwd, argv_clean[1]) < sizeof(mnt_abs))
-        ctx.c_mountpoint = mnt_abs;
-      else
-        ctx.c_mountpoint = argv_clean[1];
-    }
-    else
-    {
-      ctx.c_mountpoint = argv_clean[1];
-    }
-  }
-
-  ctx.c_hotplug_fd = -1;
-  ctx.c_hotplug_active = 0;
-  ctx.c_hotplug_lock_init = 0;
-  ctx.c_hotplug_session_id = 0;
-  ctx.c_hotplug_epoch = 0;
-  ctx.c_hotplug_data_mode = KAFS_RPC_DATA_INLINE;
-  ctx.c_hotplug_state = KAFS_HOTPLUG_STATE_DISABLED;
-  ctx.c_hotplug_last_error = 0;
-  ctx.c_hotplug_wait_queue_len = 0;
-  ctx.c_hotplug_wait_queue_limit = KAFS_HOTPLUG_WAIT_QUEUE_LIMIT_DEFAULT;
-  ctx.c_hotplug_wait_timeout_ms = KAFS_HOTPLUG_WAIT_TIMEOUT_MS_DEFAULT;
-  ctx.c_hotplug_wait_lock_init = 0;
-  ctx.c_hotplug_connecting = 0;
-  ctx.c_hotplug_uds_path[0] = '\0';
-  ctx.c_hotplug_front_major = KAFS_RPC_HELLO_MAJOR;
-  ctx.c_hotplug_front_minor = KAFS_RPC_HELLO_MINOR;
-  ctx.c_hotplug_front_features = KAFS_RPC_HELLO_FEATURES;
-  ctx.c_hotplug_back_major = 0;
-  ctx.c_hotplug_back_minor = 0;
-  ctx.c_hotplug_back_features = 0;
-  ctx.c_hotplug_compat_result = KAFS_HOTPLUG_COMPAT_UNKNOWN;
-  ctx.c_hotplug_compat_reason = 0;
-  ctx.c_pending_worker_prio_mode = pending_worker_prio_mode;
-  ctx.c_pending_worker_nice = pending_worker_nice;
-  ctx.c_pending_worker_prio_base_mode = pending_worker_prio_mode;
-  ctx.c_pending_worker_nice_base = pending_worker_nice;
-  ctx.c_pending_worker_auto_boosted = 0;
-  ctx.c_pending_ttl_soft_ms = pending_ttl_soft_ms;
-  ctx.c_pending_ttl_hard_ms = pending_ttl_hard_ms;
-  ctx.c_pending_oldest_age_ms = 0;
-  ctx.c_pending_ttl_over_soft = 0;
-  ctx.c_pending_ttl_over_hard = 0;
-  ctx.c_pending_worker_prio_apply_error = 0;
-  ctx.c_pending_worker_prio_dirty = 1;
-  ctx.c_pendinglog_capacity = pending_cap_initial;
-  ctx.c_pendinglog_capacity_min = pending_cap_min;
-  ctx.c_pendinglog_capacity_max = pending_cap_max;
-  ctx.c_tombstone_gc_cursor = KAFS_INO_ROOTDIR + 1u;
-  ctx.c_bg_dedup_enabled = bg_dedup_scan_enabled;
-  ctx.c_bg_dedup_interval_ms = bg_dedup_interval_ms;
-  ctx.c_bg_dedup_quiet_interval_ms = bg_dedup_quiet_interval_ms;
-  ctx.c_bg_dedup_pressure_interval_ms = bg_dedup_pressure_interval_ms;
-  ctx.c_bg_dedup_start_used_pct = bg_dedup_start_used_pct;
-  ctx.c_bg_dedup_pressure_used_pct = bg_dedup_pressure_used_pct;
-  ctx.c_bg_dedup_worker_prio_mode = bg_dedup_worker_prio_mode;
-  ctx.c_bg_dedup_worker_nice = bg_dedup_worker_nice;
-  ctx.c_bg_dedup_worker_prio_base_mode = bg_dedup_worker_prio_mode;
-  ctx.c_bg_dedup_worker_nice_base = bg_dedup_worker_nice;
-  ctx.c_bg_dedup_worker_auto_boosted = 0;
-  ctx.c_bg_dedup_worker_prio_apply_error = 0;
-  ctx.c_bg_dedup_worker_prio_dirty = 1;
-  ctx.c_bg_dedup_mode = KAFS_BG_DEDUP_MODE_COLD;
-  ctx.c_bg_dedup_telemetry_valid = 0;
-  ctx.c_bg_dedup_last_scanned_blocks = 0;
-  ctx.c_bg_dedup_last_direct_candidates = 0;
-  ctx.c_bg_dedup_last_replacements = 0;
-  ctx.c_bg_dedup_idle_skip_streak = 0;
-  ctx.c_bg_dedup_cold_start_due_ns = 0;
-  ctx.c_fsync_policy = fsync_policy;
-
-  const char *data_mode = getenv("KAFS_HOTPLUG_DATA_MODE");
-  if (data_mode)
-  {
-    if (strcmp(data_mode, "inline") == 0)
-      ctx.c_hotplug_data_mode = KAFS_RPC_DATA_INLINE;
-    else if (strcmp(data_mode, "plan_only") == 0)
-      ctx.c_hotplug_data_mode = KAFS_RPC_DATA_PLAN_ONLY;
-    else if (strcmp(data_mode, "shm") == 0)
-      ctx.c_hotplug_data_mode = KAFS_RPC_DATA_SHM;
-  }
-
-  const char *wait_timeout_env = getenv("KAFS_HOTPLUG_WAIT_TIMEOUT_MS");
-  if (wait_timeout_env && *wait_timeout_env)
-  {
-    char *endp = NULL;
-    unsigned long v = strtoul(wait_timeout_env, &endp, 10);
-    if (endp && *endp == '\0')
-      ctx.c_hotplug_wait_timeout_ms = (uint32_t)v;
-  }
-
-  const char *wait_limit_env = getenv("KAFS_HOTPLUG_WAIT_QUEUE_LIMIT");
-  if (wait_limit_env && *wait_limit_env)
-  {
-    char *endp = NULL;
-    unsigned long v = strtoul(wait_limit_env, &endp, 10);
-    if (endp && *endp == '\0')
-      ctx.c_hotplug_wait_queue_limit = (uint32_t)v;
-  }
+  kafs_main_init_context(&ctx, &opts, argv_clean[1], mnt_abs, sizeof(mnt_abs));
+  kafs_main_apply_hotplug_env(&ctx);
 
   const char *hotplug_uds =
       hotplug_uds_opt[0] != '\0' ? hotplug_uds_opt : getenv("KAFS_HOTPLUG_UDS");
   const char *hotplug_back_bin =
       hotplug_back_bin_opt[0] != '\0' ? hotplug_back_bin_opt : getenv("KAFS_HOTPLUG_BACK_BIN");
-  if (hotplug_uds)
-  {
-    ctx.c_hotplug_state = KAFS_HOTPLUG_STATE_WAITING;
-    snprintf(ctx.c_hotplug_uds_path, sizeof(ctx.c_hotplug_uds_path), "%s", hotplug_uds);
-    (void)kafs_hotplug_env_set(&ctx, "KAFS_HOTPLUG_UDS", hotplug_uds);
-    if (image_path && *image_path)
-      (void)kafs_hotplug_env_set(&ctx, "KAFS_IMAGE", image_path);
-    if (hotplug_back_bin && *hotplug_back_bin)
-      (void)kafs_hotplug_env_set(&ctx, "KAFS_HOTPLUG_BACK_BIN", hotplug_back_bin);
-    if (!ctx.c_hotplug_wait_lock_init)
-    {
-      if (pthread_mutex_init(&ctx.c_hotplug_wait_lock, NULL) == 0 &&
-          pthread_cond_init(&ctx.c_hotplug_wait_cond, NULL) == 0)
-        ctx.c_hotplug_wait_lock_init = 1;
-    }
-    if (snprintf(hotplug_uds_path, sizeof(hotplug_uds_path), "%s", hotplug_uds) <
-        (int)sizeof(hotplug_uds_path))
-    {
-      int rc_hp = kafs_hotplug_wait_for_back(&ctx, hotplug_uds_path, -1);
-      if (rc_hp != 0)
-      {
-        ctx.c_hotplug_state = KAFS_HOTPLUG_STATE_ERROR;
-        ctx.c_hotplug_last_error = rc_hp;
-        fprintf(stderr, "hotplug: failed to accept back rc=%d\n", rc_hp);
-        return 2;
-      }
-    }
-    else
-    {
-      ctx.c_hotplug_state = KAFS_HOTPLUG_STATE_ERROR;
-      ctx.c_hotplug_last_error = -ENAMETOOLONG;
-      fprintf(stderr, "hotplug: uds path too long\n");
-      return 2;
-    }
-  }
+  if (kafs_main_start_hotplug(&ctx, image_path, hotplug_uds, hotplug_back_bin, hotplug_uds_path,
+                              sizeof(hotplug_uds_path)) != 0)
+    return 2;
 
   ctx.c_fd = open(image_path, O_RDWR, 0666);
   if (ctx.c_fd < 0)
@@ -11499,124 +11594,17 @@ int main(int argc, char **argv)
     exit(2);
   }
 
-  int saw_single = 0;
-  for (int i = 0; i < argc_clean; ++i)
-  {
-    if (strcmp(argv_clean[i], "-s") == 0)
-    {
-      saw_single = 1;
-      break;
-    }
-  }
-  // 余裕を持って追加オプション(-s, -o max_threads=)用のスロットを確保
   char *argv_fuse[argc_clean + 10];
-  for (int i = 0; i < argc_clean; ++i)
-    argv_fuse[i] = argv_clean[i];
-  int argc_fuse = argc_clean;
-  // default single-threaded: always add -s unless MT explicitly enabled.
-  if (!enable_mt && !saw_single)
-  {
-    argv_fuse[argc_fuse++] = "-s";
-  }
-  if (enable_mt && saw_single)
-  {
-    // -s takes precedence for predictable CLI behavior.
-    enable_mt = KAFS_FALSE;
-  }
-  if (kafs_debug_level() >= 3)
-  {
-    argv_fuse[argc_fuse++] = "-d"; // libfuse debug
-  }
-  // MT有効時は max_threads を明示（libfuseの既定/奇妙な値を避ける）
   char mt_opt_buf[64];
-  if (enable_mt && !saw_max_threads)
-  {
-    unsigned mt_cnt = 8; // Raspi向けデフォルト
-    if (mt_cnt_override_set)
-    {
-      mt_cnt = mt_cnt_override;
-    }
-    else
-    {
-      const char *mt_env = getenv("KAFS_MAX_THREADS");
-      if (mt_env && *mt_env)
-      {
-        char *endp = NULL;
-        unsigned long v = strtoul(mt_env, &endp, 10);
-        if (endp && *endp == '\0')
-          mt_cnt = (unsigned)v;
-      }
-      if (mt_cnt < 1)
-        mt_cnt = 1;
-      if (mt_cnt > 100000)
-        mt_cnt = 100000;
-    }
-    // 安全のため -o と値を分けて渡す（-omax_threads= 形式のパース差異を回避）
-    snprintf(mt_opt_buf, sizeof(mt_opt_buf), "max_threads=%u", mt_cnt);
-    argv_fuse[argc_fuse++] = "-o";
-    argv_fuse[argc_fuse++] = mt_opt_buf;
-    kafs_log(KAFS_LOG_INFO, "kafs: enabling multithread with -o %s\n", mt_opt_buf);
-  }
-  g_kafs_writeback_cache_enabled = writeback_cache_enabled ? 1 : 0;
-  ctx.c_trim_on_free = trim_on_free_enabled ? 1u : 0u;
-  if (writeback_cache_explicit)
-  {
-    kafs_log(KAFS_LOG_INFO, "kafs: writeback_cache %s (explicit)\n",
-             writeback_cache_enabled ? "enabled" : "disabled");
-  }
-  else
-  {
-    kafs_log(KAFS_LOG_INFO, "kafs: writeback_cache %s (default)\n",
-             writeback_cache_enabled ? "enabled" : "disabled");
-  }
-  if (trim_on_free_explicit)
-  {
-    kafs_log(KAFS_LOG_INFO, "kafs: trim_on_free %s (explicit)\n",
-             trim_on_free_enabled ? "enabled" : "disabled");
-  }
-  else
-  {
-    kafs_log(KAFS_LOG_INFO, "kafs: trim_on_free %s (default)\n",
-             trim_on_free_enabled ? "enabled" : "disabled");
-  }
-  // 起動引数を一度だけ情報ログに出力（デバッグ用途）
-  if (kafs_debug_level() >= 1)
-  {
-    kafs_log(KAFS_LOG_INFO, "kafs: fuse argv (%d):\n", argc_fuse);
-    for (int i = 0; i < argc_fuse; ++i)
-    {
-      kafs_log(KAFS_LOG_INFO, "  argv[%d]=%s\n", i, argv_fuse[i]);
-    }
-  }
-  argv_fuse[argc_fuse] = NULL; // ensure NULL-terminated argv for libfuse safety
+  int argc_fuse = 0;
+  kafs_main_build_fuse_argv(argv_clean, argc_clean, &enable_mt, saw_max_threads, mt_cnt_override,
+                            mt_cnt_override_set, argv_fuse, &argc_fuse, mt_opt_buf,
+                            sizeof(mt_opt_buf));
+  kafs_main_log_runtime_options(&ctx, writeback_cache_enabled, writeback_cache_explicit,
+                                trim_on_free_enabled, trim_on_free_explicit, argc_fuse, argv_fuse);
   fuse_set_log_func(kafs_fuse_log_func);
   int rc = fuse_main(argc_fuse, argv_fuse, &kafs_operations, &ctx);
   fuse_set_log_func(NULL);
-  kafs_bg_dedup_worker_stop(&ctx);
-  kafs_pending_worker_stop(&ctx);
-  kafs_journal_shutdown(&ctx);
-  if (ctx.c_hotplug_fd >= 0)
-    close(ctx.c_hotplug_fd);
-  ctx.c_hotplug_active = 0;
-  if (hotplug_uds_path[0] != '\0')
-    unlink(hotplug_uds_path);
-  if (ctx.c_hotplug_lock_init)
-    pthread_mutex_destroy(&ctx.c_hotplug_lock);
-  if (ctx.c_hotplug_wait_lock_init)
-  {
-    pthread_cond_destroy(&ctx.c_hotplug_wait_cond);
-    pthread_mutex_destroy(&ctx.c_hotplug_wait_lock);
-  }
-  free(ctx.c_meta_bitmap_words);
-  free(ctx.c_meta_bitmap_dirty);
-  free(ctx.c_ino_epoch);
-  free(ctx.c_diag_create_seq);
-  free(ctx.c_diag_create_mode);
-  free(ctx.c_diag_create_first_write_seen);
-  free(ctx.c_diag_create_paths);
-  kafs_diag_log_close(&ctx);
-  if (ctx.c_img_base && ctx.c_img_base != MAP_FAILED)
-    munmap(ctx.c_img_base, ctx.c_img_size);
-  return rc;
+  return kafs_main_cleanup(&ctx, hotplug_uds_path, rc);
 }
 #endif

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -11124,7 +11124,7 @@ int kafs_core_migrate_image(const char *image_path, int assume_yes)
     return -EINVAL;
 
   kafs_ssuperblock_t sb;
-  uint32_t fmt;
+  uint32_t fmt = 0;
   int rc = kafs_migrate_read_superblock(image_path, &sb, &fmt);
   if (rc != 0)
     return rc;

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -10676,115 +10676,141 @@ static int kafs_main_handle_mt_token(kafs_main_options_t *opts, const char *tok,
   return 1;
 }
 
+static const char *kafs_main_token_value_alias2(const char *tok, const char *prefix_a,
+                                                const char *prefix_b)
+{
+  size_t prefix_a_len = strlen(prefix_a);
+  if (strncmp(tok, prefix_a, prefix_a_len) == 0)
+    return tok + prefix_a_len;
+
+  size_t prefix_b_len = strlen(prefix_b);
+  if (strncmp(tok, prefix_b, prefix_b_len) == 0)
+    return tok + prefix_b_len;
+
+  return NULL;
+}
+
+static int kafs_main_parse_token_prio_alias2(const char *tok, const char *prefix_a,
+                                             const char *prefix_b,
+                                             uint32_t *pending_worker_prio_mode,
+                                             const char *error_label)
+{
+  const char *value = kafs_main_token_value_alias2(tok, prefix_a, prefix_b);
+  if (!value)
+    return 0;
+  if (kafs_pending_worker_prio_mode_parse(value, pending_worker_prio_mode) != 0)
+  {
+    fprintf(stderr, "invalid -o %s: '%s'\n", error_label, value);
+    return 2;
+  }
+  return 1;
+}
+
+static int kafs_main_parse_token_nice_alias2(const char *tok, const char *prefix_a,
+                                             const char *prefix_b, int *nice_out,
+                                             const char *error_label)
+{
+  const char *value = kafs_main_token_value_alias2(tok, prefix_a, prefix_b);
+  if (!value)
+    return 0;
+
+  char *endp = NULL;
+  long parsed = strtol(value, &endp, 10);
+  if (!endp || *endp != '\0' || parsed < 0 || parsed > 19)
+  {
+    fprintf(stderr, "invalid -o %s: '%s'\n", error_label, value);
+    return 2;
+  }
+  *nice_out = (int)parsed;
+  return 1;
+}
+
+static int kafs_main_parse_token_u32(const char *tok, const char *prefix, uint32_t min_value,
+                                     uint32_t max_value, uint32_t *value_out,
+                                     const char *error_label)
+{
+  size_t prefix_len = strlen(prefix);
+  if (strncmp(tok, prefix, prefix_len) != 0)
+    return 0;
+  if (kafs_parse_u32_range(tok + prefix_len, min_value, max_value, value_out) != 0)
+  {
+    fprintf(stderr, "invalid -o %s: '%s'\n", error_label, tok + prefix_len);
+    return 2;
+  }
+  return 1;
+}
+
+static int kafs_main_parse_token_u32_alias2(const char *tok, const char *prefix_a,
+                                            const char *prefix_b, uint32_t min_value,
+                                            uint32_t max_value, uint32_t *value_out,
+                                            const char *error_label)
+{
+  const char *value = kafs_main_token_value_alias2(tok, prefix_a, prefix_b);
+  if (!value)
+    return 0;
+  if (kafs_parse_u32_range(value, min_value, max_value, value_out) != 0)
+  {
+    fprintf(stderr, "invalid -o %s: '%s'\n", error_label, value);
+    return 2;
+  }
+  return 1;
+}
+
+static int kafs_main_parse_token_onoff_alias2(const char *tok, const char *prefix_a,
+                                              const char *prefix_b, uint32_t *value_out,
+                                              const char *error_label)
+{
+  const char *value = kafs_main_token_value_alias2(tok, prefix_a, prefix_b);
+  if (!value)
+    return 0;
+  if (kafs_parse_onoff(value, value_out) != 0)
+  {
+    fprintf(stderr, "invalid -o %s: '%s'\n", error_label, value);
+    return 2;
+  }
+  return 1;
+}
+
 static int kafs_main_handle_pending_token(kafs_main_options_t *opts, const char *tok)
 {
-  const char *prio_str = NULL;
-  if (strncmp(tok, "pending_worker_prio=", 20) == 0)
-    prio_str = tok + 20;
-  else if (strncmp(tok, "dedup_worker_prio=", 18) == 0)
-    prio_str = tok + 18;
-  if (prio_str)
-  {
-    if (kafs_pending_worker_prio_mode_parse(prio_str, &opts->pending_worker_prio_mode) != 0)
-    {
-      fprintf(stderr, "invalid -o pending_worker_prio: '%s'\n", prio_str);
-      return 2;
-    }
-    return 1;
-  }
+  int rc = kafs_main_parse_token_prio_alias2(
+      tok, "pending_worker_prio=", "dedup_worker_prio=", &opts->pending_worker_prio_mode,
+      "pending_worker_prio");
+  if (rc != 0)
+    return rc;
 
-  const char *nice_str = NULL;
-  if (strncmp(tok, "pending_worker_nice=", 20) == 0)
-    nice_str = tok + 20;
-  else if (strncmp(tok, "dedup_worker_nice=", 18) == 0)
-    nice_str = tok + 18;
-  if (nice_str)
-  {
-    char *endp = NULL;
-    long v = strtol(nice_str, &endp, 10);
-    if (!endp || *endp != '\0' || v < 0 || v > 19)
-    {
-      fprintf(stderr, "invalid -o pending_worker_nice: '%s'\n", nice_str);
-      return 2;
-    }
-    opts->pending_worker_nice = (int)v;
-    return 1;
-  }
+  rc = kafs_main_parse_token_nice_alias2(tok, "pending_worker_nice=", "dedup_worker_nice=",
+                                         &opts->pending_worker_nice, "pending_worker_nice");
+  if (rc != 0)
+    return rc;
 
-  const char *ttl_soft_str = NULL;
-  if (strncmp(tok, "pending_ttl_soft_ms=", 20) == 0)
-    ttl_soft_str = tok + 20;
-  if (ttl_soft_str)
-  {
-    if (kafs_parse_u32_range(ttl_soft_str, 0, 3600000u, &opts->pending_ttl_soft_ms) != 0)
-    {
-      fprintf(stderr, "invalid -o pending_ttl_soft_ms: '%s'\n", ttl_soft_str);
-      return 2;
-    }
-    return 1;
-  }
+  rc = kafs_main_parse_token_u32(tok, "pending_ttl_soft_ms=", 0, 3600000u,
+                                 &opts->pending_ttl_soft_ms, "pending_ttl_soft_ms");
+  if (rc != 0)
+    return rc;
 
-  const char *ttl_hard_str = NULL;
-  if (strncmp(tok, "pending_ttl_hard_ms=", 20) == 0)
-    ttl_hard_str = tok + 20;
-  if (ttl_hard_str)
-  {
-    if (kafs_parse_u32_range(ttl_hard_str, 0, 3600000u, &opts->pending_ttl_hard_ms) != 0)
-    {
-      fprintf(stderr, "invalid -o pending_ttl_hard_ms: '%s'\n", ttl_hard_str);
-      return 2;
-    }
-    return 1;
-  }
+  rc = kafs_main_parse_token_u32(tok, "pending_ttl_hard_ms=", 0, 3600000u,
+                                 &opts->pending_ttl_hard_ms, "pending_ttl_hard_ms");
+  if (rc != 0)
+    return rc;
 
-  const char *pcap_initial_str = NULL;
-  if (strncmp(tok, "pendinglog_cap_initial=", 23) == 0)
-    pcap_initial_str = tok + 23;
-  else if (strncmp(tok, "pending_cap_initial=", 20) == 0)
-    pcap_initial_str = tok + 20;
-  if (pcap_initial_str)
-  {
-    if (kafs_parse_u32_range(pcap_initial_str, 0, 1000000000u, &opts->pending_cap_initial) != 0)
-    {
-      fprintf(stderr, "invalid -o pendinglog_cap_initial: '%s'\n", pcap_initial_str);
-      return 2;
-    }
-    return 1;
-  }
+  rc = kafs_main_parse_token_u32_alias2(tok, "pendinglog_cap_initial=", "pending_cap_initial=", 0,
+                                        1000000000u, &opts->pending_cap_initial,
+                                        "pendinglog_cap_initial");
+  if (rc != 0)
+    return rc;
 
-  const char *pcap_min_str = NULL;
-  if (strncmp(tok, "pendinglog_cap_min=", 19) == 0)
-    pcap_min_str = tok + 19;
-  else if (strncmp(tok, "pending_cap_min=", 16) == 0)
-    pcap_min_str = tok + 16;
-  if (pcap_min_str)
-  {
-    if (kafs_parse_u32_range(pcap_min_str, 0, 1000000000u, &opts->pending_cap_min) != 0)
-    {
-      fprintf(stderr, "invalid -o pendinglog_cap_min: '%s'\n", pcap_min_str);
-      return 2;
-    }
-    return 1;
-  }
+  rc = kafs_main_parse_token_u32_alias2(tok, "pendinglog_cap_min=", "pending_cap_min=", 0,
+                                        1000000000u, &opts->pending_cap_min, "pendinglog_cap_min");
+  if (rc != 0)
+    return rc;
 
-  const char *pcap_max_str = NULL;
-  if (strncmp(tok, "pendinglog_cap_max=", 19) == 0)
-    pcap_max_str = tok + 19;
-  else if (strncmp(tok, "pending_cap_max=", 16) == 0)
-    pcap_max_str = tok + 16;
-  if (pcap_max_str)
-  {
-    if (kafs_parse_u32_range(pcap_max_str, 0, 1000000000u, &opts->pending_cap_max) != 0)
-    {
-      fprintf(stderr, "invalid -o pendinglog_cap_max: '%s'\n", pcap_max_str);
-      return 2;
-    }
-    return 1;
-  }
+  rc = kafs_main_parse_token_u32_alias2(tok, "pendinglog_cap_max=", "pending_cap_max=", 0,
+                                        1000000000u, &opts->pending_cap_max, "pendinglog_cap_max");
+  if (rc != 0)
+    return rc;
 
-  const char *fsp_str = NULL;
-  if (strncmp(tok, "fsync_policy=", 13) == 0)
-    fsp_str = tok + 13;
+  const char *fsp_str = kafs_main_token_value_alias2(tok, "fsync_policy=", "fsync_policy=");
   if (fsp_str)
   {
     if (kafs_fsync_policy_parse(fsp_str, &opts->fsync_policy) != 0)
@@ -10813,138 +10839,57 @@ static int kafs_main_handle_bg_dedup_token(kafs_main_options_t *opts, const char
     return 1;
   }
 
-  const char *bg_scan_str = NULL;
-  if (strncmp(tok, "bg_dedup_scan=", 14) == 0)
-    bg_scan_str = tok + 14;
-  else if (strncmp(tok, "dedup_scan=", 11) == 0)
-    bg_scan_str = tok + 11;
-  if (bg_scan_str)
-  {
-    if (kafs_parse_onoff(bg_scan_str, &opts->bg_dedup_scan_enabled) != 0)
-    {
-      fprintf(stderr, "invalid -o dedup_scan/bg_dedup_scan: '%s'\n", bg_scan_str);
-      return 2;
-    }
-    return 1;
-  }
+  int rc = kafs_main_parse_token_onoff_alias2(
+      tok, "bg_dedup_scan=", "dedup_scan=", &opts->bg_dedup_scan_enabled,
+      "dedup_scan/bg_dedup_scan");
+  if (rc != 0)
+    return rc;
 
-  const char *bg_interval_str = NULL;
-  if (strncmp(tok, "bg_dedup_interval_ms=", 21) == 0)
-    bg_interval_str = tok + 21;
-  else if (strncmp(tok, "dedup_interval_ms=", 18) == 0)
-    bg_interval_str = tok + 18;
-  if (bg_interval_str)
-  {
-    if (kafs_parse_u32_range(bg_interval_str, KAFS_BG_DEDUP_INTERVAL_MS_MIN,
-                             KAFS_BG_DEDUP_INTERVAL_MS_MAX, &opts->bg_dedup_interval_ms) != 0)
-    {
-      fprintf(stderr, "invalid -o dedup_interval_ms/bg_dedup_interval_ms: '%s'\n", bg_interval_str);
-      return 2;
-    }
-    return 1;
-  }
+  rc = kafs_main_parse_token_u32_alias2(
+      tok, "bg_dedup_interval_ms=", "dedup_interval_ms=", KAFS_BG_DEDUP_INTERVAL_MS_MIN,
+      KAFS_BG_DEDUP_INTERVAL_MS_MAX, &opts->bg_dedup_interval_ms,
+      "dedup_interval_ms/bg_dedup_interval_ms");
+  if (rc != 0)
+    return rc;
 
-  const char *bg_quiet_interval_str = NULL;
-  if (strncmp(tok, "bg_dedup_quiet_interval_ms=", 27) == 0)
-    bg_quiet_interval_str = tok + 27;
-  else if (strncmp(tok, "dedup_quiet_interval_ms=", 24) == 0)
-    bg_quiet_interval_str = tok + 24;
-  if (bg_quiet_interval_str)
-  {
-    if (kafs_parse_u32_range(bg_quiet_interval_str, KAFS_BG_DEDUP_INTERVAL_MS_MIN,
-                             KAFS_BG_DEDUP_INTERVAL_MS_MAX, &opts->bg_dedup_quiet_interval_ms) != 0)
-    {
-      fprintf(stderr, "invalid -o dedup_quiet_interval_ms/bg_dedup_quiet_interval_ms: '%s'\n",
-              bg_quiet_interval_str);
-      return 2;
-    }
-    return 1;
-  }
+  rc = kafs_main_parse_token_u32_alias2(
+      tok, "bg_dedup_quiet_interval_ms=", "dedup_quiet_interval_ms=", KAFS_BG_DEDUP_INTERVAL_MS_MIN,
+      KAFS_BG_DEDUP_INTERVAL_MS_MAX, &opts->bg_dedup_quiet_interval_ms,
+      "dedup_quiet_interval_ms/bg_dedup_quiet_interval_ms");
+  if (rc != 0)
+    return rc;
 
-  const char *bg_pressure_interval_str = NULL;
-  if (strncmp(tok, "bg_dedup_pressure_interval_ms=", 30) == 0)
-    bg_pressure_interval_str = tok + 30;
-  else if (strncmp(tok, "dedup_pressure_interval_ms=", 27) == 0)
-    bg_pressure_interval_str = tok + 27;
-  if (bg_pressure_interval_str)
-  {
-    if (kafs_parse_u32_range(bg_pressure_interval_str, KAFS_BG_DEDUP_INTERVAL_MS_MIN,
-                             KAFS_BG_DEDUP_INTERVAL_MS_MAX,
-                             &opts->bg_dedup_pressure_interval_ms) != 0)
-    {
-      fprintf(stderr, "invalid -o dedup_pressure_interval_ms/bg_dedup_pressure_interval_ms: '%s'\n",
-              bg_pressure_interval_str);
-      return 2;
-    }
-    return 1;
-  }
+  rc = kafs_main_parse_token_u32_alias2(
+      tok, "bg_dedup_pressure_interval_ms=", "dedup_pressure_interval_ms=",
+      KAFS_BG_DEDUP_INTERVAL_MS_MIN, KAFS_BG_DEDUP_INTERVAL_MS_MAX,
+      &opts->bg_dedup_pressure_interval_ms,
+      "dedup_pressure_interval_ms/bg_dedup_pressure_interval_ms");
+  if (rc != 0)
+    return rc;
 
-  const char *bg_start_pct_str = NULL;
-  if (strncmp(tok, "bg_dedup_start_used_pct=", 24) == 0)
-    bg_start_pct_str = tok + 24;
-  else if (strncmp(tok, "dedup_start_used_pct=", 21) == 0)
-    bg_start_pct_str = tok + 21;
-  if (bg_start_pct_str)
-  {
-    if (kafs_parse_u32_range(bg_start_pct_str, 0, 100u, &opts->bg_dedup_start_used_pct) != 0)
-    {
-      fprintf(stderr, "invalid -o dedup_start_used_pct/bg_dedup_start_used_pct: '%s'\n",
-              bg_start_pct_str);
-      return 2;
-    }
-    return 1;
-  }
+  rc = kafs_main_parse_token_u32_alias2(tok, "bg_dedup_start_used_pct=", "dedup_start_used_pct=", 0,
+                                        100u, &opts->bg_dedup_start_used_pct,
+                                        "dedup_start_used_pct/bg_dedup_start_used_pct");
+  if (rc != 0)
+    return rc;
 
-  const char *bg_pressure_pct_str = NULL;
-  if (strncmp(tok, "bg_dedup_pressure_used_pct=", 27) == 0)
-    bg_pressure_pct_str = tok + 27;
-  else if (strncmp(tok, "dedup_pressure_used_pct=", 24) == 0)
-    bg_pressure_pct_str = tok + 24;
-  if (bg_pressure_pct_str)
-  {
-    if (kafs_parse_u32_range(bg_pressure_pct_str, 0, 100u, &opts->bg_dedup_pressure_used_pct) != 0)
-    {
-      fprintf(stderr, "invalid -o dedup_pressure_used_pct/bg_dedup_pressure_used_pct: '%s'\n",
-              bg_pressure_pct_str);
-      return 2;
-    }
-    return 1;
-  }
+  rc = kafs_main_parse_token_u32_alias2(
+      tok, "bg_dedup_pressure_used_pct=", "dedup_pressure_used_pct=", 0, 100u,
+      &opts->bg_dedup_pressure_used_pct, "dedup_pressure_used_pct/bg_dedup_pressure_used_pct");
+  if (rc != 0)
+    return rc;
 
-  const char *bg_prio_str = NULL;
-  if (strncmp(tok, "bg_dedup_worker_prio=", 21) == 0)
-    bg_prio_str = tok + 21;
-  else if (strncmp(tok, "dedup_scan_worker_prio=", 23) == 0)
-    bg_prio_str = tok + 23;
-  if (bg_prio_str)
-  {
-    if (kafs_pending_worker_prio_mode_parse(bg_prio_str, &opts->bg_dedup_worker_prio_mode) != 0)
-    {
-      fprintf(stderr, "invalid -o bg_dedup_worker_prio/dedup_scan_worker_prio: '%s'\n",
-              bg_prio_str);
-      return 2;
-    }
-    return 1;
-  }
+  rc = kafs_main_parse_token_prio_alias2(
+      tok, "bg_dedup_worker_prio=", "dedup_scan_worker_prio=", &opts->bg_dedup_worker_prio_mode,
+      "bg_dedup_worker_prio/dedup_scan_worker_prio");
+  if (rc != 0)
+    return rc;
 
-  const char *bg_nice_str = NULL;
-  if (strncmp(tok, "bg_dedup_worker_nice=", 21) == 0)
-    bg_nice_str = tok + 21;
-  else if (strncmp(tok, "dedup_scan_worker_nice=", 23) == 0)
-    bg_nice_str = tok + 23;
-  if (bg_nice_str)
-  {
-    char *endp = NULL;
-    long v = strtol(bg_nice_str, &endp, 10);
-    if (!endp || *endp != '\0' || v < 0 || v > 19)
-    {
-      fprintf(stderr, "invalid -o bg_dedup_worker_nice/dedup_scan_worker_nice: '%s'\n",
-              bg_nice_str);
-      return 2;
-    }
-    opts->bg_dedup_worker_nice = (int)v;
-    return 1;
-  }
+  rc = kafs_main_parse_token_nice_alias2(
+      tok, "bg_dedup_worker_nice=", "dedup_scan_worker_nice=", &opts->bg_dedup_worker_nice,
+      "bg_dedup_worker_nice/dedup_scan_worker_nice");
+  if (rc != 0)
+    return rc;
 
   return 0;
 }

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -1157,6 +1157,78 @@ static int kafs_pendinglog_inode_has_pending_id(struct kafs_context *ctx, uint32
   return 0;
 }
 
+static void kafs_pendinglog_requeue_entry(kafs_pendinglog_entry_t *slot, uint64_t now_rt_ns,
+                                          uint32_t *replay_requeued)
+{
+  slot->state = KAFS_PENDING_QUEUED;
+  if (slot->seq == 0)
+    slot->seq = now_rt_ns;
+  (*replay_requeued)++;
+}
+
+static int kafs_pendinglog_replay_scan_entries(struct kafs_context *ctx, kafs_pendinglog_hdr_t *hdr,
+                                               uint64_t now_rt_ns, uint32_t *replay_requeued)
+{
+  uint32_t idx = hdr->head;
+  while (idx != hdr->tail)
+  {
+    kafs_pendinglog_entry_t *slot = kafs_pendinglog_entry_ptr(ctx, idx);
+    if (!slot)
+      return -EIO;
+
+    if (slot->state == KAFS_PENDING_HASHED)
+      kafs_pendinglog_requeue_entry(slot, now_rt_ns, replay_requeued);
+    else if (slot->state == KAFS_PENDING_RESOLVED)
+    {
+      int still_pending = 0;
+      (void)kafs_pendinglog_inode_has_pending_id(ctx, slot->ino, slot->iblk, slot->pending_id,
+                                                 &still_pending);
+      if (still_pending)
+        kafs_pendinglog_requeue_entry(slot, now_rt_ns, replay_requeued);
+    }
+
+    idx = kafs_pendinglog_next_idx(hdr, idx);
+  }
+  return 0;
+}
+
+static int kafs_pendinglog_replay_trim_head(struct kafs_context *ctx, kafs_pendinglog_hdr_t *hdr,
+                                            uint64_t now_rt_ns, uint32_t *replay_requeued,
+                                            uint32_t *replay_dropped)
+{
+  while (hdr->head != hdr->tail)
+  {
+    kafs_pendinglog_entry_t *slot = kafs_pendinglog_entry_ptr(ctx, hdr->head);
+    if (!slot)
+      return -EIO;
+
+    if (slot->state == KAFS_PENDING_FAILED)
+    {
+      hdr->head = kafs_pendinglog_next_idx(hdr, hdr->head);
+      (*replay_dropped)++;
+      continue;
+    }
+
+    if (slot->state == KAFS_PENDING_RESOLVED)
+    {
+      int still_pending = 0;
+      (void)kafs_pendinglog_inode_has_pending_id(ctx, slot->ino, slot->iblk, slot->pending_id,
+                                                 &still_pending);
+      if (!still_pending)
+      {
+        hdr->head = kafs_pendinglog_next_idx(hdr, hdr->head);
+        (*replay_dropped)++;
+        continue;
+      }
+
+      kafs_pendinglog_requeue_entry(slot, now_rt_ns, replay_requeued);
+    }
+
+    break;
+  }
+  return 0;
+}
+
 static int kafs_pendinglog_replay_mount(struct kafs_context *ctx)
 {
   if (!ctx || !ctx->c_pendinglog_enabled)
@@ -1171,68 +1243,12 @@ static int kafs_pendinglog_replay_mount(struct kafs_context *ctx)
   uint32_t replay_requeued = 0;
   uint32_t replay_dropped = 0;
 
-  uint32_t idx = hdr->head;
-  while (idx != hdr->tail)
-  {
-    kafs_pendinglog_entry_t *slot = kafs_pendinglog_entry_ptr(ctx, idx);
-    if (!slot)
-      return -EIO;
-
-    if (slot->state == KAFS_PENDING_HASHED)
-    {
-      slot->state = KAFS_PENDING_QUEUED;
-      if (slot->seq == 0)
-        slot->seq = now_rt_ns;
-      replay_requeued++;
-    }
-    else if (slot->state == KAFS_PENDING_RESOLVED)
-    {
-      int still_pending = 0;
-      (void)kafs_pendinglog_inode_has_pending_id(ctx, slot->ino, slot->iblk, slot->pending_id,
-                                                 &still_pending);
-      if (still_pending)
-      {
-        slot->state = KAFS_PENDING_QUEUED;
-        if (slot->seq == 0)
-          slot->seq = now_rt_ns;
-        replay_requeued++;
-      }
-    }
-    idx = kafs_pendinglog_next_idx(hdr, idx);
-  }
-
-  while (hdr->head != hdr->tail)
-  {
-    kafs_pendinglog_entry_t *slot = kafs_pendinglog_entry_ptr(ctx, hdr->head);
-    if (!slot)
-      return -EIO;
-
-    if (slot->state == KAFS_PENDING_FAILED)
-    {
-      hdr->head = kafs_pendinglog_next_idx(hdr, hdr->head);
-      replay_dropped++;
-      continue;
-    }
-
-    if (slot->state == KAFS_PENDING_RESOLVED)
-    {
-      int still_pending = 0;
-      (void)kafs_pendinglog_inode_has_pending_id(ctx, slot->ino, slot->iblk, slot->pending_id,
-                                                 &still_pending);
-      if (!still_pending)
-      {
-        hdr->head = kafs_pendinglog_next_idx(hdr, hdr->head);
-        replay_dropped++;
-        continue;
-      }
-      slot->state = KAFS_PENDING_QUEUED;
-      if (slot->seq == 0)
-        slot->seq = now_rt_ns;
-      replay_requeued++;
-    }
-
-    break;
-  }
+  int rc = kafs_pendinglog_replay_scan_entries(ctx, hdr, now_rt_ns, &replay_requeued);
+  if (rc != 0)
+    return rc;
+  rc = kafs_pendinglog_replay_trim_head(ctx, hdr, now_rt_ns, &replay_requeued, &replay_dropped);
+  if (rc != 0)
+    return rc;
 
   if (replay_requeued || replay_dropped)
   {

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -216,25 +216,21 @@ static void kafs_diag_format_sample(const void *buf, size_t len, char *hex_out, 
   if (!buf || len == 0)
     return;
 
+  size_t sample_len = len < 16 ? len : 16;
   const unsigned char *bytes = (const unsigned char *)buf;
-  size_t sample_len = len;
-  if (sample_len > 16u)
-    sample_len = 16u;
-
-  size_t hex_off = 0;
-  size_t ascii_off = 0;
+  size_t hex_used = 0;
+  size_t ascii_used = 0;
   for (size_t i = 0; i < sample_len; ++i)
   {
-    if (hex_off + 4 >= hex_cap || ascii_off + 2 >= ascii_cap)
+    int n = snprintf(hex_out + hex_used, hex_cap - hex_used, "%s%02x", i == 0 ? "" : " ", bytes[i]);
+    if (n < 0 || (size_t)n >= hex_cap - hex_used)
       break;
-    int hex_written = snprintf(hex_out + hex_off, hex_cap - hex_off, "%s%02x", (i == 0) ? "" : " ",
-                               (unsigned)bytes[i]);
-    if (hex_written < 0)
+    hex_used += (size_t)n;
+    ascii_out[ascii_used++] = isprint(bytes[i]) ? (char)bytes[i] : '.';
+    if (ascii_used + 1 >= ascii_cap)
       break;
-    hex_off += (size_t)hex_written;
-    ascii_out[ascii_off++] = (bytes[i] >= 32 && bytes[i] <= 126) ? (char)bytes[i] : '.';
   }
-  ascii_out[ascii_off] = '\0';
+  ascii_out[ascii_used] = '\0';
 }
 
 static void kafs_diag_log_dir_iblk_write(const char *phase, struct kafs_context *ctx,
@@ -246,9 +242,6 @@ static void kafs_diag_log_dir_iblk_write(const char *phase, struct kafs_context 
     return;
 
   kafs_mode_t mode = kafs_ino_mode_get(inoent);
-  if (!S_ISDIR(mode))
-    return;
-
   char hex_sample[3 * 16 + 1];
   char ascii_sample[16 + 1];
   kafs_diag_format_sample(buf, len, hex_sample, sizeof(hex_sample), ascii_sample,
@@ -3691,6 +3684,53 @@ static int kafs_ino_iblk_write_pending(struct kafs_context *ctx, kafs_sinode_t *
   return 0;
 }
 
+static int kafs_iblk_write_hrl_acquire_candidate(struct kafs_context *ctx, const void *buf,
+                                                 int *is_new, kafs_blkcnt_t *candidate_blo,
+                                                 int *candidate_kind)
+{
+  *is_new = 0;
+  *candidate_blo = KAFS_BLO_NONE;
+  *candidate_kind = 0;
+
+  kafs_hrid_t hrid = 0;
+  ctx->c_stat_hrl_put_calls++;
+  uint64_t t_hrl0 = kafs_now_ns();
+  int rc = kafs_hrl_put(ctx, buf, &hrid, is_new, candidate_blo);
+  uint64_t t_hrl1 = kafs_now_ns();
+  __atomic_add_fetch(&ctx->c_stat_iblk_write_ns_hrl_put, t_hrl1 - t_hrl0, __ATOMIC_RELAXED);
+  if (rc == 0)
+  {
+    *candidate_kind = 1;
+    return 0;
+  }
+  if (rc == -ENOSPC)
+  {
+    int rescue_is_new = 0;
+    kafs_blkcnt_t rescue_blo = KAFS_BLO_NONE;
+    int rrc = kafs_hrl_try_enospc_rescue(ctx, buf, &rescue_blo, &rescue_is_new);
+    if (rrc == 0)
+    {
+      *is_new = rescue_is_new;
+      *candidate_blo = rescue_blo;
+      *candidate_kind = 2;
+      return 0;
+    }
+  }
+
+  return rc;
+}
+
+static void kafs_iblk_write_release_candidate(struct kafs_context *ctx, uint32_t ino_idx,
+                                              kafs_blkcnt_t candidate_blo)
+{
+  if (candidate_blo == KAFS_BLO_NONE)
+    return;
+
+  kafs_inode_unlock(ctx, ino_idx);
+  (void)kafs_inode_release_hrl_ref(ctx, candidate_blo);
+  kafs_inode_lock(ctx, ino_idx);
+}
+
 static int kafs_ino_iblk_write_hrl_retry(struct kafs_context *ctx, kafs_sinode_t *inoent,
                                          kafs_iblkcnt_t iblo, const void *buf)
 {
@@ -3704,31 +3744,11 @@ static int kafs_ino_iblk_write_hrl_retry(struct kafs_context *ctx, kafs_sinode_t
 
     kafs_inode_unlock(ctx, ino_idx);
 
-    kafs_hrid_t hrid = 0;
-    int is_new = 0;
-    kafs_blkcnt_t candidate_blo = KAFS_BLO_NONE;
-    int candidate_kind = 0;
-
-    ctx->c_stat_hrl_put_calls++;
-    uint64_t t_hrl0 = kafs_now_ns();
-    rc = kafs_hrl_put(ctx, buf, &hrid, &is_new, &candidate_blo);
-    uint64_t t_hrl1 = kafs_now_ns();
-    __atomic_add_fetch(&ctx->c_stat_iblk_write_ns_hrl_put, t_hrl1 - t_hrl0, __ATOMIC_RELAXED);
-    if (rc == 0)
-      candidate_kind = 1;
-    else if (rc == -ENOSPC)
-    {
-      int rescue_is_new = 0;
-      kafs_blkcnt_t rescue_blo = KAFS_BLO_NONE;
-      int rrc = kafs_hrl_try_enospc_rescue(ctx, buf, &rescue_blo, &rescue_is_new);
-      if (rrc == 0)
-      {
-        rc = 0;
-        is_new = rescue_is_new;
-        candidate_blo = rescue_blo;
-        candidate_kind = 2;
-      }
-    }
+    int is_new;
+    kafs_blkcnt_t candidate_blo;
+    int candidate_kind;
+    int hrl_rc =
+        kafs_iblk_write_hrl_acquire_candidate(ctx, buf, &is_new, &candidate_blo, &candidate_kind);
 
     kafs_inode_lock(ctx, ino_idx);
 
@@ -3738,16 +3758,12 @@ static int kafs_ino_iblk_write_hrl_retry(struct kafs_context *ctx, kafs_sinode_t
       return rc;
     if (current_old_blo != expected_old_blo)
     {
-      if (rc == 0 && candidate_blo != KAFS_BLO_NONE)
-      {
-        kafs_inode_unlock(ctx, ino_idx);
-        (void)kafs_inode_release_hrl_ref(ctx, candidate_blo);
-        kafs_inode_lock(ctx, ino_idx);
-      }
+      if (hrl_rc == 0)
+        kafs_iblk_write_release_candidate(ctx, ino_idx, candidate_blo);
       continue;
     }
 
-    if (rc == 0)
+    if (hrl_rc == 0)
     {
       if (is_new)
         ctx->c_stat_hrl_put_misses++;
@@ -3771,6 +3787,7 @@ static int kafs_ino_iblk_write_hrl_retry(struct kafs_context *ctx, kafs_sinode_t
       return 0;
     }
 
+    rc = hrl_rc;
     break;
   }
 

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -3015,6 +3015,129 @@ static int kafs_ino_ibrk_run_single(struct kafs_context *ctx, kafs_sinode_t *ino
   return KAFS_SUCCESS;
 }
 
+typedef struct kafs_ibrk_double_path
+{
+  kafs_sblkcnt_t *blkreftbl1;
+  kafs_sblkcnt_t *blkreftbl2;
+  kafs_blkcnt_t blo_blkreftbl1;
+  kafs_blkcnt_t blo_blkreftbl2;
+  kafs_blkcnt_t iblo1;
+  kafs_blkcnt_t iblo2;
+} kafs_ibrk_double_path_t;
+
+static int kafs_ino_ibrk_double_read_leaf(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                          kafs_ibrk_double_path_t *path, kafs_blkcnt_t *pblo)
+{
+  path->blo_blkreftbl1 = kafs_blkcnt_stoh(inoent->i_blkreftbl[13]);
+  if (path->blo_blkreftbl1 == KAFS_BLO_NONE)
+  {
+    *pblo = KAFS_BLO_NONE;
+    return KAFS_SUCCESS;
+  }
+
+  KAFS_CALL(kafs_blk_read, ctx, path->blo_blkreftbl1, path->blkreftbl1);
+  path->blo_blkreftbl2 = kafs_blkcnt_stoh(path->blkreftbl1[path->iblo1]);
+  if (path->blo_blkreftbl2 == KAFS_BLO_NONE)
+  {
+    *pblo = KAFS_BLO_NONE;
+    return KAFS_SUCCESS;
+  }
+
+  KAFS_CALL(kafs_blk_read, ctx, path->blo_blkreftbl2, path->blkreftbl2);
+  *pblo = kafs_blkcnt_stoh(path->blkreftbl2[path->iblo2]);
+  return KAFS_SUCCESS;
+}
+
+static int kafs_ino_ibrk_double_prepare_leaf(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                             kafs_ibrk_double_path_t *path, kafs_blksize_t blksize,
+                                             int adjust_inode_blocks)
+{
+  path->blo_blkreftbl1 = kafs_blkcnt_stoh(inoent->i_blkreftbl[13]);
+  if (path->blo_blkreftbl1 == KAFS_BLO_NONE)
+  {
+    KAFS_CALL(kafs_blk_alloc, ctx, &path->blo_blkreftbl1);
+    inoent->i_blkreftbl[13] = kafs_blkcnt_htos(path->blo_blkreftbl1);
+    if (adjust_inode_blocks)
+      kafs_ino_blocks_adjust(inoent, +1);
+    memset(path->blkreftbl1, 0, blksize);
+    path->blo_blkreftbl2 = KAFS_BLO_NONE;
+  }
+  else
+  {
+    KAFS_CALL(kafs_blk_read, ctx, path->blo_blkreftbl1, path->blkreftbl1);
+    path->blo_blkreftbl2 = kafs_blkcnt_stoh(path->blkreftbl1[path->iblo1]);
+  }
+
+  if (path->blo_blkreftbl2 == KAFS_BLO_NONE)
+  {
+    KAFS_CALL(kafs_blk_alloc, ctx, &path->blo_blkreftbl2);
+    path->blkreftbl1[path->iblo1] = kafs_blkcnt_htos(path->blo_blkreftbl2);
+    KAFS_CALL(kafs_blk_write, ctx, path->blo_blkreftbl1, path->blkreftbl1);
+    if (adjust_inode_blocks)
+      kafs_ino_blocks_adjust(inoent, +1);
+    memset(path->blkreftbl2, 0, blksize);
+  }
+  else
+  {
+    KAFS_CALL(kafs_blk_read, ctx, path->blo_blkreftbl2, path->blkreftbl2);
+  }
+
+  return KAFS_SUCCESS;
+}
+
+static int kafs_ino_ibrk_run_double_get_raw(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                            kafs_ibrk_double_path_t *path, kafs_blkcnt_t *pblo)
+{
+  return kafs_ino_ibrk_double_read_leaf(ctx, inoent, path, pblo);
+}
+
+static int kafs_ino_ibrk_run_double_get(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                        kafs_ibrk_double_path_t *path, kafs_blkcnt_t *pblo)
+{
+  KAFS_CALL(kafs_ino_ibrk_double_read_leaf, ctx, inoent, path, pblo);
+  if (*pblo == KAFS_BLO_NONE)
+    return KAFS_SUCCESS;
+  KAFS_CALL(kafs_ref_resolve_data_blo, ctx, *pblo, pblo);
+  return KAFS_SUCCESS;
+}
+
+static int kafs_ino_ibrk_run_double_put(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                        kafs_ibrk_double_path_t *path, kafs_blkcnt_t *pblo,
+                                        kafs_blksize_t blksize)
+{
+  kafs_blkcnt_t blo_data;
+
+  KAFS_CALL(kafs_ino_ibrk_double_prepare_leaf, ctx, inoent, path, blksize, 0);
+  KAFS_CALL(kafs_ref_resolve_data_blo, ctx, kafs_blkcnt_stoh(path->blkreftbl2[path->iblo2]),
+            &blo_data);
+  if (blo_data == KAFS_BLO_NONE)
+  {
+    KAFS_CALL(kafs_blk_alloc, ctx, &blo_data);
+    path->blkreftbl2[path->iblo2] = kafs_blkcnt_htos(blo_data);
+    KAFS_CALL(kafs_blk_write, ctx, path->blo_blkreftbl2, path->blkreftbl2);
+  }
+  *pblo = blo_data;
+  return KAFS_SUCCESS;
+}
+
+static int kafs_ino_ibrk_run_double_set(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                        kafs_ibrk_double_path_t *path, kafs_iblkcnt_t iblo_orig,
+                                        kafs_blkcnt_t *pblo, kafs_blksize_t blksize)
+{
+  kafs_blkcnt_t blo_data;
+
+  KAFS_CALL(kafs_ino_ibrk_double_prepare_leaf, ctx, inoent, path, blksize, 1);
+  blo_data = kafs_blkcnt_stoh(path->blkreftbl2[path->iblo2]);
+  kafs_diag_log_dir_ref_set("ibrk_set_double", ctx, inoent, iblo_orig, blo_data, *pblo);
+  if (blo_data == KAFS_BLO_NONE && *pblo != KAFS_BLO_NONE)
+    kafs_ino_blocks_adjust(inoent, +1);
+  else if (blo_data != KAFS_BLO_NONE && *pblo == KAFS_BLO_NONE)
+    kafs_ino_blocks_adjust(inoent, -1);
+  path->blkreftbl2[path->iblo2] = kafs_blkcnt_htos(*pblo);
+  KAFS_CALL(kafs_blk_write, ctx, path->blo_blkreftbl2, path->blkreftbl2);
+  return KAFS_SUCCESS;
+}
+
 static int kafs_ino_ibrk_run_double(struct kafs_context *ctx, kafs_sinode_t *inoent,
                                     kafs_iblkcnt_t iblo, kafs_iblkcnt_t iblo_orig,
                                     kafs_blkcnt_t *pblo, kafs_iblkref_func_t ifunc,
@@ -3023,118 +3146,28 @@ static int kafs_ino_ibrk_run_double(struct kafs_context *ctx, kafs_sinode_t *ino
 {
   kafs_sblkcnt_t blkreftbl1[blkrefs_pb];
   kafs_sblkcnt_t blkreftbl2[blkrefs_pb];
-  kafs_blkcnt_t blo_blkreftbl1 = kafs_blkcnt_stoh(inoent->i_blkreftbl[13]);
-  kafs_blkcnt_t blo_blkreftbl2;
-  kafs_blkcnt_t blo_data;
-  kafs_blkcnt_t iblo1 = iblo >> log_blkrefs_pb;
-  kafs_blkcnt_t iblo2 = iblo & (blkrefs_pb - 1);
+  kafs_ibrk_double_path_t path = {
+      .blkreftbl1 = blkreftbl1,
+      .blkreftbl2 = blkreftbl2,
+      .blo_blkreftbl1 = KAFS_BLO_NONE,
+      .blo_blkreftbl2 = KAFS_BLO_NONE,
+      .iblo1 = iblo >> log_blkrefs_pb,
+      .iblo2 = iblo & (blkrefs_pb - 1),
+  };
 
   switch (ifunc)
   {
   case KAFS_IBLKREF_FUNC_GET_RAW:
-    if (blo_blkreftbl1 == KAFS_BLO_NONE)
-    {
-      *pblo = KAFS_BLO_NONE;
-      return KAFS_SUCCESS;
-    }
-    KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl1, blkreftbl1);
-    blo_blkreftbl2 = kafs_blkcnt_stoh(blkreftbl1[iblo1]);
-    if (blo_blkreftbl2 == KAFS_BLO_NONE)
-    {
-      *pblo = KAFS_BLO_NONE;
-      return KAFS_SUCCESS;
-    }
-    KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl2, blkreftbl2);
-    *pblo = kafs_blkcnt_stoh(blkreftbl2[iblo2]);
-    return KAFS_SUCCESS;
+    return kafs_ino_ibrk_run_double_get_raw(ctx, inoent, &path, pblo);
 
   case KAFS_IBLKREF_FUNC_GET:
-    if (blo_blkreftbl1 == KAFS_BLO_NONE)
-    {
-      *pblo = KAFS_BLO_NONE;
-      return KAFS_SUCCESS;
-    }
-    KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl1, blkreftbl1);
-    blo_blkreftbl2 = kafs_blkcnt_stoh(blkreftbl1[iblo1]);
-    if (blo_blkreftbl2 == KAFS_BLO_NONE)
-    {
-      *pblo = KAFS_BLO_NONE;
-      return KAFS_SUCCESS;
-    }
-    KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl2, blkreftbl2);
-    KAFS_CALL(kafs_ref_resolve_data_blo, ctx, kafs_blkcnt_stoh(blkreftbl2[iblo2]), pblo);
-    return KAFS_SUCCESS;
+    return kafs_ino_ibrk_run_double_get(ctx, inoent, &path, pblo);
 
   case KAFS_IBLKREF_FUNC_PUT:
-    if (blo_blkreftbl1 == KAFS_BLO_NONE)
-    {
-      KAFS_CALL(kafs_blk_alloc, ctx, &blo_blkreftbl1);
-      inoent->i_blkreftbl[13] = kafs_blkcnt_htos(blo_blkreftbl1);
-      memset(blkreftbl1, 0, blksize);
-      blo_blkreftbl2 = KAFS_BLO_NONE;
-    }
-    else
-    {
-      KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl1, blkreftbl1);
-      blo_blkreftbl2 = kafs_blkcnt_stoh(blkreftbl1[iblo1]);
-    }
-    if (blo_blkreftbl2 == KAFS_BLO_NONE)
-    {
-      KAFS_CALL(kafs_blk_alloc, ctx, &blo_blkreftbl2);
-      blkreftbl1[iblo1] = kafs_blkcnt_htos(blo_blkreftbl2);
-      KAFS_CALL(kafs_blk_write, ctx, blo_blkreftbl1, blkreftbl1);
-      memset(blkreftbl2, 0, blksize);
-      blo_data = KAFS_BLO_NONE;
-    }
-    else
-    {
-      KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl2, blkreftbl2);
-      KAFS_CALL(kafs_ref_resolve_data_blo, ctx, kafs_blkcnt_stoh(blkreftbl2[iblo2]), &blo_data);
-    }
-    if (blo_data == KAFS_BLO_NONE)
-    {
-      KAFS_CALL(kafs_blk_alloc, ctx, &blo_data);
-      blkreftbl2[iblo2] = kafs_blkcnt_htos(blo_data);
-      KAFS_CALL(kafs_blk_write, ctx, blo_blkreftbl2, blkreftbl2);
-    }
-    *pblo = blo_data;
-    return KAFS_SUCCESS;
+    return kafs_ino_ibrk_run_double_put(ctx, inoent, &path, pblo, blksize);
 
   case KAFS_IBLKREF_FUNC_SET:
-    if (blo_blkreftbl1 == KAFS_BLO_NONE)
-    {
-      KAFS_CALL(kafs_blk_alloc, ctx, &blo_blkreftbl1);
-      inoent->i_blkreftbl[13] = kafs_blkcnt_htos(blo_blkreftbl1);
-      kafs_ino_blocks_adjust(inoent, +1);
-      memset(blkreftbl1, 0, blksize);
-      blo_blkreftbl2 = KAFS_BLO_NONE;
-    }
-    else
-    {
-      KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl1, blkreftbl1);
-      blo_blkreftbl2 = kafs_blkcnt_stoh(blkreftbl1[iblo1]);
-    }
-    if (blo_blkreftbl2 == KAFS_BLO_NONE)
-    {
-      KAFS_CALL(kafs_blk_alloc, ctx, &blo_blkreftbl2);
-      blkreftbl1[iblo1] = kafs_blkcnt_htos(blo_blkreftbl2);
-      KAFS_CALL(kafs_blk_write, ctx, blo_blkreftbl1, blkreftbl1);
-      kafs_ino_blocks_adjust(inoent, +1);
-      memset(blkreftbl2, 0, blksize);
-    }
-    else
-    {
-      KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl2, blkreftbl2);
-    }
-    blo_data = kafs_blkcnt_stoh(blkreftbl2[iblo2]);
-    kafs_diag_log_dir_ref_set("ibrk_set_double", ctx, inoent, iblo_orig, blo_data, *pblo);
-    if (blo_data == KAFS_BLO_NONE && *pblo != KAFS_BLO_NONE)
-      kafs_ino_blocks_adjust(inoent, +1);
-    else if (blo_data != KAFS_BLO_NONE && *pblo == KAFS_BLO_NONE)
-      kafs_ino_blocks_adjust(inoent, -1);
-    blkreftbl2[iblo2] = kafs_blkcnt_htos(*pblo);
-    KAFS_CALL(kafs_blk_write, ctx, blo_blkreftbl2, blkreftbl2);
-    return KAFS_SUCCESS;
+    return kafs_ino_ibrk_run_double_set(ctx, inoent, &path, iblo_orig, pblo, blksize);
   }
 
   return KAFS_SUCCESS;

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -10514,6 +10514,423 @@ static int kafs_main_collect_args(int argc, char **argv, const char *prog,
   return 0;
 }
 
+static void kafs_main_set_hotplug_default(kafs_main_options_t *opts)
+{
+  snprintf(opts->hotplug_uds_opt, sizeof(opts->hotplug_uds_opt), "%s", KAFS_HOTPLUG_UDS_DEFAULT);
+}
+
+static int kafs_main_handle_cache_hotplug_token(kafs_main_options_t *opts, const char *tok)
+{
+  if (strcmp(tok, "writeback_cache") == 0)
+  {
+    opts->writeback_cache_enabled = KAFS_TRUE;
+    opts->writeback_cache_explicit = KAFS_TRUE;
+    return 1;
+  }
+  if (strcmp(tok, "no_writeback_cache") == 0)
+  {
+    opts->writeback_cache_enabled = KAFS_FALSE;
+    opts->writeback_cache_explicit = KAFS_TRUE;
+    return 1;
+  }
+  if (strcmp(tok, "trim_on_free") == 0 || strcmp(tok, "trim-on-free") == 0)
+  {
+    opts->trim_on_free_enabled = KAFS_TRUE;
+    opts->trim_on_free_explicit = KAFS_TRUE;
+    return 1;
+  }
+  if (strcmp(tok, "no_trim_on_free") == 0 || strcmp(tok, "no-trim-on-free") == 0)
+  {
+    opts->trim_on_free_enabled = KAFS_FALSE;
+    opts->trim_on_free_explicit = KAFS_TRUE;
+    return 1;
+  }
+  if (strcmp(tok, "hotplug") == 0)
+  {
+    kafs_main_set_hotplug_default(opts);
+    return 1;
+  }
+
+  const char *hotplug_uds_v = NULL;
+  if (strncmp(tok, "hotplug=", 8) == 0)
+    hotplug_uds_v = tok + 8;
+  else if (strncmp(tok, "hotplug_uds=", 12) == 0)
+    hotplug_uds_v = tok + 12;
+  else if (strncmp(tok, "hotplug-uds=", 12) == 0)
+    hotplug_uds_v = tok + 12;
+  if (hotplug_uds_v)
+  {
+    if (!*hotplug_uds_v || snprintf(opts->hotplug_uds_opt, sizeof(opts->hotplug_uds_opt), "%s",
+                                    hotplug_uds_v) >= (int)sizeof(opts->hotplug_uds_opt))
+    {
+      fprintf(stderr, "invalid -o hotplug uds path: '%s'\n", hotplug_uds_v);
+      return 2;
+    }
+    return 1;
+  }
+
+  const char *hotplug_back_bin_v = NULL;
+  if (strncmp(tok, "hotplug_back_bin=", 17) == 0)
+    hotplug_back_bin_v = tok + 17;
+  else if (strncmp(tok, "hotplug-back-bin=", 17) == 0)
+    hotplug_back_bin_v = tok + 17;
+  if (hotplug_back_bin_v)
+  {
+    if (!*hotplug_back_bin_v ||
+        snprintf(opts->hotplug_back_bin_opt, sizeof(opts->hotplug_back_bin_opt), "%s",
+                 hotplug_back_bin_v) >= (int)sizeof(opts->hotplug_back_bin_opt))
+    {
+      fprintf(stderr, "invalid -o hotplug_back_bin path: '%s'\n", hotplug_back_bin_v);
+      return 2;
+    }
+    return 1;
+  }
+
+  return 0;
+}
+
+static int kafs_main_handle_mt_token(kafs_main_options_t *opts, const char *tok, int *want_mt)
+{
+  if (strncmp(tok, "max_threads=", 12) == 0 || strcmp(tok, "max_threads") == 0)
+    opts->saw_max_threads = 1;
+
+  if (strcmp(tok, "multi_thread") == 0 || strcmp(tok, "multi-thread") == 0 ||
+      strcmp(tok, "multithread") == 0)
+  {
+    *want_mt = 1;
+    return 1;
+  }
+
+  const char *vstr = NULL;
+  if (strncmp(tok, "multi_thread=", 13) == 0)
+    vstr = tok + 13;
+  else if (strncmp(tok, "multi-thread=", 13) == 0)
+    vstr = tok + 13;
+  else if (strncmp(tok, "multithread=", 12) == 0)
+    vstr = tok + 12;
+  if (!vstr)
+    return 0;
+
+  char *endp = NULL;
+  unsigned long v = strtoul(vstr, &endp, 10);
+  if (!endp || *endp != '\0')
+  {
+    fprintf(stderr, "invalid -o multi_thread=N: '%s'\n", vstr);
+    return 2;
+  }
+  if (v < 1)
+    v = 1;
+  if (v > 100000)
+    v = 100000;
+  opts->mt_cnt_override = (unsigned)v;
+  opts->mt_cnt_override_set = 1;
+  *want_mt = 1;
+  return 1;
+}
+
+static int kafs_main_handle_pending_token(kafs_main_options_t *opts, const char *tok)
+{
+  const char *prio_str = NULL;
+  if (strncmp(tok, "pending_worker_prio=", 20) == 0)
+    prio_str = tok + 20;
+  else if (strncmp(tok, "dedup_worker_prio=", 18) == 0)
+    prio_str = tok + 18;
+  if (prio_str)
+  {
+    if (kafs_pending_worker_prio_mode_parse(prio_str, &opts->pending_worker_prio_mode) != 0)
+    {
+      fprintf(stderr, "invalid -o pending_worker_prio: '%s'\n", prio_str);
+      return 2;
+    }
+    return 1;
+  }
+
+  const char *nice_str = NULL;
+  if (strncmp(tok, "pending_worker_nice=", 20) == 0)
+    nice_str = tok + 20;
+  else if (strncmp(tok, "dedup_worker_nice=", 18) == 0)
+    nice_str = tok + 18;
+  if (nice_str)
+  {
+    char *endp = NULL;
+    long v = strtol(nice_str, &endp, 10);
+    if (!endp || *endp != '\0' || v < 0 || v > 19)
+    {
+      fprintf(stderr, "invalid -o pending_worker_nice: '%s'\n", nice_str);
+      return 2;
+    }
+    opts->pending_worker_nice = (int)v;
+    return 1;
+  }
+
+  const char *ttl_soft_str = NULL;
+  if (strncmp(tok, "pending_ttl_soft_ms=", 20) == 0)
+    ttl_soft_str = tok + 20;
+  if (ttl_soft_str)
+  {
+    if (kafs_parse_u32_range(ttl_soft_str, 0, 3600000u, &opts->pending_ttl_soft_ms) != 0)
+    {
+      fprintf(stderr, "invalid -o pending_ttl_soft_ms: '%s'\n", ttl_soft_str);
+      return 2;
+    }
+    return 1;
+  }
+
+  const char *ttl_hard_str = NULL;
+  if (strncmp(tok, "pending_ttl_hard_ms=", 20) == 0)
+    ttl_hard_str = tok + 20;
+  if (ttl_hard_str)
+  {
+    if (kafs_parse_u32_range(ttl_hard_str, 0, 3600000u, &opts->pending_ttl_hard_ms) != 0)
+    {
+      fprintf(stderr, "invalid -o pending_ttl_hard_ms: '%s'\n", ttl_hard_str);
+      return 2;
+    }
+    return 1;
+  }
+
+  const char *pcap_initial_str = NULL;
+  if (strncmp(tok, "pendinglog_cap_initial=", 23) == 0)
+    pcap_initial_str = tok + 23;
+  else if (strncmp(tok, "pending_cap_initial=", 20) == 0)
+    pcap_initial_str = tok + 20;
+  if (pcap_initial_str)
+  {
+    if (kafs_parse_u32_range(pcap_initial_str, 0, 1000000000u, &opts->pending_cap_initial) != 0)
+    {
+      fprintf(stderr, "invalid -o pendinglog_cap_initial: '%s'\n", pcap_initial_str);
+      return 2;
+    }
+    return 1;
+  }
+
+  const char *pcap_min_str = NULL;
+  if (strncmp(tok, "pendinglog_cap_min=", 19) == 0)
+    pcap_min_str = tok + 19;
+  else if (strncmp(tok, "pending_cap_min=", 16) == 0)
+    pcap_min_str = tok + 16;
+  if (pcap_min_str)
+  {
+    if (kafs_parse_u32_range(pcap_min_str, 0, 1000000000u, &opts->pending_cap_min) != 0)
+    {
+      fprintf(stderr, "invalid -o pendinglog_cap_min: '%s'\n", pcap_min_str);
+      return 2;
+    }
+    return 1;
+  }
+
+  const char *pcap_max_str = NULL;
+  if (strncmp(tok, "pendinglog_cap_max=", 19) == 0)
+    pcap_max_str = tok + 19;
+  else if (strncmp(tok, "pending_cap_max=", 16) == 0)
+    pcap_max_str = tok + 16;
+  if (pcap_max_str)
+  {
+    if (kafs_parse_u32_range(pcap_max_str, 0, 1000000000u, &opts->pending_cap_max) != 0)
+    {
+      fprintf(stderr, "invalid -o pendinglog_cap_max: '%s'\n", pcap_max_str);
+      return 2;
+    }
+    return 1;
+  }
+
+  const char *fsp_str = NULL;
+  if (strncmp(tok, "fsync_policy=", 13) == 0)
+    fsp_str = tok + 13;
+  if (fsp_str)
+  {
+    if (kafs_fsync_policy_parse(fsp_str, &opts->fsync_policy) != 0)
+    {
+      fprintf(stderr, "invalid -o fsync_policy: '%s'\n", fsp_str);
+      return 2;
+    }
+    return 1;
+  }
+
+  return 0;
+}
+
+static int kafs_main_handle_bg_dedup_token(kafs_main_options_t *opts, const char *tok)
+{
+  if (strcmp(tok, "bg_dedup_scan") == 0 || strcmp(tok, "bg_dedup_scan=on") == 0 ||
+      strcmp(tok, "dedup_scan") == 0 || strcmp(tok, "dedup_scan=on") == 0)
+  {
+    opts->bg_dedup_scan_enabled = 1u;
+    return 1;
+  }
+  if (strcmp(tok, "no_bg_dedup_scan") == 0 || strcmp(tok, "bg_dedup_scan=off") == 0 ||
+      strcmp(tok, "no_dedup_scan") == 0 || strcmp(tok, "dedup_scan=off") == 0)
+  {
+    opts->bg_dedup_scan_enabled = 0u;
+    return 1;
+  }
+
+  const char *bg_scan_str = NULL;
+  if (strncmp(tok, "bg_dedup_scan=", 14) == 0)
+    bg_scan_str = tok + 14;
+  else if (strncmp(tok, "dedup_scan=", 11) == 0)
+    bg_scan_str = tok + 11;
+  if (bg_scan_str)
+  {
+    if (kafs_parse_onoff(bg_scan_str, &opts->bg_dedup_scan_enabled) != 0)
+    {
+      fprintf(stderr, "invalid -o dedup_scan/bg_dedup_scan: '%s'\n", bg_scan_str);
+      return 2;
+    }
+    return 1;
+  }
+
+  const char *bg_interval_str = NULL;
+  if (strncmp(tok, "bg_dedup_interval_ms=", 21) == 0)
+    bg_interval_str = tok + 21;
+  else if (strncmp(tok, "dedup_interval_ms=", 18) == 0)
+    bg_interval_str = tok + 18;
+  if (bg_interval_str)
+  {
+    if (kafs_parse_u32_range(bg_interval_str, KAFS_BG_DEDUP_INTERVAL_MS_MIN,
+                             KAFS_BG_DEDUP_INTERVAL_MS_MAX, &opts->bg_dedup_interval_ms) != 0)
+    {
+      fprintf(stderr, "invalid -o dedup_interval_ms/bg_dedup_interval_ms: '%s'\n", bg_interval_str);
+      return 2;
+    }
+    return 1;
+  }
+
+  const char *bg_quiet_interval_str = NULL;
+  if (strncmp(tok, "bg_dedup_quiet_interval_ms=", 27) == 0)
+    bg_quiet_interval_str = tok + 27;
+  else if (strncmp(tok, "dedup_quiet_interval_ms=", 24) == 0)
+    bg_quiet_interval_str = tok + 24;
+  if (bg_quiet_interval_str)
+  {
+    if (kafs_parse_u32_range(bg_quiet_interval_str, KAFS_BG_DEDUP_INTERVAL_MS_MIN,
+                             KAFS_BG_DEDUP_INTERVAL_MS_MAX, &opts->bg_dedup_quiet_interval_ms) != 0)
+    {
+      fprintf(stderr, "invalid -o dedup_quiet_interval_ms/bg_dedup_quiet_interval_ms: '%s'\n",
+              bg_quiet_interval_str);
+      return 2;
+    }
+    return 1;
+  }
+
+  const char *bg_pressure_interval_str = NULL;
+  if (strncmp(tok, "bg_dedup_pressure_interval_ms=", 30) == 0)
+    bg_pressure_interval_str = tok + 30;
+  else if (strncmp(tok, "dedup_pressure_interval_ms=", 27) == 0)
+    bg_pressure_interval_str = tok + 27;
+  if (bg_pressure_interval_str)
+  {
+    if (kafs_parse_u32_range(bg_pressure_interval_str, KAFS_BG_DEDUP_INTERVAL_MS_MIN,
+                             KAFS_BG_DEDUP_INTERVAL_MS_MAX,
+                             &opts->bg_dedup_pressure_interval_ms) != 0)
+    {
+      fprintf(stderr, "invalid -o dedup_pressure_interval_ms/bg_dedup_pressure_interval_ms: '%s'\n",
+              bg_pressure_interval_str);
+      return 2;
+    }
+    return 1;
+  }
+
+  const char *bg_start_pct_str = NULL;
+  if (strncmp(tok, "bg_dedup_start_used_pct=", 24) == 0)
+    bg_start_pct_str = tok + 24;
+  else if (strncmp(tok, "dedup_start_used_pct=", 21) == 0)
+    bg_start_pct_str = tok + 21;
+  if (bg_start_pct_str)
+  {
+    if (kafs_parse_u32_range(bg_start_pct_str, 0, 100u, &opts->bg_dedup_start_used_pct) != 0)
+    {
+      fprintf(stderr, "invalid -o dedup_start_used_pct/bg_dedup_start_used_pct: '%s'\n",
+              bg_start_pct_str);
+      return 2;
+    }
+    return 1;
+  }
+
+  const char *bg_pressure_pct_str = NULL;
+  if (strncmp(tok, "bg_dedup_pressure_used_pct=", 27) == 0)
+    bg_pressure_pct_str = tok + 27;
+  else if (strncmp(tok, "dedup_pressure_used_pct=", 24) == 0)
+    bg_pressure_pct_str = tok + 24;
+  if (bg_pressure_pct_str)
+  {
+    if (kafs_parse_u32_range(bg_pressure_pct_str, 0, 100u, &opts->bg_dedup_pressure_used_pct) != 0)
+    {
+      fprintf(stderr, "invalid -o dedup_pressure_used_pct/bg_dedup_pressure_used_pct: '%s'\n",
+              bg_pressure_pct_str);
+      return 2;
+    }
+    return 1;
+  }
+
+  const char *bg_prio_str = NULL;
+  if (strncmp(tok, "bg_dedup_worker_prio=", 21) == 0)
+    bg_prio_str = tok + 21;
+  else if (strncmp(tok, "dedup_scan_worker_prio=", 23) == 0)
+    bg_prio_str = tok + 23;
+  if (bg_prio_str)
+  {
+    if (kafs_pending_worker_prio_mode_parse(bg_prio_str, &opts->bg_dedup_worker_prio_mode) != 0)
+    {
+      fprintf(stderr, "invalid -o bg_dedup_worker_prio/dedup_scan_worker_prio: '%s'\n",
+              bg_prio_str);
+      return 2;
+    }
+    return 1;
+  }
+
+  const char *bg_nice_str = NULL;
+  if (strncmp(tok, "bg_dedup_worker_nice=", 21) == 0)
+    bg_nice_str = tok + 21;
+  else if (strncmp(tok, "dedup_scan_worker_nice=", 23) == 0)
+    bg_nice_str = tok + 23;
+  if (bg_nice_str)
+  {
+    char *endp = NULL;
+    long v = strtol(bg_nice_str, &endp, 10);
+    if (!endp || *endp != '\0' || v < 0 || v > 19)
+    {
+      fprintf(stderr, "invalid -o bg_dedup_worker_nice/dedup_scan_worker_nice: '%s'\n",
+              bg_nice_str);
+      return 2;
+    }
+    opts->bg_dedup_worker_nice = (int)v;
+    return 1;
+  }
+
+  return 0;
+}
+
+static void kafs_main_append_filtered_token(char *filtered, size_t *used, const char *tok)
+{
+  size_t tlen = strlen(tok);
+  size_t need = tlen + (*used ? 1 : 0);
+  if (!need)
+    return;
+  if (*used)
+    filtered[(*used)++] = ',';
+  memcpy(filtered + *used, tok, tlen);
+  *used += tlen;
+  filtered[*used] = '\0';
+}
+
+static int kafs_main_handle_mount_token(kafs_main_options_t *opts, const char *tok, int *want_mt)
+{
+  int rc = kafs_main_handle_cache_hotplug_token(opts, tok);
+  if (rc != 0)
+    return rc;
+
+  rc = kafs_main_handle_mt_token(opts, tok, want_mt);
+  if (rc != 0)
+    return rc;
+
+  rc = kafs_main_handle_pending_token(opts, tok);
+  if (rc != 0)
+    return rc;
+
+  return kafs_main_handle_bg_dedup_token(opts, tok);
+}
+
 static int kafs_main_filter_mount_options(kafs_main_options_t *opts, char **argv_clean,
                                           int *argc_clean)
 {
@@ -10563,404 +10980,16 @@ static int kafs_main_filter_mount_options(kafs_main_options_t *opts, char **argv
     char *saveptr = NULL;
     for (char *tok = strtok_r(dup, ",", &saveptr); tok; tok = strtok_r(NULL, ",", &saveptr))
     {
-      if (strncmp(tok, "max_threads=", 12) == 0 || strcmp(tok, "max_threads") == 0)
-        opts->saw_max_threads = 1;
+      int rc = kafs_main_handle_mount_token(opts, tok, &want_mt);
+      if (rc == 2)
+      {
+        free(dup);
+        return 2;
+      }
+      if (rc == 1)
+        continue;
 
-      if (strcmp(tok, "writeback_cache") == 0)
-      {
-        opts->writeback_cache_enabled = KAFS_TRUE;
-        opts->writeback_cache_explicit = KAFS_TRUE;
-        continue;
-      }
-      if (strcmp(tok, "no_writeback_cache") == 0)
-      {
-        opts->writeback_cache_enabled = KAFS_FALSE;
-        opts->writeback_cache_explicit = KAFS_TRUE;
-        continue;
-      }
-      if (strcmp(tok, "trim_on_free") == 0 || strcmp(tok, "trim-on-free") == 0)
-      {
-        opts->trim_on_free_enabled = KAFS_TRUE;
-        opts->trim_on_free_explicit = KAFS_TRUE;
-        continue;
-      }
-      if (strcmp(tok, "no_trim_on_free") == 0 || strcmp(tok, "no-trim-on-free") == 0)
-      {
-        opts->trim_on_free_enabled = KAFS_FALSE;
-        opts->trim_on_free_explicit = KAFS_TRUE;
-        continue;
-      }
-      if (strcmp(tok, "hotplug") == 0)
-      {
-        snprintf(opts->hotplug_uds_opt, sizeof(opts->hotplug_uds_opt), "%s",
-                 KAFS_HOTPLUG_UDS_DEFAULT);
-        continue;
-      }
-
-      const char *hotplug_uds_v = NULL;
-      if (strncmp(tok, "hotplug=", 8) == 0)
-        hotplug_uds_v = tok + 8;
-      else if (strncmp(tok, "hotplug_uds=", 12) == 0)
-        hotplug_uds_v = tok + 12;
-      else if (strncmp(tok, "hotplug-uds=", 12) == 0)
-        hotplug_uds_v = tok + 12;
-      if (hotplug_uds_v)
-      {
-        if (!*hotplug_uds_v || snprintf(opts->hotplug_uds_opt, sizeof(opts->hotplug_uds_opt), "%s",
-                                        hotplug_uds_v) >= (int)sizeof(opts->hotplug_uds_opt))
-        {
-          fprintf(stderr, "invalid -o hotplug uds path: '%s'\n", hotplug_uds_v);
-          free(dup);
-          return 2;
-        }
-        continue;
-      }
-
-      const char *hotplug_back_bin_v = NULL;
-      if (strncmp(tok, "hotplug_back_bin=", 17) == 0)
-        hotplug_back_bin_v = tok + 17;
-      else if (strncmp(tok, "hotplug-back-bin=", 17) == 0)
-        hotplug_back_bin_v = tok + 17;
-      if (hotplug_back_bin_v)
-      {
-        if (!*hotplug_back_bin_v ||
-            snprintf(opts->hotplug_back_bin_opt, sizeof(opts->hotplug_back_bin_opt), "%s",
-                     hotplug_back_bin_v) >= (int)sizeof(opts->hotplug_back_bin_opt))
-        {
-          fprintf(stderr, "invalid -o hotplug_back_bin path: '%s'\n", hotplug_back_bin_v);
-          free(dup);
-          return 2;
-        }
-        continue;
-      }
-
-      if (strcmp(tok, "multi_thread") == 0 || strcmp(tok, "multi-thread") == 0 ||
-          strcmp(tok, "multithread") == 0)
-      {
-        want_mt = 1;
-        continue;
-      }
-
-      const char *vstr = NULL;
-      if (strncmp(tok, "multi_thread=", 13) == 0)
-        vstr = tok + 13;
-      else if (strncmp(tok, "multi-thread=", 13) == 0)
-        vstr = tok + 13;
-      else if (strncmp(tok, "multithread=", 12) == 0)
-        vstr = tok + 12;
-      if (vstr)
-      {
-        char *endp = NULL;
-        unsigned long v = strtoul(vstr, &endp, 10);
-        if (!endp || *endp != '\0')
-        {
-          fprintf(stderr, "invalid -o multi_thread=N: '%s'\n", vstr);
-          free(dup);
-          return 2;
-        }
-        if (v < 1)
-          v = 1;
-        if (v > 100000)
-          v = 100000;
-        opts->mt_cnt_override = (unsigned)v;
-        opts->mt_cnt_override_set = 1;
-        want_mt = 1;
-        continue;
-      }
-
-      const char *prio_str = NULL;
-      if (strncmp(tok, "pending_worker_prio=", 20) == 0)
-        prio_str = tok + 20;
-      else if (strncmp(tok, "dedup_worker_prio=", 18) == 0)
-        prio_str = tok + 18;
-      if (prio_str)
-      {
-        if (kafs_pending_worker_prio_mode_parse(prio_str, &opts->pending_worker_prio_mode) != 0)
-        {
-          fprintf(stderr, "invalid -o pending_worker_prio: '%s'\n", prio_str);
-          free(dup);
-          return 2;
-        }
-        continue;
-      }
-
-      const char *nice_str = NULL;
-      if (strncmp(tok, "pending_worker_nice=", 20) == 0)
-        nice_str = tok + 20;
-      else if (strncmp(tok, "dedup_worker_nice=", 18) == 0)
-        nice_str = tok + 18;
-      if (nice_str)
-      {
-        char *endp = NULL;
-        long v = strtol(nice_str, &endp, 10);
-        if (!endp || *endp != '\0' || v < 0 || v > 19)
-        {
-          fprintf(stderr, "invalid -o pending_worker_nice: '%s'\n", nice_str);
-          free(dup);
-          return 2;
-        }
-        opts->pending_worker_nice = (int)v;
-        continue;
-      }
-
-      const char *ttl_soft_str = NULL;
-      if (strncmp(tok, "pending_ttl_soft_ms=", 20) == 0)
-        ttl_soft_str = tok + 20;
-      if (ttl_soft_str)
-      {
-        if (kafs_parse_u32_range(ttl_soft_str, 0, 3600000u, &opts->pending_ttl_soft_ms) != 0)
-        {
-          fprintf(stderr, "invalid -o pending_ttl_soft_ms: '%s'\n", ttl_soft_str);
-          free(dup);
-          return 2;
-        }
-        continue;
-      }
-
-      const char *ttl_hard_str = NULL;
-      if (strncmp(tok, "pending_ttl_hard_ms=", 20) == 0)
-        ttl_hard_str = tok + 20;
-      if (ttl_hard_str)
-      {
-        if (kafs_parse_u32_range(ttl_hard_str, 0, 3600000u, &opts->pending_ttl_hard_ms) != 0)
-        {
-          fprintf(stderr, "invalid -o pending_ttl_hard_ms: '%s'\n", ttl_hard_str);
-          free(dup);
-          return 2;
-        }
-        continue;
-      }
-
-      const char *pcap_initial_str = NULL;
-      if (strncmp(tok, "pendinglog_cap_initial=", 23) == 0)
-        pcap_initial_str = tok + 23;
-      else if (strncmp(tok, "pending_cap_initial=", 20) == 0)
-        pcap_initial_str = tok + 20;
-      if (pcap_initial_str)
-      {
-        if (kafs_parse_u32_range(pcap_initial_str, 0, 1000000000u, &opts->pending_cap_initial) != 0)
-        {
-          fprintf(stderr, "invalid -o pendinglog_cap_initial: '%s'\n", pcap_initial_str);
-          free(dup);
-          return 2;
-        }
-        continue;
-      }
-
-      const char *pcap_min_str = NULL;
-      if (strncmp(tok, "pendinglog_cap_min=", 19) == 0)
-        pcap_min_str = tok + 19;
-      else if (strncmp(tok, "pending_cap_min=", 16) == 0)
-        pcap_min_str = tok + 16;
-      if (pcap_min_str)
-      {
-        if (kafs_parse_u32_range(pcap_min_str, 0, 1000000000u, &opts->pending_cap_min) != 0)
-        {
-          fprintf(stderr, "invalid -o pendinglog_cap_min: '%s'\n", pcap_min_str);
-          free(dup);
-          return 2;
-        }
-        continue;
-      }
-
-      const char *pcap_max_str = NULL;
-      if (strncmp(tok, "pendinglog_cap_max=", 19) == 0)
-        pcap_max_str = tok + 19;
-      else if (strncmp(tok, "pending_cap_max=", 16) == 0)
-        pcap_max_str = tok + 16;
-      if (pcap_max_str)
-      {
-        if (kafs_parse_u32_range(pcap_max_str, 0, 1000000000u, &opts->pending_cap_max) != 0)
-        {
-          fprintf(stderr, "invalid -o pendinglog_cap_max: '%s'\n", pcap_max_str);
-          free(dup);
-          return 2;
-        }
-        continue;
-      }
-
-      const char *fsp_str = NULL;
-      if (strncmp(tok, "fsync_policy=", 13) == 0)
-        fsp_str = tok + 13;
-      if (fsp_str)
-      {
-        if (kafs_fsync_policy_parse(fsp_str, &opts->fsync_policy) != 0)
-        {
-          fprintf(stderr, "invalid -o fsync_policy: '%s'\n", fsp_str);
-          free(dup);
-          return 2;
-        }
-        continue;
-      }
-
-      if (strcmp(tok, "bg_dedup_scan") == 0 || strcmp(tok, "bg_dedup_scan=on") == 0 ||
-          strcmp(tok, "dedup_scan") == 0 || strcmp(tok, "dedup_scan=on") == 0)
-      {
-        opts->bg_dedup_scan_enabled = 1u;
-        continue;
-      }
-      if (strcmp(tok, "no_bg_dedup_scan") == 0 || strcmp(tok, "bg_dedup_scan=off") == 0 ||
-          strcmp(tok, "no_dedup_scan") == 0 || strcmp(tok, "dedup_scan=off") == 0)
-      {
-        opts->bg_dedup_scan_enabled = 0u;
-        continue;
-      }
-
-      const char *bg_scan_str = NULL;
-      if (strncmp(tok, "bg_dedup_scan=", 14) == 0)
-        bg_scan_str = tok + 14;
-      else if (strncmp(tok, "dedup_scan=", 11) == 0)
-        bg_scan_str = tok + 11;
-      if (bg_scan_str)
-      {
-        if (kafs_parse_onoff(bg_scan_str, &opts->bg_dedup_scan_enabled) != 0)
-        {
-          fprintf(stderr, "invalid -o dedup_scan/bg_dedup_scan: '%s'\n", bg_scan_str);
-          free(dup);
-          return 2;
-        }
-        continue;
-      }
-
-      const char *bg_interval_str = NULL;
-      if (strncmp(tok, "bg_dedup_interval_ms=", 21) == 0)
-        bg_interval_str = tok + 21;
-      else if (strncmp(tok, "dedup_interval_ms=", 18) == 0)
-        bg_interval_str = tok + 18;
-      if (bg_interval_str)
-      {
-        if (kafs_parse_u32_range(bg_interval_str, KAFS_BG_DEDUP_INTERVAL_MS_MIN,
-                                 KAFS_BG_DEDUP_INTERVAL_MS_MAX, &opts->bg_dedup_interval_ms) != 0)
-        {
-          fprintf(stderr, "invalid -o dedup_interval_ms/bg_dedup_interval_ms: '%s'\n",
-                  bg_interval_str);
-          free(dup);
-          return 2;
-        }
-        continue;
-      }
-
-      const char *bg_quiet_interval_str = NULL;
-      if (strncmp(tok, "bg_dedup_quiet_interval_ms=", 27) == 0)
-        bg_quiet_interval_str = tok + 27;
-      else if (strncmp(tok, "dedup_quiet_interval_ms=", 24) == 0)
-        bg_quiet_interval_str = tok + 24;
-      if (bg_quiet_interval_str)
-      {
-        if (kafs_parse_u32_range(bg_quiet_interval_str, KAFS_BG_DEDUP_INTERVAL_MS_MIN,
-                                 KAFS_BG_DEDUP_INTERVAL_MS_MAX,
-                                 &opts->bg_dedup_quiet_interval_ms) != 0)
-        {
-          fprintf(stderr, "invalid -o dedup_quiet_interval_ms/bg_dedup_quiet_interval_ms: '%s'\n",
-                  bg_quiet_interval_str);
-          free(dup);
-          return 2;
-        }
-        continue;
-      }
-
-      const char *bg_pressure_interval_str = NULL;
-      if (strncmp(tok, "bg_dedup_pressure_interval_ms=", 30) == 0)
-        bg_pressure_interval_str = tok + 30;
-      else if (strncmp(tok, "dedup_pressure_interval_ms=", 27) == 0)
-        bg_pressure_interval_str = tok + 27;
-      if (bg_pressure_interval_str)
-      {
-        if (kafs_parse_u32_range(bg_pressure_interval_str, KAFS_BG_DEDUP_INTERVAL_MS_MIN,
-                                 KAFS_BG_DEDUP_INTERVAL_MS_MAX,
-                                 &opts->bg_dedup_pressure_interval_ms) != 0)
-        {
-          fprintf(stderr,
-                  "invalid -o dedup_pressure_interval_ms/bg_dedup_pressure_interval_ms: '%s'\n",
-                  bg_pressure_interval_str);
-          free(dup);
-          return 2;
-        }
-        continue;
-      }
-
-      const char *bg_start_pct_str = NULL;
-      if (strncmp(tok, "bg_dedup_start_used_pct=", 24) == 0)
-        bg_start_pct_str = tok + 24;
-      else if (strncmp(tok, "dedup_start_used_pct=", 21) == 0)
-        bg_start_pct_str = tok + 21;
-      if (bg_start_pct_str)
-      {
-        if (kafs_parse_u32_range(bg_start_pct_str, 0, 100u, &opts->bg_dedup_start_used_pct) != 0)
-        {
-          fprintf(stderr, "invalid -o dedup_start_used_pct/bg_dedup_start_used_pct: '%s'\n",
-                  bg_start_pct_str);
-          free(dup);
-          return 2;
-        }
-        continue;
-      }
-
-      const char *bg_pressure_pct_str = NULL;
-      if (strncmp(tok, "bg_dedup_pressure_used_pct=", 27) == 0)
-        bg_pressure_pct_str = tok + 27;
-      else if (strncmp(tok, "dedup_pressure_used_pct=", 24) == 0)
-        bg_pressure_pct_str = tok + 24;
-      if (bg_pressure_pct_str)
-      {
-        if (kafs_parse_u32_range(bg_pressure_pct_str, 0, 100u, &opts->bg_dedup_pressure_used_pct) !=
-            0)
-        {
-          fprintf(stderr, "invalid -o dedup_pressure_used_pct/bg_dedup_pressure_used_pct: '%s'\n",
-                  bg_pressure_pct_str);
-          free(dup);
-          return 2;
-        }
-        continue;
-      }
-
-      const char *bg_prio_str = NULL;
-      if (strncmp(tok, "bg_dedup_worker_prio=", 21) == 0)
-        bg_prio_str = tok + 21;
-      else if (strncmp(tok, "dedup_scan_worker_prio=", 23) == 0)
-        bg_prio_str = tok + 23;
-      if (bg_prio_str)
-      {
-        if (kafs_pending_worker_prio_mode_parse(bg_prio_str, &opts->bg_dedup_worker_prio_mode) != 0)
-        {
-          fprintf(stderr, "invalid -o bg_dedup_worker_prio/dedup_scan_worker_prio: '%s'\n",
-                  bg_prio_str);
-          free(dup);
-          return 2;
-        }
-        continue;
-      }
-
-      const char *bg_nice_str = NULL;
-      if (strncmp(tok, "bg_dedup_worker_nice=", 21) == 0)
-        bg_nice_str = tok + 21;
-      else if (strncmp(tok, "dedup_scan_worker_nice=", 23) == 0)
-        bg_nice_str = tok + 23;
-      if (bg_nice_str)
-      {
-        char *endp = NULL;
-        long v = strtol(bg_nice_str, &endp, 10);
-        if (!endp || *endp != '\0' || v < 0 || v > 19)
-        {
-          fprintf(stderr, "invalid -o bg_dedup_worker_nice/dedup_scan_worker_nice: '%s'\n",
-                  bg_nice_str);
-          free(dup);
-          return 2;
-        }
-        opts->bg_dedup_worker_nice = (int)v;
-        continue;
-      }
-
-      size_t tlen = strlen(tok);
-      size_t need = tlen + (used ? 1 : 0);
-      if (need)
-      {
-        if (used)
-          filtered[used++] = ',';
-        memcpy(filtered + used, tok, tlen);
-        used += tlen;
-        filtered[used] = '\0';
-      }
+      kafs_main_append_filtered_token(filtered, &used, tok);
     }
 
     free(dup);

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -6817,9 +6817,7 @@ static ssize_t kafs_hotplug_call_read(struct fuse_context *fctx, kafs_context_t 
   return rc;
 }
 
-static ssize_t kafs_hotplug_call_write(struct fuse_context *fctx, kafs_context_t *ctx,
-                                       kafs_inocnt_t ino, const char *buf, size_t size,
-                                       off_t offset)
+static int kafs_hotplug_write_validate_request(kafs_context_t *ctx, size_t size)
 {
   int wait_rc = kafs_hotplug_wait_ready(ctx);
   if (wait_rc != 0)
@@ -6829,8 +6827,13 @@ static ssize_t kafs_hotplug_call_write(struct fuse_context *fctx, kafs_context_t
   if (ctx->c_hotplug_data_mode == KAFS_RPC_DATA_INLINE &&
       size > (KAFS_RPC_MAX_PAYLOAD - sizeof(kafs_rpc_write_req_t)))
     return -EOPNOTSUPP;
+  return 0;
+}
 
-  uint8_t payload[KAFS_RPC_MAX_PAYLOAD];
+static uint32_t kafs_hotplug_write_prepare_payload(struct fuse_context *fctx, kafs_context_t *ctx,
+                                                   kafs_inocnt_t ino, const char *buf, size_t size,
+                                                   off_t offset, uint8_t *payload)
+{
   kafs_rpc_write_req_t *req = (kafs_rpc_write_req_t *)payload;
   req->ino = (uint32_t)ino;
   req->uid = (uint32_t)fctx->uid;
@@ -6845,13 +6848,42 @@ static ssize_t kafs_hotplug_call_write(struct fuse_context *fctx, kafs_context_t
     memcpy(payload + sizeof(*req), buf, size);
     payload_len = (uint32_t)(sizeof(*req) + size);
   }
+  return payload_len;
+}
+
+static int kafs_hotplug_write_finish(kafs_context_t *ctx, int rc, int need_local, kafs_inocnt_t ino,
+                                     const char *buf, size_t size, off_t offset)
+{
+  if (kafs_hotplug_is_disconnect_error(rc))
+  {
+    kafs_hotplug_mark_disconnected(ctx, rc);
+    rc = -EIO;
+  }
+  if (rc == 0 && need_local)
+  {
+    ssize_t wlen = kafs_core_write(ctx, ino, buf, size, offset);
+    rc = wlen < 0 ? (int)wlen : (int)wlen;
+  }
+  return rc;
+}
+
+static ssize_t kafs_hotplug_call_write(struct fuse_context *fctx, kafs_context_t *ctx,
+                                       kafs_inocnt_t ino, const char *buf, size_t size,
+                                       off_t offset)
+{
+  int rc = kafs_hotplug_write_validate_request(ctx, size);
+  if (rc != 0)
+    return rc;
+
+  uint8_t payload[KAFS_RPC_MAX_PAYLOAD];
+  uint32_t payload_len =
+      kafs_hotplug_write_prepare_payload(fctx, ctx, ino, buf, size, offset, payload);
   uint64_t req_id = kafs_rpc_next_req_id();
 
   if (ctx->c_hotplug_lock_init)
     pthread_mutex_lock(&ctx->c_hotplug_lock);
-  int rc =
-      kafs_rpc_send_msg(ctx->c_hotplug_fd, KAFS_RPC_OP_WRITE, KAFS_RPC_FLAG_ENDIAN_HOST, req_id,
-                        ctx->c_hotplug_session_id, ctx->c_hotplug_epoch, payload, payload_len);
+  rc = kafs_rpc_send_msg(ctx->c_hotplug_fd, KAFS_RPC_OP_WRITE, KAFS_RPC_FLAG_ENDIAN_HOST, req_id,
+                         ctx->c_hotplug_session_id, ctx->c_hotplug_epoch, payload, payload_len);
   int need_local = 0;
   if (rc == 0)
   {
@@ -6877,17 +6909,7 @@ static ssize_t kafs_hotplug_call_write(struct fuse_context *fctx, kafs_context_t
   }
   if (ctx->c_hotplug_lock_init)
     pthread_mutex_unlock(&ctx->c_hotplug_lock);
-  if (kafs_hotplug_is_disconnect_error(rc))
-  {
-    kafs_hotplug_mark_disconnected(ctx, rc);
-    rc = -EIO;
-  }
-  if (rc == 0 && need_local)
-  {
-    ssize_t wlen = kafs_core_write(ctx, ino, buf, size, offset);
-    rc = wlen < 0 ? (int)wlen : (int)wlen;
-  }
-  return rc;
+  return kafs_hotplug_write_finish(ctx, rc, need_local, ino, buf, size, offset);
 }
 
 static int kafs_hotplug_call_truncate(struct fuse_context *fctx, kafs_context_t *ctx,

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -4093,6 +4093,38 @@ static int kafs_tailmeta_resolve_slot_shape(const kafs_sinode_taildesc_v5_t *tai
   return 0;
 }
 
+static int kafs_tailmeta_lookup_container(struct kafs_context *ctx,
+                                          const kafs_sinode_taildesc_v5_t *taildesc,
+                                          struct kafs_tailmeta_region_view *view,
+                                          uint32_t *out_container_index)
+{
+  int rc = kafs_tailmeta_region_view_get(ctx, view);
+  if (rc != 0)
+    return rc;
+
+  return kafs_tailmeta_find_container_index_by_blo(
+      view, kafs_ino_taildesc_v5_container_blo_get(taildesc), out_container_index);
+}
+
+static int kafs_tailmeta_validate_slot_for_inode(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                                 const kafs_sinode_taildesc_v5_t *taildesc,
+                                                 const struct kafs_tailmeta_region_view *view,
+                                                 uint32_t container_index, uint16_t class_bytes,
+                                                 uint16_t slot_index)
+{
+  kafs_tailmeta_slot_desc_t *slot = kafs_tailmeta_slot_desc_ptr(view, container_index, slot_index);
+  if (!slot)
+    return -ERANGE;
+
+  kafs_tailmeta_inode_desc_t desc;
+  kafs_inocnt_t ino = (kafs_inocnt_t)kafs_ctx_ino_no(ctx, inoent);
+  kafs_off_t inode_size = kafs_ino_size_get(inoent);
+  kafs_blksize_t blksize = kafs_sb_blksize_get(ctx->c_superblock);
+  kafs_tailmeta_inode_desc_from_inode_taildesc(&desc, taildesc);
+  return kafs_tailmeta_inode_desc_matches_slot_for_inode(&desc, slot, class_bytes, ino, inode_size,
+                                                         blksize);
+}
+
 static int kafs_tailmeta_lookup_tail_slot(struct kafs_context *ctx, kafs_sinode_t *inoent,
                                           const kafs_sinode_taildesc_v5_t *taildesc,
                                           struct kafs_tailmeta_region_view *view,
@@ -4100,13 +4132,7 @@ static int kafs_tailmeta_lookup_tail_slot(struct kafs_context *ctx, kafs_sinode_
                                           uint16_t *out_class_bytes, uint16_t *out_len,
                                           char **out_payload)
 {
-  kafs_tailmeta_slot_desc_t *slot;
-  kafs_tailmeta_inode_desc_t desc;
-  kafs_inocnt_t ino;
-  kafs_off_t inode_size;
-  kafs_blksize_t blksize;
   uint32_t container_index;
-  char *payload;
   int rc;
 
   if (!ctx || !inoent || !taildesc || !view || !out_container_index || !out_slot_index ||
@@ -4115,11 +4141,7 @@ static int kafs_tailmeta_lookup_tail_slot(struct kafs_context *ctx, kafs_sinode_
   if (!kafs_tail_layout_uses_tail_storage(kafs_ino_taildesc_v5_layout_kind_get(taildesc)))
     return -EINVAL;
 
-  rc = kafs_tailmeta_region_view_get(ctx, view);
-  if (rc != 0)
-    return rc;
-  rc = kafs_tailmeta_find_container_index_by_blo(
-      view, kafs_ino_taildesc_v5_container_blo_get(taildesc), &container_index);
+  rc = kafs_tailmeta_lookup_container(ctx, taildesc, view, &container_index);
   if (rc != 0)
     return rc;
 
@@ -4128,25 +4150,16 @@ static int kafs_tailmeta_lookup_tail_slot(struct kafs_context *ctx, kafs_sinode_
   if (rc != 0)
     return rc;
 
-  slot = kafs_tailmeta_slot_desc_ptr(view, container_index, *out_slot_index);
-  if (!slot)
-    return -ERANGE;
-
-  ino = (kafs_inocnt_t)kafs_ctx_ino_no(ctx, inoent);
-  inode_size = kafs_ino_size_get(inoent);
-  blksize = kafs_sb_blksize_get(ctx->c_superblock);
-  kafs_tailmeta_inode_desc_from_inode_taildesc(&desc, taildesc);
-  rc = kafs_tailmeta_inode_desc_matches_slot_for_inode(&desc, slot, *out_class_bytes, ino,
-                                                       inode_size, blksize);
+  rc = kafs_tailmeta_validate_slot_for_inode(ctx, inoent, taildesc, view, container_index,
+                                             *out_class_bytes, *out_slot_index);
   if (rc != 0)
     return rc;
 
-  payload = kafs_tailmeta_slot_payload_ptr(view, container_index, *out_slot_index);
-  if (!payload)
+  *out_payload = kafs_tailmeta_slot_payload_ptr(view, container_index, *out_slot_index);
+  if (!*out_payload)
     return -ERANGE;
 
   *out_container_index = container_index;
-  *out_payload = payload;
   return 0;
 }
 

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -12013,58 +12013,89 @@ static int kafs_main_start_hotplug(kafs_context_t *ctx, const char *image_path,
   return 0;
 }
 
+static int kafs_main_copy_fuse_args(char **argv_clean, int argc_clean, char **argv_fuse)
+{
+  int saw_single = 0;
+
+  for (int i = 0; i < argc_clean; ++i)
+  {
+    if (strcmp(argv_clean[i], "-s") == 0)
+      saw_single = 1;
+    argv_fuse[i] = argv_clean[i];
+  }
+
+  return saw_single;
+}
+
+static unsigned kafs_main_mt_thread_count(unsigned mt_cnt_override, int mt_cnt_override_set)
+{
+  unsigned mt_cnt = 8;
+
+  if (mt_cnt_override_set)
+  {
+    mt_cnt = mt_cnt_override;
+  }
+  else
+  {
+    const char *mt_env = getenv("KAFS_MAX_THREADS");
+    if (mt_env && *mt_env)
+    {
+      char *endp = NULL;
+      unsigned long v = strtoul(mt_env, &endp, 10);
+      if (endp && *endp == '\0')
+        mt_cnt = (unsigned)v;
+    }
+    if (mt_cnt < 1)
+      mt_cnt = 1;
+    if (mt_cnt > 100000)
+      mt_cnt = 100000;
+  }
+
+  return mt_cnt;
+}
+
+static void kafs_main_apply_fuse_debug_arg(char **argv_fuse, int *argc_fuse)
+{
+  if (kafs_debug_level() >= 3)
+    argv_fuse[(*argc_fuse)++] = "-d";
+}
+
+static void kafs_main_apply_fuse_single_arg(kafs_bool_t *enable_mt, int saw_single,
+                                            char **argv_fuse, int *argc_fuse)
+{
+  if (!*enable_mt && !saw_single)
+    argv_fuse[(*argc_fuse)++] = "-s";
+  if (*enable_mt && saw_single)
+    *enable_mt = KAFS_FALSE;
+}
+
+static void kafs_main_apply_fuse_mt_arg(kafs_bool_t enable_mt, int saw_max_threads,
+                                        unsigned mt_cnt_override, int mt_cnt_override_set,
+                                        char **argv_fuse, int *argc_fuse, char *mt_opt_buf,
+                                        size_t mt_opt_buf_size)
+{
+  if (!enable_mt || saw_max_threads)
+    return;
+
+  unsigned mt_cnt = kafs_main_mt_thread_count(mt_cnt_override, mt_cnt_override_set);
+  snprintf(mt_opt_buf, mt_opt_buf_size, "max_threads=%u", mt_cnt);
+  argv_fuse[(*argc_fuse)++] = "-o";
+  argv_fuse[(*argc_fuse)++] = mt_opt_buf;
+  kafs_log(KAFS_LOG_INFO, "kafs: enabling multithread with -o %s\n", mt_opt_buf);
+}
+
 static void kafs_main_build_fuse_argv(char **argv_clean, int argc_clean, kafs_bool_t *enable_mt,
                                       int saw_max_threads, unsigned mt_cnt_override,
                                       int mt_cnt_override_set, char **argv_fuse, int *argc_fuse,
                                       char *mt_opt_buf, size_t mt_opt_buf_size)
 {
-  int saw_single = 0;
-  for (int i = 0; i < argc_clean; ++i)
-  {
-    if (strcmp(argv_clean[i], "-s") == 0)
-    {
-      saw_single = 1;
-      break;
-    }
-    argv_fuse[i] = argv_clean[i];
-  }
+  int saw_single = kafs_main_copy_fuse_args(argv_clean, argc_clean, argv_fuse);
 
   *argc_fuse = argc_clean;
-  if (!*enable_mt && !saw_single)
-    argv_fuse[(*argc_fuse)++] = "-s";
-  if (*enable_mt && saw_single)
-    *enable_mt = KAFS_FALSE;
-  if (kafs_debug_level() >= 3)
-    argv_fuse[(*argc_fuse)++] = "-d";
-
-  if (*enable_mt && !saw_max_threads)
-  {
-    unsigned mt_cnt = 8;
-    if (mt_cnt_override_set)
-    {
-      mt_cnt = mt_cnt_override;
-    }
-    else
-    {
-      const char *mt_env = getenv("KAFS_MAX_THREADS");
-      if (mt_env && *mt_env)
-      {
-        char *endp = NULL;
-        unsigned long v = strtoul(mt_env, &endp, 10);
-        if (endp && *endp == '\0')
-          mt_cnt = (unsigned)v;
-      }
-      if (mt_cnt < 1)
-        mt_cnt = 1;
-      if (mt_cnt > 100000)
-        mt_cnt = 100000;
-    }
-
-    snprintf(mt_opt_buf, mt_opt_buf_size, "max_threads=%u", mt_cnt);
-    argv_fuse[(*argc_fuse)++] = "-o";
-    argv_fuse[(*argc_fuse)++] = mt_opt_buf;
-    kafs_log(KAFS_LOG_INFO, "kafs: enabling multithread with -o %s\n", mt_opt_buf);
-  }
+  kafs_main_apply_fuse_single_arg(enable_mt, saw_single, argv_fuse, argc_fuse);
+  kafs_main_apply_fuse_debug_arg(argv_fuse, argc_fuse);
+  kafs_main_apply_fuse_mt_arg(*enable_mt, saw_max_threads, mt_cnt_override, mt_cnt_override_set,
+                              argv_fuse, argc_fuse, mt_opt_buf, mt_opt_buf_size);
 
   argv_fuse[*argc_fuse] = NULL;
 }

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -556,6 +556,7 @@ typedef enum
 static int kafs_ino_ibrk_run(struct kafs_context *ctx, kafs_sinode_t *inoent, kafs_iblkcnt_t iblo,
                              kafs_blkcnt_t *pblo, kafs_iblkref_func_t ifunc);
 static int kafs_blk_read(struct kafs_context *ctx, kafs_blkcnt_t blo, void *buf);
+static void kafs_ino_blocks_adjust(kafs_sinode_t *inoent, int delta);
 static int kafs_pending_worker_start(struct kafs_context *ctx);
 static void kafs_pending_worker_stop(struct kafs_context *ctx);
 static int kafs_tombstone_gc_worker_start(struct kafs_context *ctx);
@@ -2768,6 +2769,47 @@ static int kafs_blk_read(struct kafs_context *ctx, kafs_blkcnt_t blo, void *buf)
   return KAFS_SUCCESS;
 }
 
+#if KAFS_ENABLE_EXTRA_DIAG
+static int kafs_diag_live_dir_block0_matches(kafs_sinode_t *inoent, kafs_blkcnt_t blo,
+                                             kafs_mode_t *mode_out)
+{
+  if (!kafs_ino_get_usage(inoent))
+    return 0;
+
+  kafs_mode_t mode = kafs_ino_mode_get(inoent);
+  if (!S_ISDIR(mode))
+    return 0;
+  if (kafs_ino_size_get(inoent) <= KAFS_INODE_DIRECT_BYTES)
+    return 0;
+  if (kafs_blkcnt_stoh(inoent->i_blkreftbl[0]) != blo)
+    return 0;
+
+  *mode_out = mode;
+  return 1;
+}
+
+static void kafs_diag_log_live_dir_block0_match(struct kafs_context *ctx, kafs_inocnt_t ino,
+                                                kafs_sinode_t *inoent, kafs_blkcnt_t blo,
+                                                kafs_mode_t mode, const char *hex_sample,
+                                                const char *ascii_sample)
+{
+  kafs_log(KAFS_LOG_WARNING,
+           "%s: blk=%" PRIuFAST32 " matches live dir block0 ino=%" PRIuFAST32
+           " mode=%o size=%" PRIuFAST64 " sample_hex=%s sample_ascii='%s'\n",
+           __func__, (uint_fast32_t)blo, (uint_fast32_t)ino, (unsigned)mode,
+           (uint_fast64_t)kafs_ino_size_get(inoent), hex_sample[0] ? hex_sample : "-",
+           ascii_sample[0] ? ascii_sample : "-");
+  kafs_diag_appendf(ctx,
+                    "%s: blk=%" PRIuFAST32 " matches live dir block0 ino=%" PRIuFAST32
+                    " mode=%o size=%" PRIuFAST64 " src_ino=%" PRIuFAST32
+                    " src_path=%s sample_hex=%s sample_ascii='%s'\n",
+                    __func__, (uint_fast32_t)blo, (uint_fast32_t)ino, (unsigned)mode,
+                    (uint_fast64_t)kafs_ino_size_get(inoent), (uint_fast32_t)g_diag_write_ino,
+                    g_diag_write_path ? g_diag_write_path : "(null)",
+                    hex_sample[0] ? hex_sample : "-", ascii_sample[0] ? ascii_sample : "-");
+}
+#endif
+
 static void kafs_diag_log_live_dir_block0_write(struct kafs_context *ctx, kafs_blkcnt_t blo,
                                                 const void *buf, size_t len)
 {
@@ -2779,35 +2821,15 @@ static void kafs_diag_log_live_dir_block0_write(struct kafs_context *ctx, kafs_b
   for (kafs_inocnt_t ino = KAFS_INO_ROOTDIR; ino < inocnt; ++ino)
   {
     kafs_sinode_t *inoent = kafs_ctx_inode(ctx, ino);
-    if (!kafs_ino_get_usage(inoent))
-      continue;
-    kafs_mode_t mode = kafs_ino_mode_get(inoent);
-    if (!S_ISDIR(mode))
-      continue;
-    if (kafs_ino_size_get(inoent) <= KAFS_INODE_DIRECT_BYTES)
-      continue;
-    kafs_blkcnt_t cur_ref = kafs_blkcnt_stoh(inoent->i_blkreftbl[0]);
-    if (cur_ref != blo)
+    kafs_mode_t mode;
+    if (!kafs_diag_live_dir_block0_matches(inoent, blo, &mode))
       continue;
 
     char hex_sample[3 * 16 + 1];
     char ascii_sample[16 + 1];
     kafs_diag_format_sample(buf, len, hex_sample, sizeof(hex_sample), ascii_sample,
                             sizeof(ascii_sample));
-    kafs_log(KAFS_LOG_WARNING,
-             "%s: blk=%" PRIuFAST32 " matches live dir block0 ino=%" PRIuFAST32
-             " mode=%o size=%" PRIuFAST64 " sample_hex=%s sample_ascii='%s'\n",
-             __func__, (uint_fast32_t)blo, (uint_fast32_t)ino, (unsigned)mode,
-             (uint_fast64_t)kafs_ino_size_get(inoent), hex_sample[0] ? hex_sample : "-",
-             ascii_sample[0] ? ascii_sample : "-");
-    kafs_diag_appendf(ctx,
-                      "%s: blk=%" PRIuFAST32 " matches live dir block0 ino=%" PRIuFAST32
-                      " mode=%o size=%" PRIuFAST64 " src_ino=%" PRIuFAST32
-                      " src_path=%s sample_hex=%s sample_ascii='%s'\n",
-                      __func__, (uint_fast32_t)blo, (uint_fast32_t)ino, (unsigned)mode,
-                      (uint_fast64_t)kafs_ino_size_get(inoent), (uint_fast32_t)g_diag_write_ino,
-                      g_diag_write_path ? g_diag_write_path : "(null)",
-                      hex_sample[0] ? hex_sample : "-", ascii_sample[0] ? ascii_sample : "-");
+    kafs_diag_log_live_dir_block0_match(ctx, ino, inoent, blo, mode, hex_sample, ascii_sample);
   }
 }
 

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -10518,20 +10518,64 @@ static void kafs_op_destroy(void *private_data)
   kafs_pending_worker_stop(ctx);
 }
 
+static int kafs_release_handle_ctl_path(const char *path, struct fuse_file_info *fi)
+{
+  if (!kafs_is_ctl_path(path))
+    return 0;
+
+  kafs_ctl_session_t *sess = (kafs_ctl_session_t *)(uintptr_t)fi->fh;
+  free(sess);
+  fi->fh = 0;
+  kafs_dlog(2, "%s: exit rc=0 ctl path=%s\n", __func__, path ? path : "(null)");
+  return 1;
+}
+
+static void kafs_release_finalize_last_open(struct kafs_context *ctx, kafs_inocnt_t ino,
+                                            int *reclaimed)
+{
+  int reclaim_now = kafs_tombstone_pressure(ctx);
+  kafs_inode_lock(ctx, (uint32_t)ino);
+  if (kafs_inode_is_tombstone(kafs_ctx_inode(ctx, ino)))
+  {
+    if (!reclaim_now)
+    {
+      int trc = kafs_tailmeta_try_reclaim_tombstone_payload_locked(ctx, ino);
+      if (trc < 0)
+      {
+        kafs_log(KAFS_LOG_WARNING, "%s: early tail reclaim failed ino=%" PRIuFAST32 " rc=%d\n",
+                 __func__, (uint32_t)ino, trc);
+      }
+    }
+    if (reclaim_now)
+      (void)kafs_try_reclaim_unlinked_inode_locked(ctx, ino, reclaimed);
+  }
+  else
+  {
+    int nrc = kafs_tailmeta_normalize_block_layout(ctx, kafs_ctx_inode(ctx, ino));
+    if (nrc < 0)
+      kafs_log(KAFS_LOG_WARNING, "%s: mixed tail normalize failed ino=%" PRIuFAST32 " rc=%d\n",
+               __func__, (uint32_t)ino, nrc);
+  }
+  kafs_inode_unlock(ctx, (uint32_t)ino);
+}
+
+static void kafs_release_record_reclaimed_inode(struct kafs_context *ctx)
+{
+  kafs_inode_alloc_lock(ctx);
+  (void)kafs_sb_inocnt_free_incr(ctx->c_superblock);
+  kafs_sb_wtime_set(ctx->c_superblock, kafs_now());
+  kafs_inode_alloc_unlock(ctx);
+}
+
 static int kafs_op_release(const char *path, struct fuse_file_info *fi)
 {
   struct fuse_context *fctx = fuse_get_context();
   struct kafs_context *ctx = fctx ? fctx->private_data : NULL;
   kafs_dlog(2, "%s: enter path=%s ino=%" PRIuFAST32 "\n", __func__, path ? path : "(null)",
             fi ? (uint32_t)fi->fh : (uint32_t)KAFS_INO_NONE);
-  if (kafs_is_ctl_path(path))
-  {
-    kafs_ctl_session_t *sess = (kafs_ctl_session_t *)(uintptr_t)fi->fh;
-    free(sess);
-    fi->fh = 0;
-    kafs_dlog(2, "%s: exit rc=0 ctl path=%s\n", __func__, path ? path : "(null)");
+  if (kafs_release_handle_ctl_path(path, fi))
     return 0;
-  }
+
   kafs_inocnt_t ino = fi->fh;
   int reclaimed = 0;
   if (ctx && ctx->c_open_cnt)
@@ -10541,38 +10585,10 @@ static int kafs_op_release(const char *path, struct fuse_file_info *fi)
               (uint32_t)ino, after);
     if (after == 0)
     {
-      int reclaim_now = kafs_tombstone_pressure(ctx);
-      kafs_inode_lock(ctx, (uint32_t)ino);
-      if (kafs_inode_is_tombstone(kafs_ctx_inode(ctx, ino)))
-      {
-        if (!reclaim_now)
-        {
-          int trc = kafs_tailmeta_try_reclaim_tombstone_payload_locked(ctx, ino);
-          if (trc < 0)
-          {
-            kafs_log(KAFS_LOG_WARNING, "%s: early tail reclaim failed ino=%" PRIuFAST32 " rc=%d\n",
-                     __func__, (uint32_t)ino, trc);
-          }
-        }
-        if (reclaim_now)
-          (void)kafs_try_reclaim_unlinked_inode_locked(ctx, ino, &reclaimed);
-      }
-      else
-      {
-        int nrc = kafs_tailmeta_normalize_block_layout(ctx, kafs_ctx_inode(ctx, ino));
-        if (nrc < 0)
-          kafs_log(KAFS_LOG_WARNING, "%s: mixed tail normalize failed ino=%" PRIuFAST32 " rc=%d\n",
-                   __func__, (uint32_t)ino, nrc);
-      }
-      kafs_inode_unlock(ctx, (uint32_t)ino);
+      kafs_release_finalize_last_open(ctx, ino, &reclaimed);
 
       if (reclaimed)
-      {
-        kafs_inode_alloc_lock(ctx);
-        (void)kafs_sb_inocnt_free_incr(ctx->c_superblock);
-        kafs_sb_wtime_set(ctx->c_superblock, kafs_now());
-        kafs_inode_alloc_unlock(ctx);
-      }
+        kafs_release_record_reclaimed_inode(ctx);
     }
   }
   int rc = kafs_op_flush(path, fi);

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -8207,62 +8207,60 @@ static int kafs_ctl_handle_set_runtime(kafs_context_t *ctx, uint32_t payload_len
   return 0;
 }
 
-static int kafs_ctl_handle_request(kafs_context_t *ctx, kafs_ctl_session_t *sess,
-                                   const unsigned char *buf, size_t size)
+static int kafs_ctl_parse_request(const unsigned char *buf, size_t size, kafs_rpc_hdr_t *hdr)
 {
-  if (!ctx || !sess || !buf)
+  if (!buf || !hdr)
     return -EINVAL;
-  if (size < sizeof(kafs_rpc_hdr_t) || size > KAFS_CTL_MAX_REQ)
+  if (size < sizeof(*hdr) || size > KAFS_CTL_MAX_REQ)
     return -EINVAL;
 
-  kafs_rpc_hdr_t hdr;
-  memcpy(&hdr, buf, sizeof(hdr));
-  if (hdr.magic != KAFS_RPC_MAGIC || hdr.version != KAFS_RPC_VERSION)
+  memcpy(hdr, buf, sizeof(*hdr));
+  if (hdr->magic != KAFS_RPC_MAGIC || hdr->version != KAFS_RPC_VERSION)
     return -EPROTONOSUPPORT;
-  if (hdr.payload_len > KAFS_RPC_MAX_PAYLOAD)
+  if (hdr->payload_len > KAFS_RPC_MAX_PAYLOAD)
     return -EMSGSIZE;
-  if (sizeof(hdr) + hdr.payload_len != size)
+  if (sizeof(*hdr) + hdr->payload_len != size)
     return -EBADMSG;
+  return 0;
+}
 
-  const unsigned char *payload = buf + sizeof(hdr);
-  unsigned char resp_payload[KAFS_RPC_MAX_PAYLOAD];
-  uint32_t resp_len = 0;
-  int32_t result = 0;
-
-  switch (hdr.op)
+static int32_t kafs_ctl_dispatch_request(kafs_context_t *ctx, const kafs_rpc_hdr_t *hdr,
+                                         const unsigned char *payload, unsigned char *resp_payload,
+                                         uint32_t *resp_len)
+{
+  switch (hdr->op)
   {
   case KAFS_RPC_OP_CTL_STATUS:
   case KAFS_RPC_OP_CTL_COMPAT:
-    kafs_ctl_write_status_response(ctx, resp_payload, &resp_len);
-    break;
+    kafs_ctl_write_status_response(ctx, resp_payload, resp_len);
+    return 0;
   case KAFS_RPC_OP_CTL_RESTART:
-    result = kafs_hotplug_restart_back(ctx);
-    break;
+    return kafs_hotplug_restart_back(ctx);
   case KAFS_RPC_OP_CTL_SET_TIMEOUT:
-    result = kafs_ctl_handle_set_timeout(ctx, hdr.payload_len, payload);
-    break;
+    return kafs_ctl_handle_set_timeout(ctx, hdr->payload_len, payload);
   case KAFS_RPC_OP_CTL_ENV_LIST:
-    kafs_ctl_write_env_list_response(ctx, resp_payload, &resp_len);
-    break;
+    kafs_ctl_write_env_list_response(ctx, resp_payload, resp_len);
+    return 0;
   case KAFS_RPC_OP_CTL_ENV_SET:
-    result = kafs_ctl_handle_env_update(ctx, hdr.payload_len, payload, 0);
-    break;
+    return kafs_ctl_handle_env_update(ctx, hdr->payload_len, payload, 0);
   case KAFS_RPC_OP_CTL_ENV_UNSET:
-    result = kafs_ctl_handle_env_update(ctx, hdr.payload_len, payload, 1);
-    break;
+    return kafs_ctl_handle_env_update(ctx, hdr->payload_len, payload, 1);
   case KAFS_RPC_OP_CTL_SET_DEDUP_PRIO:
-    result = kafs_ctl_handle_set_dedup_prio(ctx, hdr.payload_len, payload);
-    break;
+    return kafs_ctl_handle_set_dedup_prio(ctx, hdr->payload_len, payload);
   case KAFS_RPC_OP_CTL_SET_RUNTIME:
-    result = kafs_ctl_handle_set_runtime(ctx, hdr.payload_len, payload);
-    break;
+    return kafs_ctl_handle_set_runtime(ctx, hdr->payload_len, payload);
   default:
-    result = -ENOSYS;
-    break;
+    return -ENOSYS;
   }
+}
 
+static int kafs_ctl_store_response(kafs_ctl_session_t *sess, const kafs_rpc_hdr_t *hdr,
+                                   int32_t result, const unsigned char *resp_payload,
+                                   uint32_t resp_len)
+{
   kafs_rpc_resp_hdr_t rhdr;
-  rhdr.req_id = hdr.req_id;
+
+  rhdr.req_id = hdr->req_id;
   rhdr.result = result;
   rhdr.payload_len = resp_len;
   if (sizeof(rhdr) + resp_len > sizeof(sess->resp))
@@ -8271,6 +8269,28 @@ static int kafs_ctl_handle_request(kafs_context_t *ctx, kafs_ctl_session_t *sess
   if (resp_len != 0)
     memcpy(sess->resp + sizeof(rhdr), resp_payload, resp_len);
   sess->resp_len = sizeof(rhdr) + resp_len;
+  return 0;
+}
+
+static int kafs_ctl_handle_request(kafs_context_t *ctx, kafs_ctl_session_t *sess,
+                                   const unsigned char *buf, size_t size)
+{
+  if (!ctx || !sess || !buf)
+    return -EINVAL;
+
+  kafs_rpc_hdr_t hdr;
+  int rc = kafs_ctl_parse_request(buf, size, &hdr);
+  if (rc != 0)
+    return rc;
+
+  const unsigned char *payload = buf + sizeof(hdr);
+  unsigned char resp_payload[KAFS_RPC_MAX_PAYLOAD];
+  uint32_t resp_len = 0;
+  int32_t result = kafs_ctl_dispatch_request(ctx, &hdr, payload, resp_payload, &resp_len);
+
+  rc = kafs_ctl_store_response(sess, &hdr, result, resp_payload, resp_len);
+  if (rc != 0)
+    return rc;
   return (int)size;
 }
 

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -910,51 +910,53 @@ static void kafs_pending_worker_notify_all(struct kafs_context *ctx)
   pthread_mutex_unlock(&ctx->c_pending_worker_lock);
 }
 
-static void kafs_pending_worker_adjust_priority_locked(struct kafs_context *ctx)
+static void kafs_pending_worker_watermarks(struct kafs_context *ctx, uint32_t *high_wm,
+                                           uint32_t *low_wm)
 {
-  if (!ctx || !ctx->c_pending_worker_running)
-    return;
-
-  kafs_pendinglog_hdr_t *hdr = kafs_pendinglog_hdr_ptr(ctx);
-  if (!hdr || hdr->capacity == 0)
-    return;
-
-  // Hysteresis: boost near full, restore after queue is drained enough.
   kafs_pendinglog_adapt_capacity_locked(ctx);
   uint32_t cap = ctx->c_pendinglog_capacity;
   if (cap < KAFS_PENDINGLOG_CAPACITY_FLOOR)
     cap = KAFS_PENDINGLOG_CAPACITY_FLOOR;
-  uint32_t high_wm = cap - (cap / 8u); // 87.5%
-  uint32_t low_wm = cap / 2u;          // 50%
-  if (high_wm <= low_wm)
-    high_wm = low_wm + 1u;
+  *high_wm = cap - (cap / 8u);
+  *low_wm = cap / 2u;
+  if (*high_wm <= *low_wm)
+    *high_wm = *low_wm + 1u;
+}
 
-  uint32_t qcnt = kafs_pendinglog_count(ctx);
-  uint64_t oldest_age_ms = 0;
-  uint32_t over_soft = 0;
-  uint32_t over_hard = 0;
+static uint64_t kafs_pending_worker_oldest_age_ms(struct kafs_context *ctx,
+                                                  kafs_pendinglog_hdr_t *hdr, uint32_t qcnt)
+{
+  if (qcnt == 0)
+    return 0;
 
-  if (qcnt > 0)
-  {
-    kafs_pendinglog_entry_t *head = kafs_pendinglog_entry_ptr(ctx, hdr->head);
-    uint64_t now_rt_ns = kafs_now_realtime_ns();
-    if (head && head->seq > 0)
-    {
-      // If timestamp looks far in the future (clock jump/corruption), ignore this sample.
-      if (head->seq <= now_rt_ns + 300000000000ull && now_rt_ns >= head->seq)
-        oldest_age_ms = (now_rt_ns - head->seq) / 1000000ull;
-    }
-  }
+  kafs_pendinglog_entry_t *head = kafs_pendinglog_entry_ptr(ctx, hdr->head);
+  uint64_t now_rt_ns = kafs_now_realtime_ns();
+  if (!head || head->seq == 0)
+    return 0;
+  if (head->seq > now_rt_ns + 300000000000ull || now_rt_ns < head->seq)
+    return 0;
+  return (now_rt_ns - head->seq) / 1000000ull;
+}
 
+static void kafs_pending_worker_update_ttl_state(struct kafs_context *ctx, uint64_t oldest_age_ms,
+                                                 uint32_t *over_soft, uint32_t *over_hard)
+{
+  *over_soft = 0;
+  *over_hard = 0;
   if (ctx->c_pending_ttl_soft_ms > 0 && oldest_age_ms >= (uint64_t)ctx->c_pending_ttl_soft_ms)
-    over_soft = 1;
+    *over_soft = 1;
   if (ctx->c_pending_ttl_hard_ms > 0 && oldest_age_ms >= (uint64_t)ctx->c_pending_ttl_hard_ms)
-    over_hard = 1;
+    *over_hard = 1;
 
   ctx->c_pending_oldest_age_ms = oldest_age_ms;
-  ctx->c_pending_ttl_over_soft = over_soft;
-  ctx->c_pending_ttl_over_hard = over_hard;
+  ctx->c_pending_ttl_over_soft = *over_soft;
+  ctx->c_pending_ttl_over_hard = *over_hard;
+}
 
+static void kafs_pending_worker_apply_auto_boost(struct kafs_context *ctx, uint32_t qcnt,
+                                                 uint32_t high_wm, uint32_t low_wm,
+                                                 uint32_t over_soft)
+{
   if (!ctx->c_pending_worker_auto_boosted)
   {
     if ((qcnt >= high_wm || over_soft) &&
@@ -976,6 +978,27 @@ static void kafs_pending_worker_adjust_priority_locked(struct kafs_context *ctx)
     ctx->c_pending_worker_prio_dirty = 1;
     ctx->c_pending_worker_auto_boosted = 0;
   }
+}
+
+static void kafs_pending_worker_adjust_priority_locked(struct kafs_context *ctx)
+{
+  if (!ctx || !ctx->c_pending_worker_running)
+    return;
+
+  kafs_pendinglog_hdr_t *hdr = kafs_pendinglog_hdr_ptr(ctx);
+  if (!hdr || hdr->capacity == 0)
+    return;
+
+  uint32_t high_wm = 0;
+  uint32_t low_wm = 0;
+  kafs_pending_worker_watermarks(ctx, &high_wm, &low_wm);
+
+  uint32_t qcnt = kafs_pendinglog_count(ctx);
+  uint32_t over_soft = 0;
+  uint32_t over_hard = 0;
+  uint64_t oldest_age_ms = kafs_pending_worker_oldest_age_ms(ctx, hdr, qcnt);
+  kafs_pending_worker_update_ttl_state(ctx, oldest_age_ms, &over_soft, &over_hard);
+  kafs_pending_worker_apply_auto_boost(ctx, qcnt, high_wm, low_wm, over_soft);
 }
 
 static void kafs_pending_worker_begin_boost(struct kafs_context *ctx, uint32_t *saved_mode,

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -8380,6 +8380,87 @@ static int kafs_op_truncate(const char *path, off_t size, struct fuse_file_info 
   return rc == 0 ? 0 : rc;
 }
 
+static int kafs_fallocate_expand_locked(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                        uint32_t ino, kafs_off_t end_req)
+{
+  kafs_inode_lock(ctx, ino);
+  kafs_off_t filesize = kafs_ino_size_get(inoent);
+  int rc = 0;
+  if (end_req > filesize)
+    rc = kafs_truncate(ctx, inoent, end_req);
+  kafs_inode_unlock(ctx, ino);
+  return rc;
+}
+
+static int kafs_fallocate_zero_left_edge(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                         kafs_off_t offset, kafs_off_t end, kafs_blksize_t blksize,
+                                         kafs_logblksize_t log_blksize)
+{
+  if ((offset & ((kafs_off_t)blksize - 1)) == 0)
+    return 0;
+
+  kafs_iblkcnt_t iblo = (kafs_iblkcnt_t)(offset >> log_blksize);
+  char wbuf[blksize];
+  int rc = kafs_ino_iblk_read_or_zero(ctx, inoent, iblo, wbuf);
+  if (rc < 0)
+    return rc;
+
+  kafs_blksize_t start = (kafs_blksize_t)(offset & ((kafs_off_t)blksize - 1));
+  kafs_blksize_t stop = blksize;
+  if ((kafs_off_t)(iblo + 1) << log_blksize > end)
+    stop = (kafs_blksize_t)(end & ((kafs_off_t)blksize - 1));
+  if (stop <= start)
+    return 0;
+
+  memset(wbuf + start, 0, stop - start);
+  return kafs_ino_iblk_write(ctx, inoent, iblo, wbuf);
+}
+
+static int kafs_fallocate_release_full_blocks(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                              kafs_off_t filesize, kafs_iblkcnt_t first_full,
+                                              kafs_iblkcnt_t last_full_excl)
+{
+  if (filesize <= KAFS_INODE_DIRECT_BYTES)
+    return 0;
+
+  for (kafs_iblkcnt_t iblo = first_full; iblo < last_full_excl; ++iblo)
+  {
+    int rc = kafs_ino_iblk_release(ctx, inoent, iblo);
+    if (rc < 0)
+      return rc;
+  }
+  return 0;
+}
+
+static int kafs_fallocate_zero_right_edge(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                          kafs_off_t offset, kafs_off_t end, kafs_off_t filesize,
+                                          kafs_blksize_t blksize, kafs_logblksize_t log_blksize)
+{
+  if ((end & ((kafs_off_t)blksize - 1)) == 0)
+    return 0;
+
+  kafs_iblkcnt_t iblo = (kafs_iblkcnt_t)(end >> log_blksize);
+  if ((offset >> log_blksize) == (kafs_off_t)iblo && (offset & ((kafs_off_t)blksize - 1)) != 0)
+    return 0;
+
+  kafs_blksize_t stop = (kafs_blksize_t)(end & ((kafs_off_t)blksize - 1));
+  if (end == filesize)
+  {
+    kafs_blksize_t valid = (kafs_blksize_t)(filesize & ((kafs_off_t)blksize - 1));
+    if (valid == 0)
+      valid = blksize;
+    if (stop == valid && filesize > KAFS_INODE_DIRECT_BYTES)
+      return kafs_ino_iblk_release(ctx, inoent, iblo);
+  }
+
+  char wbuf[blksize];
+  int rc = kafs_ino_iblk_read_or_zero(ctx, inoent, iblo, wbuf);
+  if (rc < 0)
+    return rc;
+  memset(wbuf, 0, stop);
+  return kafs_ino_iblk_write(ctx, inoent, iblo, wbuf);
+}
+
 static int kafs_op_fallocate(const char *path, int mode, off_t offset, off_t length,
                              struct fuse_file_info *fi)
 {
@@ -8416,13 +8497,7 @@ static int kafs_op_fallocate(const char *path, int mode, off_t offset, off_t len
     if ((mode & FALLOC_FL_KEEP_SIZE) != 0)
       return 0;
 
-    kafs_inode_lock(ctx, ino);
-    kafs_off_t filesize = kafs_ino_size_get(inoent);
-    int rc = 0;
-    if (end_req > filesize)
-      rc = kafs_truncate(ctx, inoent, end_req);
-    kafs_inode_unlock(ctx, ino);
-    return rc;
+    return kafs_fallocate_expand_locked(ctx, inoent, ino, end_req);
   }
 
   if ((mode & FALLOC_FL_KEEP_SIZE) == 0)
@@ -8444,88 +8519,18 @@ static int kafs_op_fallocate(const char *path, int mode, off_t offset, off_t len
 
   kafs_blksize_t blksize = kafs_sb_blksize_get(ctx->c_superblock);
   kafs_logblksize_t log_blksize = kafs_sb_log_blksize_get(ctx->c_superblock);
-  char zbuf[blksize];
-  memset(zbuf, 0, blksize);
+  rc = kafs_fallocate_zero_left_edge(ctx, inoent, (kafs_off_t)offset, end, blksize, log_blksize);
+  if (rc < 0)
+    goto fallocate_unlock;
 
-  // 左端の部分ブロックは穴化せずゼロ埋めする。
-  if (((kafs_off_t)offset & ((kafs_off_t)blksize - 1)) != 0)
-  {
-    kafs_iblkcnt_t iblo = (kafs_iblkcnt_t)((kafs_off_t)offset >> log_blksize);
-    char wbuf[blksize];
-    rc = kafs_ino_iblk_read_or_zero(ctx, inoent, iblo, wbuf);
-    if (rc < 0)
-      goto fallocate_unlock;
-    kafs_blksize_t s = (kafs_blksize_t)((kafs_off_t)offset & ((kafs_off_t)blksize - 1));
-    kafs_blksize_t e = blksize;
-    if ((kafs_off_t)(iblo + 1) << log_blksize > end)
-      e = (kafs_blksize_t)(end & ((kafs_off_t)blksize - 1));
-    if (e > s)
-    {
-      memset(wbuf + s, 0, e - s);
-      rc = kafs_ino_iblk_write(ctx, inoent, iblo, wbuf);
-      if (rc < 0)
-        goto fallocate_unlock;
-    }
-  }
-
-  // 完全に範囲に含まれるブロックのみ穴化する。
   kafs_iblkcnt_t first_full = (kafs_iblkcnt_t)(((kafs_off_t)offset + blksize - 1) >> log_blksize);
   kafs_iblkcnt_t last_full_excl = (kafs_iblkcnt_t)(end >> log_blksize);
-  for (kafs_iblkcnt_t iblo = first_full; iblo < last_full_excl; ++iblo)
-  {
-    if (filesize > KAFS_INODE_DIRECT_BYTES)
-    {
-      rc = kafs_ino_iblk_release(ctx, inoent, iblo);
-      if (rc < 0)
-        goto fallocate_unlock;
-    }
-  }
+  rc = kafs_fallocate_release_full_blocks(ctx, inoent, filesize, first_full, last_full_excl);
+  if (rc < 0)
+    goto fallocate_unlock;
 
-  // 右端の部分ブロックは穴化せずゼロ埋めする。
-  if ((end & ((kafs_off_t)blksize - 1)) != 0)
-  {
-    kafs_iblkcnt_t iblo = (kafs_iblkcnt_t)(end >> log_blksize);
-    if (((kafs_off_t)offset >> log_blksize) != (kafs_off_t)iblo ||
-        ((kafs_off_t)offset & ((kafs_off_t)blksize - 1)) == 0)
-    {
-      kafs_blksize_t e = (kafs_blksize_t)(end & ((kafs_off_t)blksize - 1));
-      // 右端が EOF の場合、EOF 外は hole とみなし、論理ファイル範囲が全て対象なら穴化する。
-      if (end == filesize)
-      {
-        kafs_blksize_t valid = (kafs_blksize_t)(filesize & ((kafs_off_t)blksize - 1));
-        if (valid == 0)
-          valid = blksize;
-        if (e == valid && filesize > KAFS_INODE_DIRECT_BYTES)
-        {
-          rc = kafs_ino_iblk_release(ctx, inoent, iblo);
-          if (rc < 0)
-            goto fallocate_unlock;
-        }
-        else
-        {
-          char wbuf[blksize];
-          rc = kafs_ino_iblk_read_or_zero(ctx, inoent, iblo, wbuf);
-          if (rc < 0)
-            goto fallocate_unlock;
-          memset(wbuf, 0, e);
-          rc = kafs_ino_iblk_write(ctx, inoent, iblo, wbuf);
-          if (rc < 0)
-            goto fallocate_unlock;
-        }
-      }
-      else
-      {
-        char wbuf[blksize];
-        rc = kafs_ino_iblk_read_or_zero(ctx, inoent, iblo, wbuf);
-        if (rc < 0)
-          goto fallocate_unlock;
-        memset(wbuf, 0, e);
-        rc = kafs_ino_iblk_write(ctx, inoent, iblo, wbuf);
-        if (rc < 0)
-          goto fallocate_unlock;
-      }
-    }
-  }
+  rc = kafs_fallocate_zero_right_edge(ctx, inoent, (kafs_off_t)offset, end, filesize, blksize,
+                                      log_blksize);
 
 fallocate_unlock:
   kafs_inode_unlock(ctx, ino);

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -11705,6 +11705,99 @@ static int kafs_main_handle_mount_token(kafs_main_options_t *opts, const char *t
   return kafs_main_handle_bg_dedup_token(opts, tok);
 }
 
+static int kafs_main_extract_mount_arg(char **argv_clean, int argc_clean, int *index,
+                                       const char **oval_out, int *is_compact_out)
+{
+  const char *arg = argv_clean[*index];
+
+  *oval_out = NULL;
+  *is_compact_out = 0;
+  if (strcmp(arg, "-o") == 0)
+  {
+    if (*index + 1 < argc_clean)
+    {
+      *oval_out = argv_clean[++(*index)];
+      return 0;
+    }
+    return 1;
+  }
+
+  if (strncmp(arg, "-o", 2) == 0 && arg[2] != '\0')
+  {
+    *oval_out = arg + 2;
+    *is_compact_out = 1;
+  }
+  return 0;
+}
+
+static int kafs_main_filter_mount_tokens(kafs_main_options_t *opts, const char *oval,
+                                         char *filtered, size_t filtered_size, int *want_mt_out)
+{
+  char *dup = strdup(oval);
+  if (!dup)
+  {
+    perror("strdup");
+    return 2;
+  }
+
+  filtered[0] = '\0';
+  size_t used = 0;
+  int want_mt = 0;
+  char *saveptr = NULL;
+  for (char *tok = strtok_r(dup, ",", &saveptr); tok; tok = strtok_r(NULL, ",", &saveptr))
+  {
+    int rc = kafs_main_handle_mount_token(opts, tok, &want_mt);
+    if (rc == 2)
+    {
+      free(dup);
+      return 2;
+    }
+    if (rc == 1)
+      continue;
+
+    kafs_main_append_filtered_token(filtered, &used, tok);
+  }
+
+  free(dup);
+  (void)filtered_size;
+  *want_mt_out = want_mt;
+  return 0;
+}
+
+static int kafs_main_append_mount_arg(char **argv_user, int *argc_user, char **o_owned,
+                                      int *o_owned_cnt, const char *filtered, int is_compact)
+{
+  char *kept = NULL;
+
+  if (is_compact)
+  {
+    kept = (char *)malloc(strlen(filtered) + 3);
+    if (!kept)
+    {
+      perror("malloc");
+      return 2;
+    }
+    kept[0] = '-';
+    kept[1] = 'o';
+    strcpy(kept + 2, filtered);
+    argv_user[(*argc_user)++] = kept;
+  }
+  else
+  {
+    kept = strdup(filtered);
+    if (!kept)
+    {
+      perror("strdup");
+      return 2;
+    }
+    argv_user[(*argc_user)++] = "-o";
+    argv_user[(*argc_user)++] = kept;
+  }
+
+  o_owned[(*o_owned_cnt)++] = kept;
+  return 0;
+}
+
 static int kafs_main_filter_mount_options(kafs_main_options_t *opts, char **argv_clean,
                                           int *argc_clean)
 {
@@ -11715,23 +11808,13 @@ static int kafs_main_filter_mount_options(kafs_main_options_t *opts, char **argv
 
   for (int i = 0; i < *argc_clean; ++i)
   {
-    const char *a = argv_clean[i];
     const char *oval = NULL;
     int is_compact = 0;
-    if (strcmp(a, "-o") == 0)
+    int rc = kafs_main_extract_mount_arg(argv_clean, *argc_clean, &i, &oval, &is_compact);
+    if (rc == 1)
     {
-      if (i + 1 < *argc_clean)
-        oval = argv_clean[++i];
-      else
-      {
-        argv_user[argc_user++] = argv_clean[i];
-        continue;
-      }
-    }
-    else if (strncmp(a, "-o", 2) == 0 && a[2] != '\0')
-    {
-      oval = a + 2;
-      is_compact = 1;
+      argv_user[argc_user++] = argv_clean[i];
+      continue;
     }
 
     if (!oval)
@@ -11740,64 +11823,20 @@ static int kafs_main_filter_mount_options(kafs_main_options_t *opts, char **argv
       continue;
     }
 
-    char *dup = strdup(oval);
-    if (!dup)
-    {
-      perror("strdup");
-      return 2;
-    }
     char filtered[strlen(oval) + 1];
-    filtered[0] = '\0';
-    size_t used = 0;
     int want_mt = 0;
-
-    char *saveptr = NULL;
-    for (char *tok = strtok_r(dup, ",", &saveptr); tok; tok = strtok_r(NULL, ",", &saveptr))
-    {
-      int rc = kafs_main_handle_mount_token(opts, tok, &want_mt);
-      if (rc == 2)
-      {
-        free(dup);
-        return 2;
-      }
-      if (rc == 1)
-        continue;
-
-      kafs_main_append_filtered_token(filtered, &used, tok);
-    }
-
-    free(dup);
+    rc = kafs_main_filter_mount_tokens(opts, oval, filtered, sizeof(filtered), &want_mt);
+    if (rc != 0)
+      return rc;
     if (want_mt)
       opts->enable_mt = KAFS_TRUE;
 
     if (filtered[0] != '\0')
     {
-      char *kept = NULL;
-      if (is_compact)
-      {
-        kept = (char *)malloc(strlen(filtered) + 3);
-        if (!kept)
-        {
-          perror("malloc");
-          return 2;
-        }
-        kept[0] = '-';
-        kept[1] = 'o';
-        strcpy(kept + 2, filtered);
-        argv_user[argc_user++] = kept;
-      }
-      else
-      {
-        kept = strdup(filtered);
-        if (!kept)
-        {
-          perror("strdup");
-          return 2;
-        }
-        argv_user[argc_user++] = "-o";
-        argv_user[argc_user++] = kept;
-      }
-      o_owned[o_owned_cnt++] = kept;
+      rc = kafs_main_append_mount_arg(argv_user, &argc_user, o_owned, &o_owned_cnt, filtered,
+                                      is_compact);
+      if (rc != 0)
+        return rc;
     }
   }
 

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -9258,6 +9258,120 @@ static int kafs_rename_update_dotdot_locked(struct kafs_context *ctx, uint64_t j
   return 0;
 }
 
+static int kafs_rename_validate_request(const char *from, const char *to, unsigned int flags)
+{
+  if (kafs_is_ctl_path(from) || kafs_is_ctl_path(to))
+    return -EACCES;
+  if (from == NULL || to == NULL || from[0] != '/' || to[0] != '/')
+    return -EINVAL;
+  if (strcmp(from, to) == 0)
+    return 0;
+
+  size_t from_len = strlen(from);
+  if (from_len > 1 && strncmp(to, from, from_len) == 0 && to[from_len] == '/')
+    return -EINVAL;
+
+  if (flags & ~RENAME_NOREPLACE)
+    return -EOPNOTSUPP;
+  return 1;
+}
+
+static int kafs_rename_check_source(struct fuse_context *fctx, struct kafs_context *ctx,
+                                    const char *from, kafs_sinode_t **inoent_src_out,
+                                    int *src_is_dir_out)
+{
+  int rc = kafs_access(fctx, ctx, from, NULL, F_OK, inoent_src_out);
+  if (rc < 0)
+    return rc;
+
+  kafs_mode_t src_mode = kafs_ino_mode_get(*inoent_src_out);
+  *src_is_dir_out = S_ISDIR(src_mode) ? 1 : 0;
+  if (!S_ISREG(src_mode) && !S_ISLNK(src_mode) && !*src_is_dir_out)
+    return -EOPNOTSUPP;
+  return 0;
+}
+
+static int kafs_rename_parse_paths(const char *from, const char *to, char *from_copy,
+                                   const char **from_dir, char **from_base, char *to_copy,
+                                   const char **to_dir, char **to_base)
+{
+  int rc = kafs_split_parent_basename(from, from_copy, from_dir, from_base);
+  if (rc < 0)
+    return rc;
+  return kafs_split_parent_basename(to, to_copy, to_dir, to_base);
+}
+
+static int kafs_rename_lookup_parent_dirs(struct fuse_context *fctx, struct kafs_context *ctx,
+                                          const char *from_dir, const char *to_dir,
+                                          kafs_sinode_t **inoent_dir_from,
+                                          kafs_sinode_t **inoent_dir_to, uint32_t *ino_from_dir,
+                                          uint32_t *ino_to_dir)
+{
+  int rc = kafs_access(fctx, ctx, from_dir, NULL, W_OK, inoent_dir_from);
+  if (rc < 0)
+    return rc;
+  rc = kafs_access(fctx, ctx, to_dir, NULL, W_OK, inoent_dir_to);
+  if (rc < 0)
+    return rc;
+  *ino_from_dir = kafs_ctx_ino_no(ctx, *inoent_dir_from);
+  *ino_to_dir = kafs_ctx_ino_no(ctx, *inoent_dir_to);
+  return 0;
+}
+
+static int kafs_rename_check_noreplace(struct fuse_context *fctx, struct kafs_context *ctx,
+                                       const char *to, unsigned int flags, uint64_t jseq)
+{
+  if (!(flags & RENAME_NOREPLACE))
+    return 0;
+
+  kafs_sinode_t *inoent_tmp;
+  int ex = kafs_access(fctx, ctx, to, NULL, F_OK, &inoent_tmp);
+  if (ex == 0)
+  {
+    kafs_journal_abort(ctx, jseq, "EEXIST");
+    return -EEXIST;
+  }
+  if (ex != -ENOENT)
+  {
+    kafs_journal_abort(ctx, jseq, "access(to)=%d", ex);
+    return ex;
+  }
+  return 0;
+}
+
+static int kafs_rename_check_destination_type(struct fuse_context *fctx, struct kafs_context *ctx,
+                                              const char *to, uint64_t jseq, int src_is_dir,
+                                              kafs_sinode_t **inoent_to_exist, int *exists_to)
+{
+  *inoent_to_exist = NULL;
+  *exists_to = kafs_access(fctx, ctx, to, NULL, F_OK, inoent_to_exist);
+  if (*exists_to != 0)
+    return (*exists_to == -ENOENT) ? 0 : *exists_to;
+
+  kafs_mode_t dst_mode = kafs_ino_mode_get(*inoent_to_exist);
+  if (src_is_dir)
+  {
+    if (!S_ISDIR(dst_mode))
+    {
+      kafs_journal_abort(ctx, jseq, "DST_NOT_DIR");
+      return -ENOTDIR;
+    }
+    return 0;
+  }
+
+  if (S_ISDIR(dst_mode))
+  {
+    kafs_journal_abort(ctx, jseq, "DST_IS_DIR");
+    return -EISDIR;
+  }
+  if (!S_ISREG(dst_mode) && !S_ISLNK(dst_mode))
+  {
+    kafs_journal_abort(ctx, jseq, "DST_NOT_FILE");
+    return -EOPNOTSUPP;
+  }
+  return 0;
+}
+
 static void kafs_rename_finalize_replaced_inode(struct kafs_context *ctx,
                                                 kafs_inocnt_t removed_dst_ino)
 {
@@ -9286,107 +9400,52 @@ static int kafs_op_rename(const char *from, const char *to, unsigned int flags)
   struct kafs_context *ctx = fctx->private_data;
   kafs_dlog(2, "%s: enter from=%s to=%s flags=%u\n", __func__, from ? from : "(null)",
             to ? to : "(null)", flags);
-  if (kafs_is_ctl_path(from) || kafs_is_ctl_path(to))
-    return -EACCES;
-  if (from == NULL || to == NULL || from[0] != '/' || to[0] != '/')
-    return -EINVAL;
-  if (strcmp(from, to) == 0)
-    return 0;
-
-  // ディレクトリを自身の配下へ移動する rename は許可しない（ループ防止）。
-  // 例: rename("/a", "/a/b")
-  size_t from_len = strlen(from);
-  if (from_len > 1 && strncmp(to, from, from_len) == 0 && to[from_len] == '/')
-    return -EINVAL;
-
-  const unsigned int supported = RENAME_NOREPLACE;
-  if (flags & ~supported)
-    return -EOPNOTSUPP;
-
-  // 事前に対象 inode を確認（ディレクトリは同一親ディレクトリ内のみ対応）
   kafs_sinode_t *inoent_src;
-  int rc = kafs_access(fctx, ctx, from, NULL, F_OK, &inoent_src);
+  int src_is_dir = 0;
+  int rc = kafs_rename_validate_request(from, to, flags);
+  if (rc <= 0)
+    return rc;
+  rc = kafs_rename_check_source(fctx, ctx, from, &inoent_src, &src_is_dir);
   if (rc < 0)
     return rc;
-  kafs_mode_t src_mode = kafs_ino_mode_get(inoent_src);
-  int src_is_dir = S_ISDIR(src_mode) ? 1 : 0;
-  if (!S_ISREG(src_mode) && !S_ISLNK(src_mode) && !src_is_dir)
-    return -EOPNOTSUPP;
 
   char from_copy[strlen(from) + 1];
   const char *from_dir = from_copy;
   char *from_base = NULL;
-  rc = kafs_split_parent_basename(from, from_copy, &from_dir, &from_base);
-  if (rc < 0)
-    return rc;
-
   char to_copy[strlen(to) + 1];
   const char *to_dir = to_copy;
   char *to_base = NULL;
-  rc = kafs_split_parent_basename(to, to_copy, &to_dir, &to_base);
+  rc = kafs_rename_parse_paths(from, to, from_copy, &from_dir, &from_base, to_copy, &to_dir,
+                               &to_base);
   if (rc < 0)
     return rc;
 
   uint64_t jseq = kafs_journal_begin(ctx, "RENAME", "from=%s to=%s flags=%u", from, to, flags);
 
   kafs_sinode_t *inoent_dir_from;
-  KAFS_CALL(kafs_access, fctx, ctx, from_dir, NULL, W_OK, &inoent_dir_from);
   kafs_sinode_t *inoent_dir_to;
-  KAFS_CALL(kafs_access, fctx, ctx, to_dir, NULL, W_OK, &inoent_dir_to);
-  uint32_t ino_from_dir = kafs_ctx_ino_no(ctx, inoent_dir_from);
-  uint32_t ino_to_dir = kafs_ctx_ino_no(ctx, inoent_dir_to);
-
-  // RENAME_NOREPLACE: 既存なら EEXIST
-  if (flags & RENAME_NOREPLACE)
+  uint32_t ino_from_dir = 0;
+  uint32_t ino_to_dir = 0;
+  rc = kafs_rename_lookup_parent_dirs(fctx, ctx, from_dir, to_dir, &inoent_dir_from, &inoent_dir_to,
+                                      &ino_from_dir, &ino_to_dir);
+  if (rc < 0)
   {
-    kafs_sinode_t *inoent_tmp;
-    int ex = kafs_access(fctx, ctx, to, NULL, F_OK, &inoent_tmp);
-    if (ex == 0)
-    {
-      kafs_journal_abort(ctx, jseq, "EEXIST");
-      return -EEXIST;
-    }
-    if (ex != -ENOENT)
-    {
-      kafs_journal_abort(ctx, jseq, "access(to)=%d", ex);
-      return ex;
-    }
+    kafs_journal_abort(ctx, jseq, "parent_lookup=%d", rc);
+    return rc;
   }
+  rc = kafs_rename_check_noreplace(fctx, ctx, to, flags, jseq);
+  if (rc < 0)
+    return rc;
 
-  // 取得しておく（from の inode番号）
   kafs_inocnt_t ino_src = kafs_ctx_ino_no(ctx, inoent_src);
 
-  // 置換先が存在する場合は削除（通常ファイルのみ）
   kafs_sinode_t *inoent_to_exist = NULL;
-  int exists_to = kafs_access(fctx, ctx, to, NULL, F_OK, &inoent_to_exist);
-  if (exists_to == 0)
-  {
-    kafs_mode_t dst_mode = kafs_ino_mode_get(inoent_to_exist);
-    int dst_is_dir = S_ISDIR(dst_mode) ? 1 : 0;
-    if (src_is_dir)
-    {
-      if (!dst_is_dir)
-      {
-        kafs_journal_abort(ctx, jseq, "DST_NOT_DIR");
-        return -ENOTDIR;
-      }
-    }
-    else
-    {
-      if (dst_is_dir)
-      {
-        kafs_journal_abort(ctx, jseq, "DST_IS_DIR");
-        return -EISDIR;
-      }
-      if (!S_ISREG(dst_mode) && !S_ISLNK(dst_mode))
-      {
-        kafs_journal_abort(ctx, jseq, "DST_NOT_FILE");
-        return -EOPNOTSUPP;
-      }
-    }
-  }
+  int exists_to = 0;
+  rc = kafs_rename_check_destination_type(fctx, ctx, to, jseq, src_is_dir, &inoent_to_exist,
+                                          &exists_to);
+  if (rc < 0)
+    return rc;
 
-  // ロック順序: 関係 inode を番号昇順に取得（親ディレクトリ2つ + 対象 inode + (置換先 inode)）。
   uint32_t ino_src_u32 = (uint32_t)ino_src;
   uint32_t ino_dst_u32 = UINT32_MAX;
   if (exists_to == 0 && inoent_to_exist)

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -4989,28 +4989,37 @@ static void kafs_truncate_release_deferred_refs(struct kafs_context *ctx, uint32
   kafs_inode_lock(ctx, ino_idx);
 }
 
+static int kafs_truncate_release_tail_only_slot(struct kafs_context *ctx,
+                                                const kafs_sinode_taildesc_v5_t *taildesc)
+{
+  struct kafs_tailmeta_region_view view;
+  uint32_t container_index;
+  uint16_t class_bytes;
+  uint16_t slot_index;
+  int rc = kafs_tailmeta_region_view_get(ctx, &view);
+  if (rc != 0)
+    return rc;
+
+  rc = kafs_tailmeta_find_container_index_by_blo(
+      &view, kafs_ino_taildesc_v5_container_blo_get(taildesc), &container_index);
+  if (rc != 0)
+    return rc;
+
+  class_bytes = kafs_tailmeta_container_hdr_class_bytes_get(&view.containers[container_index]);
+  if (class_bytes == 0u || kafs_ino_taildesc_v5_fragment_off_get(taildesc) % class_bytes != 0u)
+    return -EPROTO;
+
+  slot_index = (uint16_t)(kafs_ino_taildesc_v5_fragment_off_get(taildesc) / class_bytes);
+  return kafs_tailmeta_release_slot(&view, container_index, slot_index);
+}
+
 static int kafs_truncate_handle_tail_only(struct kafs_context *ctx, kafs_sinode_t *inoent,
                                           const kafs_sinode_taildesc_v5_t *taildesc,
                                           kafs_off_t filesize_new, kafs_blksize_t blksize)
 {
   if (filesize_new == 0)
   {
-    struct kafs_tailmeta_region_view view;
-    uint32_t container_index;
-    uint16_t class_bytes;
-    uint16_t slot_index;
-    int rc = kafs_tailmeta_region_view_get(ctx, &view);
-    if (rc != 0)
-      return rc;
-    rc = kafs_tailmeta_find_container_index_by_blo(
-        &view, kafs_ino_taildesc_v5_container_blo_get(taildesc), &container_index);
-    if (rc != 0)
-      return rc;
-    class_bytes = kafs_tailmeta_container_hdr_class_bytes_get(&view.containers[container_index]);
-    if (class_bytes == 0u || kafs_ino_taildesc_v5_fragment_off_get(taildesc) % class_bytes != 0u)
-      return -EPROTO;
-    slot_index = (uint16_t)(kafs_ino_taildesc_v5_fragment_off_get(taildesc) / class_bytes);
-    KAFS_CALL(kafs_tailmeta_release_slot, &view, container_index, slot_index);
+    KAFS_CALL(kafs_truncate_release_tail_only_slot, ctx, taildesc);
     memset(inoent->i_blkreftbl, 0, sizeof(inoent->i_blkreftbl));
     kafs_ino_blocks_set(inoent, 0);
     kafs_ino_size_set(inoent, 0);
@@ -5020,26 +5029,11 @@ static int kafs_truncate_handle_tail_only(struct kafs_context *ctx, kafs_sinode_
 
   if (filesize_new <= (kafs_off_t)KAFS_INODE_DIRECT_BYTES)
   {
-    struct kafs_tailmeta_region_view view;
-    uint32_t container_index;
-    uint16_t class_bytes;
-    uint16_t slot_index;
     char inline_buf[KAFS_INODE_DIRECT_BYTES];
     int rc = kafs_tailmeta_tail_only_load(ctx, inoent, inline_buf, filesize_new, 0);
     if (rc != 0)
       return rc;
-    rc = kafs_tailmeta_region_view_get(ctx, &view);
-    if (rc != 0)
-      return rc;
-    rc = kafs_tailmeta_find_container_index_by_blo(
-        &view, kafs_ino_taildesc_v5_container_blo_get(taildesc), &container_index);
-    if (rc != 0)
-      return rc;
-    class_bytes = kafs_tailmeta_container_hdr_class_bytes_get(&view.containers[container_index]);
-    if (class_bytes == 0u || kafs_ino_taildesc_v5_fragment_off_get(taildesc) % class_bytes != 0u)
-      return -EPROTO;
-    slot_index = (uint16_t)(kafs_ino_taildesc_v5_fragment_off_get(taildesc) / class_bytes);
-    KAFS_CALL(kafs_tailmeta_release_slot, &view, container_index, slot_index);
+    KAFS_CALL(kafs_truncate_release_tail_only_slot, ctx, taildesc);
     memset(inoent->i_blkreftbl, 0, sizeof(inoent->i_blkreftbl));
     memcpy(inoent->i_blkreftbl, inline_buf, (size_t)filesize_new);
     if (filesize_new < (kafs_off_t)KAFS_INODE_DIRECT_BYTES)

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -8834,6 +8834,62 @@ fallocate_unlock:
   return rc;
 }
 
+static off_t kafs_lseek_find_data_locked(kafs_context_t *ctx, kafs_sinode_t *inoent, uint32_t ino,
+                                         off_t off, kafs_logblksize_t log_blksize,
+                                         kafs_iblkcnt_t start_iblo, kafs_iblkcnt_t end_iblo)
+{
+  for (kafs_iblkcnt_t iblo = start_iblo; iblo < end_iblo; ++iblo)
+  {
+    kafs_blkcnt_t blo = KAFS_BLO_NONE;
+    int rc = kafs_ino_ibrk_run(ctx, inoent, iblo, &blo, KAFS_IBLKREF_FUNC_GET);
+    if (rc < 0)
+    {
+      kafs_inode_unlock(ctx, ino);
+      return rc;
+    }
+    if (blo == KAFS_BLO_NONE)
+      continue;
+
+    kafs_off_t pos = ((kafs_off_t)iblo << log_blksize);
+    if (pos < (kafs_off_t)off)
+      pos = (kafs_off_t)off;
+    kafs_inode_unlock(ctx, ino);
+    return (off_t)pos;
+  }
+
+  kafs_inode_unlock(ctx, ino);
+  return -ENXIO;
+}
+
+static off_t kafs_lseek_find_hole_locked(kafs_context_t *ctx, kafs_sinode_t *inoent, uint32_t ino,
+                                         off_t off, kafs_off_t size, kafs_logblksize_t log_blksize,
+                                         kafs_iblkcnt_t start_iblo, kafs_iblkcnt_t end_iblo)
+{
+  for (kafs_iblkcnt_t iblo = start_iblo; iblo < end_iblo; ++iblo)
+  {
+    kafs_blkcnt_t blo = KAFS_BLO_NONE;
+    int rc = kafs_ino_ibrk_run(ctx, inoent, iblo, &blo, KAFS_IBLKREF_FUNC_GET);
+    if (rc < 0)
+    {
+      kafs_inode_unlock(ctx, ino);
+      return rc;
+    }
+    if (blo != KAFS_BLO_NONE)
+      continue;
+
+    kafs_off_t pos = ((kafs_off_t)iblo << log_blksize);
+    if (pos < (kafs_off_t)off)
+      pos = (kafs_off_t)off;
+    if (pos > size)
+      pos = size;
+    kafs_inode_unlock(ctx, ino);
+    return (off_t)pos;
+  }
+
+  kafs_inode_unlock(ctx, ino);
+  return (off_t)size;
+}
+
 static off_t kafs_op_lseek(const char *path, off_t off, int whence, struct fuse_file_info *fi)
 {
   struct fuse_context *fctx = fuse_get_context();
@@ -8865,9 +8921,7 @@ static off_t kafs_op_lseek(const char *path, off_t off, int whence, struct fuse_
   if (size <= KAFS_INODE_DIRECT_BYTES)
   {
     kafs_inode_unlock(ctx, ino);
-    if (whence == SEEK_DATA)
-      return off;
-    return (off_t)size;
+    return (whence == SEEK_DATA) ? off : (off_t)size;
   }
 
   kafs_blksize_t blksize = kafs_sb_blksize_get(ctx->c_superblock);
@@ -8876,53 +8930,9 @@ static off_t kafs_op_lseek(const char *path, off_t off, int whence, struct fuse_
   kafs_iblkcnt_t end_iblo = (kafs_iblkcnt_t)((size + blksize - 1) >> log_blksize);
 
   if (whence == SEEK_DATA)
-  {
-    for (kafs_iblkcnt_t iblo = start_iblo; iblo < end_iblo; ++iblo)
-    {
-      kafs_blkcnt_t blo = KAFS_BLO_NONE;
-      int rc = kafs_ino_ibrk_run(ctx, inoent, iblo, &blo, KAFS_IBLKREF_FUNC_GET);
-      if (rc < 0)
-      {
-        kafs_inode_unlock(ctx, ino);
-        return rc;
-      }
-      if (blo != KAFS_BLO_NONE)
-      {
-        kafs_off_t pos = ((kafs_off_t)iblo << log_blksize);
-        if (pos < (kafs_off_t)off)
-          pos = (kafs_off_t)off;
-        kafs_inode_unlock(ctx, ino);
-        return (off_t)pos;
-      }
-    }
-    kafs_inode_unlock(ctx, ino);
-    return -ENXIO;
-  }
-
-  // SEEK_HOLE
-  for (kafs_iblkcnt_t iblo = start_iblo; iblo < end_iblo; ++iblo)
-  {
-    kafs_blkcnt_t blo = KAFS_BLO_NONE;
-    int rc = kafs_ino_ibrk_run(ctx, inoent, iblo, &blo, KAFS_IBLKREF_FUNC_GET);
-    if (rc < 0)
-    {
-      kafs_inode_unlock(ctx, ino);
-      return rc;
-    }
-    if (blo == KAFS_BLO_NONE)
-    {
-      kafs_off_t pos = ((kafs_off_t)iblo << log_blksize);
-      if (pos < (kafs_off_t)off)
-        pos = (kafs_off_t)off;
-      if (pos > size)
-        pos = size;
-      kafs_inode_unlock(ctx, ino);
-      return (off_t)pos;
-    }
-  }
-
-  kafs_inode_unlock(ctx, ino);
-  return (off_t)size;
+    return kafs_lseek_find_data_locked(ctx, inoent, ino, off, log_blksize, start_iblo, end_iblo);
+  return kafs_lseek_find_hole_locked(ctx, inoent, ino, off, size, log_blksize, start_iblo,
+                                     end_iblo);
 }
 
 static int kafs_op_mkdir(const char *path, mode_t mode)

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -1872,6 +1872,21 @@ static void kafs_bg_dedup_step(struct kafs_context *ctx, int pressure_mode)
   }
 }
 
+static void kafs_pending_worker_record_exit(kafs_context_t *ctx);
+static int kafs_pending_worker_wait_next(kafs_context_t *ctx, uint32_t *idx,
+                                         kafs_pendinglog_entry_t *ent);
+static void kafs_pending_worker_skip_terminal_entry(kafs_context_t *ctx, uint32_t idx);
+static int kafs_pending_worker_try_install_block(kafs_context_t *ctx,
+                                                 const kafs_pendinglog_entry_t *ent,
+                                                 kafs_blkcnt_t final_blo);
+static void kafs_pending_worker_finalize_success(kafs_context_t *ctx, uint32_t idx,
+                                                 const kafs_pendinglog_entry_t *ent,
+                                                 kafs_hrid_t hrid, kafs_blkcnt_t final_blo,
+                                                 int installed);
+static uint32_t kafs_pending_worker_note_retry(kafs_context_t *ctx, uint32_t idx);
+static void kafs_pending_worker_backoff(const kafs_context_t *ctx, uint32_t retry,
+                                        uint64_t entry_seq);
+
 static void *kafs_pending_worker_main(void *arg)
 {
   kafs_context_t *ctx = (kafs_context_t *)arg;
@@ -1888,48 +1903,15 @@ static void *kafs_pending_worker_main(void *arg)
   {
     uint32_t idx = 0;
     kafs_pendinglog_entry_t ent;
-    int has_work = 0;
-
-    pthread_mutex_lock(&ctx->c_pending_worker_lock);
-    for (;;)
-    {
-      kafs_pendinglog_hdr_t *hdr = kafs_pendinglog_hdr_ptr(ctx);
-      if (ctx->c_pending_worker_stop)
-      {
-        pthread_mutex_unlock(&ctx->c_pending_worker_lock);
-        __atomic_store_n(&ctx->c_stat_pending_worker_lwp_tid, 0, __ATOMIC_RELAXED);
-        __atomic_add_fetch(&ctx->c_stat_pending_worker_main_exits, 1u, __ATOMIC_RELAXED);
-        return NULL;
-      }
-      if (hdr && hdr->capacity > 0 && hdr->head != hdr->tail)
-      {
-        idx = hdr->head;
-        kafs_pendinglog_entry_t *slot = kafs_pendinglog_entry_ptr(ctx, idx);
-        if (slot)
-        {
-          ent = *slot;
-          has_work = 1;
-          break;
-        }
-      }
-      pthread_cond_wait(&ctx->c_pending_worker_cond, &ctx->c_pending_worker_lock);
-    }
-    pthread_mutex_unlock(&ctx->c_pending_worker_lock);
+    if (kafs_pending_worker_wait_next(ctx, &idx, &ent) != 0)
+      return NULL;
 
     if (ctx->c_pending_worker_prio_dirty)
       (void)kafs_pending_worker_apply_priority_self(ctx);
 
-    if (!has_work)
-      continue;
-
     if (ent.state == KAFS_PENDING_RESOLVED || ent.state == KAFS_PENDING_FAILED)
     {
-      pthread_mutex_lock(&ctx->c_pending_worker_lock);
-      kafs_pendinglog_hdr_t *hdr = kafs_pendinglog_hdr_ptr(ctx);
-      if (hdr && hdr->capacity > 0 && hdr->head == idx)
-        hdr->head = kafs_pendinglog_next_idx(hdr, hdr->head);
-      kafs_pending_worker_adjust_priority_locked(ctx);
-      pthread_mutex_unlock(&ctx->c_pending_worker_lock);
+      kafs_pending_worker_skip_terminal_entry(ctx, idx);
       continue;
     }
 
@@ -1954,135 +1936,193 @@ static void *kafs_pending_worker_main(void *arg)
         else
           ctx->c_stat_hrl_put_hits++;
 
-        if (ent.ino < kafs_sb_inocnt_get(ctx->c_superblock))
-        {
-          kafs_inode_lock(ctx, ent.ino);
-          kafs_sinode_t *inoent = kafs_ctx_inode(ctx, ent.ino);
-          if (kafs_ino_get_usage(inoent))
-          {
-            uint32_t cur_epoch = kafs_inode_epoch_get(ctx, ent.ino);
-            if (ent.ino_epoch == 0 || ent.ino_epoch != cur_epoch)
-            {
-              kafs_inode_unlock(ctx, ent.ino);
-              goto pending_finalize;
-            }
-            kafs_off_t cur_size = kafs_ino_size_get(inoent);
-            if (cur_size > KAFS_INODE_DIRECT_BYTES)
-            {
-              kafs_blksize_t bs = kafs_sb_blksize_get(ctx->c_superblock);
-              kafs_iblkcnt_t iblocnt = (kafs_iblkcnt_t)((cur_size + bs - 1) / bs);
-              if (ent.iblk < iblocnt)
-              {
-                kafs_blkcnt_t cur_raw = KAFS_BLO_NONE;
-                if (kafs_ino_ibrk_run(ctx, inoent, ent.iblk, &cur_raw, KAFS_IBLKREF_FUNC_GET_RAW) ==
-                    0)
-                {
-                  if (kafs_ref_is_pending(cur_raw) &&
-                      kafs_ref_pending_id(cur_raw) == ent.pending_id)
-                  {
-                    if (kafs_ino_ibrk_run(ctx, inoent, ent.iblk, &final_blo,
-                                          KAFS_IBLKREF_FUNC_SET) == 0)
-                      installed = 1;
-                  }
-                }
-              }
-            }
-          }
-          kafs_inode_unlock(ctx, ent.ino);
-        }
-
-      pending_finalize:;
-
-        kafs_blkcnt_t old_blo = (kafs_blkcnt_t)ent.target_hrid;
-        if (installed && old_blo != KAFS_BLO_NONE && old_blo != (kafs_blkcnt_t)ent.temp_blo &&
-            old_blo != final_blo)
-        {
-          uint64_t t_dec0 = kafs_now_ns();
-          (void)kafs_inode_release_hrl_ref(ctx, old_blo);
-          __atomic_add_fetch(&ctx->c_stat_pending_old_block_freed, 1u, __ATOMIC_RELAXED);
-          uint64_t t_dec1 = kafs_now_ns();
-          __atomic_add_fetch(&ctx->c_stat_iblk_write_ns_dec_ref, t_dec1 - t_dec0, __ATOMIC_RELAXED);
-        }
-
-        if (!installed && final_blo != KAFS_BLO_NONE && final_blo != (kafs_blkcnt_t)ent.temp_blo)
-          (void)kafs_inode_release_hrl_ref(ctx, final_blo);
-
-        if ((kafs_blkcnt_t)ent.temp_blo != KAFS_BLO_NONE &&
-            (kafs_blkcnt_t)ent.temp_blo != final_blo)
-          (void)kafs_inode_release_hrl_ref(ctx, (kafs_blkcnt_t)ent.temp_blo);
-
-        pthread_mutex_lock(&ctx->c_pending_worker_lock);
-        kafs_pendinglog_hdr_t *hdr = kafs_pendinglog_hdr_ptr(ctx);
-        kafs_pendinglog_entry_t *slot = hdr ? kafs_pendinglog_entry_ptr(ctx, idx) : NULL;
-        if (hdr && slot)
-        {
-          slot->state = KAFS_PENDING_RESOLVED;
-          __atomic_add_fetch(&ctx->c_stat_pending_resolved, 1u, __ATOMIC_RELAXED);
-          slot->target_hrid = (uint32_t)hrid;
-          slot->reserved0 = 0;
-          if (hdr->head == idx)
-            hdr->head = kafs_pendinglog_next_idx(hdr, hdr->head);
-        }
-        kafs_pending_worker_adjust_priority_locked(ctx);
-        pthread_cond_broadcast(&ctx->c_pending_worker_cond);
-        pthread_mutex_unlock(&ctx->c_pending_worker_lock);
+        installed = kafs_pending_worker_try_install_block(ctx, &ent, final_blo);
+        kafs_pending_worker_finalize_success(ctx, idx, &ent, hrid, final_blo, installed);
         continue;
       }
     }
 
-    pthread_mutex_lock(&ctx->c_pending_worker_lock);
+    uint32_t retry = kafs_pending_worker_note_retry(ctx, idx);
+    kafs_pending_worker_backoff(ctx, retry, ent.seq);
+  }
+}
+
+static void kafs_pending_worker_record_exit(kafs_context_t *ctx)
+{
+  __atomic_store_n(&ctx->c_stat_pending_worker_lwp_tid, 0, __ATOMIC_RELAXED);
+  __atomic_add_fetch(&ctx->c_stat_pending_worker_main_exits, 1u, __ATOMIC_RELAXED);
+}
+
+static int kafs_pending_worker_wait_next(kafs_context_t *ctx, uint32_t *idx,
+                                         kafs_pendinglog_entry_t *ent)
+{
+  pthread_mutex_lock(&ctx->c_pending_worker_lock);
+  for (;;)
+  {
     kafs_pendinglog_hdr_t *hdr = kafs_pendinglog_hdr_ptr(ctx);
-    kafs_pendinglog_entry_t *slot = hdr ? kafs_pendinglog_entry_ptr(ctx, idx) : NULL;
-    uint32_t retry = 0;
-    if (slot)
+    if (ctx->c_pending_worker_stop)
     {
-      slot->state = KAFS_PENDING_HASHED;
-      slot->reserved0 += 1u;
-      retry = slot->reserved0;
-      if (retry >= 32u)
+      pthread_mutex_unlock(&ctx->c_pending_worker_lock);
+      kafs_pending_worker_record_exit(ctx);
+      return -1;
+    }
+    if (hdr && hdr->capacity > 0 && hdr->head != hdr->tail)
+    {
+      *idx = hdr->head;
+      kafs_pendinglog_entry_t *slot = kafs_pendinglog_entry_ptr(ctx, *idx);
+      if (slot)
       {
-        slot->state = KAFS_PENDING_FAILED;
-        if (hdr && hdr->head == idx)
-          hdr->head = kafs_pendinglog_next_idx(hdr, hdr->head);
+        *ent = *slot;
+        pthread_mutex_unlock(&ctx->c_pending_worker_lock);
+        return 0;
       }
     }
-    kafs_pending_worker_adjust_priority_locked(ctx);
-    pthread_cond_broadcast(&ctx->c_pending_worker_cond);
-    pthread_mutex_unlock(&ctx->c_pending_worker_lock);
+    pthread_cond_wait(&ctx->c_pending_worker_cond, &ctx->c_pending_worker_lock);
+  }
+}
 
-    if (retry > 0)
+static void kafs_pending_worker_skip_terminal_entry(kafs_context_t *ctx, uint32_t idx)
+{
+  pthread_mutex_lock(&ctx->c_pending_worker_lock);
+  kafs_pendinglog_hdr_t *hdr = kafs_pendinglog_hdr_ptr(ctx);
+  if (hdr && hdr->capacity > 0 && hdr->head == idx)
+    hdr->head = kafs_pendinglog_next_idx(hdr, hdr->head);
+  kafs_pending_worker_adjust_priority_locked(ctx);
+  pthread_mutex_unlock(&ctx->c_pending_worker_lock);
+}
+
+static int kafs_pending_worker_try_install_block(kafs_context_t *ctx,
+                                                 const kafs_pendinglog_entry_t *ent,
+                                                 kafs_blkcnt_t final_blo)
+{
+  if (ent->ino >= kafs_sb_inocnt_get(ctx->c_superblock))
+    return 0;
+
+  int installed = 0;
+  kafs_inode_lock(ctx, ent->ino);
+  kafs_sinode_t *inoent = kafs_ctx_inode(ctx, ent->ino);
+  if (kafs_ino_get_usage(inoent))
+  {
+    uint32_t cur_epoch = kafs_inode_epoch_get(ctx, ent->ino);
+    if (ent->ino_epoch != 0 && ent->ino_epoch == cur_epoch)
     {
-      int hard_ttl_exceeded = 0;
-      if (ctx->c_pending_ttl_hard_ms > 0 && ent.seq > 0)
+      kafs_off_t cur_size = kafs_ino_size_get(inoent);
+      if (cur_size > KAFS_INODE_DIRECT_BYTES)
       {
-        uint64_t now_rt_ns = kafs_now_realtime_ns();
-        if (now_rt_ns >= ent.seq)
+        kafs_blksize_t bs = kafs_sb_blksize_get(ctx->c_superblock);
+        kafs_iblkcnt_t iblocnt = (kafs_iblkcnt_t)((cur_size + bs - 1) / bs);
+        if (ent->iblk < iblocnt)
         {
-          uint64_t age_ms = (now_rt_ns - ent.seq) / 1000000ull;
-          if (age_ms >= (uint64_t)ctx->c_pending_ttl_hard_ms)
-            hard_ttl_exceeded = 1;
+          kafs_blkcnt_t cur_raw = KAFS_BLO_NONE;
+          if (kafs_ino_ibrk_run(ctx, inoent, ent->iblk, &cur_raw, KAFS_IBLKREF_FUNC_GET_RAW) == 0 &&
+              kafs_ref_is_pending(cur_raw) && kafs_ref_pending_id(cur_raw) == ent->pending_id &&
+              kafs_ino_ibrk_run(ctx, inoent, ent->iblk, &final_blo, KAFS_IBLKREF_FUNC_SET) == 0)
+          {
+            installed = 1;
+          }
         }
       }
-
-      uint32_t backoff_ms;
-      if (hard_ttl_exceeded)
-      {
-        // Keep drain aggressive under hard TTL pressure, but avoid hot-spin starvation.
-        backoff_ms = 1u;
-      }
-      else
-      {
-        if (retry > 6u)
-          retry = 6u;
-        backoff_ms = 1u << retry;
-      }
-      struct timespec ts = {
-          .tv_sec = (time_t)(backoff_ms / 1000u),
-          .tv_nsec = (long)((backoff_ms % 1000u) * 1000000u),
-      };
-      nanosleep(&ts, NULL);
     }
   }
+  kafs_inode_unlock(ctx, ent->ino);
+  return installed;
+}
+
+static void kafs_pending_worker_finalize_success(kafs_context_t *ctx, uint32_t idx,
+                                                 const kafs_pendinglog_entry_t *ent,
+                                                 kafs_hrid_t hrid, kafs_blkcnt_t final_blo,
+                                                 int installed)
+{
+  kafs_blkcnt_t old_blo = (kafs_blkcnt_t)ent->target_hrid;
+  if (installed && old_blo != KAFS_BLO_NONE && old_blo != (kafs_blkcnt_t)ent->temp_blo &&
+      old_blo != final_blo)
+  {
+    uint64_t t_dec0 = kafs_now_ns();
+    (void)kafs_inode_release_hrl_ref(ctx, old_blo);
+    __atomic_add_fetch(&ctx->c_stat_pending_old_block_freed, 1u, __ATOMIC_RELAXED);
+    uint64_t t_dec1 = kafs_now_ns();
+    __atomic_add_fetch(&ctx->c_stat_iblk_write_ns_dec_ref, t_dec1 - t_dec0, __ATOMIC_RELAXED);
+  }
+
+  if (!installed && final_blo != KAFS_BLO_NONE && final_blo != (kafs_blkcnt_t)ent->temp_blo)
+    (void)kafs_inode_release_hrl_ref(ctx, final_blo);
+
+  if ((kafs_blkcnt_t)ent->temp_blo != KAFS_BLO_NONE && (kafs_blkcnt_t)ent->temp_blo != final_blo)
+    (void)kafs_inode_release_hrl_ref(ctx, (kafs_blkcnt_t)ent->temp_blo);
+
+  pthread_mutex_lock(&ctx->c_pending_worker_lock);
+  kafs_pendinglog_hdr_t *hdr = kafs_pendinglog_hdr_ptr(ctx);
+  kafs_pendinglog_entry_t *slot = hdr ? kafs_pendinglog_entry_ptr(ctx, idx) : NULL;
+  if (hdr && slot)
+  {
+    slot->state = KAFS_PENDING_RESOLVED;
+    __atomic_add_fetch(&ctx->c_stat_pending_resolved, 1u, __ATOMIC_RELAXED);
+    slot->target_hrid = (uint32_t)hrid;
+    slot->reserved0 = 0;
+    if (hdr->head == idx)
+      hdr->head = kafs_pendinglog_next_idx(hdr, hdr->head);
+  }
+  kafs_pending_worker_adjust_priority_locked(ctx);
+  pthread_cond_broadcast(&ctx->c_pending_worker_cond);
+  pthread_mutex_unlock(&ctx->c_pending_worker_lock);
+}
+
+static uint32_t kafs_pending_worker_note_retry(kafs_context_t *ctx, uint32_t idx)
+{
+  uint32_t retry = 0;
+
+  pthread_mutex_lock(&ctx->c_pending_worker_lock);
+  kafs_pendinglog_hdr_t *hdr = kafs_pendinglog_hdr_ptr(ctx);
+  kafs_pendinglog_entry_t *slot = hdr ? kafs_pendinglog_entry_ptr(ctx, idx) : NULL;
+  if (slot)
+  {
+    slot->state = KAFS_PENDING_HASHED;
+    slot->reserved0 += 1u;
+    retry = slot->reserved0;
+    if (retry >= 32u)
+    {
+      slot->state = KAFS_PENDING_FAILED;
+      if (hdr && hdr->head == idx)
+        hdr->head = kafs_pendinglog_next_idx(hdr, hdr->head);
+    }
+  }
+  kafs_pending_worker_adjust_priority_locked(ctx);
+  pthread_cond_broadcast(&ctx->c_pending_worker_cond);
+  pthread_mutex_unlock(&ctx->c_pending_worker_lock);
+  return retry;
+}
+
+static void kafs_pending_worker_backoff(const kafs_context_t *ctx, uint32_t retry,
+                                        uint64_t entry_seq)
+{
+  if (retry == 0)
+    return;
+
+  int hard_ttl_exceeded = 0;
+  if (ctx->c_pending_ttl_hard_ms > 0 && entry_seq > 0)
+  {
+    uint64_t now_rt_ns = kafs_now_realtime_ns();
+    if (now_rt_ns >= entry_seq)
+    {
+      uint64_t age_ms = (now_rt_ns - entry_seq) / 1000000ull;
+      if (age_ms >= (uint64_t)ctx->c_pending_ttl_hard_ms)
+        hard_ttl_exceeded = 1;
+    }
+  }
+
+  uint32_t backoff_ms = 1u;
+  if (!hard_ttl_exceeded)
+  {
+    if (retry > 6u)
+      retry = 6u;
+    backoff_ms = 1u << retry;
+  }
+
+  struct timespec ts = {
+      .tv_sec = (time_t)(backoff_ms / 1000u),
+      .tv_nsec = (long)((backoff_ms % 1000u) * 1000000u),
+  };
+  nanosleep(&ts, NULL);
 }
 
 static int kafs_pending_worker_start(struct kafs_context *ctx)

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -12097,6 +12097,84 @@ static void kafs_main_validate_image_format(const char *image_path, uint32_t fmt
   }
 }
 
+static void kafs_main_calc_runtime_layout(const kafs_ssuperblock_t *sbdisk,
+                                          kafs_blksize_t blksizemask, kafs_inocnt_t inocnt,
+                                          kafs_blkcnt_t r_blkcnt, off_t *mapsize_out,
+                                          intptr_t *blkmask_off_out, intptr_t *inotbl_off_out)
+{
+  off_t mapsize = 0;
+
+  mapsize += sizeof(kafs_ssuperblock_t);
+  mapsize = (mapsize + blksizemask) & ~blksizemask;
+  *blkmask_off_out = (intptr_t)mapsize;
+  assert(sizeof(kafs_blkmask_t) <= 8);
+  mapsize += (r_blkcnt + 7) >> 3;
+  mapsize = (mapsize + 7) & ~7;
+  mapsize = (mapsize + blksizemask) & ~blksizemask;
+  *inotbl_off_out = (intptr_t)mapsize;
+  mapsize += (off_t)kafs_inode_table_bytes_for_format(kafs_sb_format_version_get(sbdisk), inocnt);
+  mapsize = (mapsize + blksizemask) & ~blksizemask;
+  *mapsize_out = mapsize;
+}
+
+static off_t kafs_main_runtime_imgsize(const kafs_ssuperblock_t *sbdisk,
+                                       kafs_logblksize_t log_blksize, kafs_blksize_t blksizemask,
+                                       kafs_blkcnt_t r_blkcnt)
+{
+  off_t imgsize = (off_t)r_blkcnt << log_blksize;
+  uint64_t idx_off = kafs_sb_hrl_index_offset_get(sbdisk);
+  uint64_t idx_size = kafs_sb_hrl_index_size_get(sbdisk);
+  uint64_t ent_off = kafs_sb_hrl_entry_offset_get(sbdisk);
+  uint64_t ent_cnt = kafs_sb_hrl_entry_cnt_get(sbdisk);
+  uint64_t ent_size = ent_cnt * (uint64_t)sizeof(kafs_hrl_entry_t);
+  uint64_t j_off = kafs_sb_journal_offset_get(sbdisk);
+  uint64_t j_size = kafs_sb_journal_size_get(sbdisk);
+  uint64_t p_off = kafs_sb_pendinglog_offset_get(sbdisk);
+  uint64_t p_size = kafs_sb_pendinglog_size_get(sbdisk);
+  uint64_t end1 = (idx_off && idx_size) ? (idx_off + idx_size) : 0;
+  uint64_t end2 = (ent_off && ent_size) ? (ent_off + ent_size) : 0;
+  uint64_t end3 = (j_off && j_size) ? (j_off + j_size) : 0;
+  uint64_t end4 = (p_off && p_size) ? (p_off + p_size) : 0;
+  uint64_t max_end = end1;
+
+  if (end2 > max_end)
+    max_end = end2;
+  if (end3 > max_end)
+    max_end = end3;
+  if (end4 > max_end)
+    max_end = end4;
+  if ((off_t)max_end > imgsize)
+    imgsize = (off_t)max_end;
+  return (imgsize + blksizemask) & ~blksizemask;
+}
+
+static void kafs_main_map_runtime_memory(kafs_context_t *ctx, uint32_t fmt_ver, off_t imgsize,
+                                         off_t mapsize, intptr_t blkmask_off, intptr_t inotbl_off)
+{
+  ctx->c_img_base = mmap(NULL, imgsize, PROT_READ | PROT_WRITE, MAP_SHARED, ctx->c_fd, 0);
+  if (ctx->c_img_base == MAP_FAILED)
+  {
+    perror("mmap");
+    exit(2);
+  }
+
+  ctx->c_img_size = (size_t)imgsize;
+  ctx->c_superblock = (kafs_ssuperblock_t *)ctx->c_img_base;
+  ctx->c_mapsize = (size_t)mapsize;
+  ctx->c_blkmasktbl = (void *)ctx->c_superblock + blkmask_off;
+  ctx->c_inotbl = (void *)ctx->c_superblock + inotbl_off;
+  if (!kafs_ctx_runtime_mount_supported(ctx))
+  {
+    fprintf(stderr, "unsupported format version: %u (runtime admission failed).\n", fmt_ver);
+    exit(2);
+  }
+  if (kafs_ctx_validate_runtime_mount_state(ctx) != 0)
+  {
+    fprintf(stderr, "invalid v5 tail metadata region; refusing runtime mount.\n");
+    exit(2);
+  }
+}
+
 static void kafs_main_map_runtime_image(kafs_context_t *ctx, const kafs_ssuperblock_t *sbdisk,
                                         uint32_t fmt_ver, kafs_inocnt_t *inocnt_out,
                                         kafs_blkcnt_t *r_blkcnt_out)
@@ -12108,65 +12186,13 @@ static void kafs_main_map_runtime_image(kafs_context_t *ctx, const kafs_ssuperbl
   kafs_blkcnt_t r_blkcnt = kafs_blkcnt_stoh(sbdisk->s_r_blkcnt);
 
   off_t mapsize = 0;
-  mapsize += sizeof(kafs_ssuperblock_t);
-  mapsize = (mapsize + blksizemask) & ~blksizemask;
-  void *blkmask_off = (void *)mapsize;
-  assert(sizeof(kafs_blkmask_t) <= 8);
-  mapsize += (r_blkcnt + 7) >> 3;
-  mapsize = (mapsize + 7) & ~7;
-  mapsize = (mapsize + blksizemask) & ~blksizemask;
-  void *inotbl_off = (void *)mapsize;
-  mapsize += (off_t)kafs_inode_table_bytes_for_format(kafs_sb_format_version_get(sbdisk), inocnt);
-  mapsize = (mapsize + blksizemask) & ~blksizemask;
+  intptr_t blkmask_off = 0;
+  intptr_t inotbl_off = 0;
+  kafs_main_calc_runtime_layout(sbdisk, blksizemask, inocnt, r_blkcnt, &mapsize, &blkmask_off,
+                                &inotbl_off);
 
-  off_t imgsize = (off_t)r_blkcnt << log_blksize;
-  {
-    uint64_t idx_off = kafs_sb_hrl_index_offset_get(sbdisk);
-    uint64_t idx_size = kafs_sb_hrl_index_size_get(sbdisk);
-    uint64_t ent_off = kafs_sb_hrl_entry_offset_get(sbdisk);
-    uint64_t ent_cnt = kafs_sb_hrl_entry_cnt_get(sbdisk);
-    uint64_t ent_size = ent_cnt * (uint64_t)sizeof(kafs_hrl_entry_t);
-    uint64_t j_off = kafs_sb_journal_offset_get(sbdisk);
-    uint64_t j_size = kafs_sb_journal_size_get(sbdisk);
-    uint64_t p_off = kafs_sb_pendinglog_offset_get(sbdisk);
-    uint64_t p_size = kafs_sb_pendinglog_size_get(sbdisk);
-    uint64_t end1 = (idx_off && idx_size) ? (idx_off + idx_size) : 0;
-    uint64_t end2 = (ent_off && ent_size) ? (ent_off + ent_size) : 0;
-    uint64_t end3 = (j_off && j_size) ? (j_off + j_size) : 0;
-    uint64_t end4 = (p_off && p_size) ? (p_off + p_size) : 0;
-    uint64_t max_end = end1;
-    if (end2 > max_end)
-      max_end = end2;
-    if (end3 > max_end)
-      max_end = end3;
-    if (end4 > max_end)
-      max_end = end4;
-    if ((off_t)max_end > imgsize)
-      imgsize = (off_t)max_end;
-    imgsize = (imgsize + blksizemask) & ~blksizemask;
-  }
-
-  ctx->c_img_base = mmap(NULL, imgsize, PROT_READ | PROT_WRITE, MAP_SHARED, ctx->c_fd, 0);
-  if (ctx->c_img_base == MAP_FAILED)
-  {
-    perror("mmap");
-    exit(2);
-  }
-  ctx->c_img_size = (size_t)imgsize;
-  ctx->c_superblock = (kafs_ssuperblock_t *)ctx->c_img_base;
-  ctx->c_mapsize = (size_t)mapsize;
-  ctx->c_blkmasktbl = (void *)ctx->c_superblock + (intptr_t)blkmask_off;
-  ctx->c_inotbl = (void *)ctx->c_superblock + (intptr_t)inotbl_off;
-  if (!kafs_ctx_runtime_mount_supported(ctx))
-  {
-    fprintf(stderr, "unsupported format version: %u (runtime admission failed).\n", fmt_ver);
-    exit(2);
-  }
-  if (kafs_ctx_validate_runtime_mount_state(ctx) != 0)
-  {
-    fprintf(stderr, "invalid v5 tail metadata region; refusing runtime mount.\n");
-    exit(2);
-  }
+  off_t imgsize = kafs_main_runtime_imgsize(sbdisk, log_blksize, blksizemask, r_blkcnt);
+  kafs_main_map_runtime_memory(ctx, fmt_ver, imgsize, mapsize, blkmask_off, inotbl_off);
 
   *inocnt_out = inocnt;
   *r_blkcnt_out = r_blkcnt;

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -11348,7 +11348,7 @@ static void kafs_main_set_hotplug_default(kafs_main_options_t *opts)
   snprintf(opts->hotplug_uds_opt, sizeof(opts->hotplug_uds_opt), "%s", KAFS_HOTPLUG_UDS_DEFAULT);
 }
 
-static int kafs_main_handle_cache_hotplug_token(kafs_main_options_t *opts, const char *tok)
+static int kafs_main_handle_writeback_cache_token(kafs_main_options_t *opts, const char *tok)
 {
   if (strcmp(tok, "writeback_cache") == 0)
   {
@@ -11362,6 +11362,11 @@ static int kafs_main_handle_cache_hotplug_token(kafs_main_options_t *opts, const
     opts->writeback_cache_explicit = KAFS_TRUE;
     return 1;
   }
+  return 0;
+}
+
+static int kafs_main_handle_trim_on_free_token(kafs_main_options_t *opts, const char *tok)
+{
   if (strcmp(tok, "trim_on_free") == 0 || strcmp(tok, "trim-on-free") == 0)
   {
     opts->trim_on_free_enabled = KAFS_TRUE;
@@ -11374,48 +11379,66 @@ static int kafs_main_handle_cache_hotplug_token(kafs_main_options_t *opts, const
     opts->trim_on_free_explicit = KAFS_TRUE;
     return 1;
   }
+  return 0;
+}
+
+static const char *kafs_main_hotplug_uds_value(const char *tok)
+{
+  if (strncmp(tok, "hotplug=", 8) == 0)
+    return tok + 8;
+  if (strncmp(tok, "hotplug_uds=", 12) == 0)
+    return tok + 12;
+  if (strncmp(tok, "hotplug-uds=", 12) == 0)
+    return tok + 12;
+  return NULL;
+}
+
+static const char *kafs_main_hotplug_back_bin_value(const char *tok)
+{
+  if (strncmp(tok, "hotplug_back_bin=", 17) == 0)
+    return tok + 17;
+  if (strncmp(tok, "hotplug-back-bin=", 17) == 0)
+    return tok + 17;
+  return NULL;
+}
+
+static int kafs_main_store_hotplug_token_path(char *dst, size_t dst_size, const char *value,
+                                              const char *label, const char *error_detail)
+{
+  if (!value)
+    return 0;
+  if (!*value || snprintf(dst, dst_size, "%s", value) >= (int)dst_size)
+  {
+    fprintf(stderr, "invalid -o %s %s: '%s'\n", label, error_detail, value);
+    return 2;
+  }
+  return 1;
+}
+
+static int kafs_main_handle_cache_hotplug_token(kafs_main_options_t *opts, const char *tok)
+{
+  int rc = kafs_main_handle_writeback_cache_token(opts, tok);
+  if (rc != 0)
+    return rc;
+
+  rc = kafs_main_handle_trim_on_free_token(opts, tok);
+  if (rc != 0)
+    return rc;
+
   if (strcmp(tok, "hotplug") == 0)
   {
     kafs_main_set_hotplug_default(opts);
     return 1;
   }
 
-  const char *hotplug_uds_v = NULL;
-  if (strncmp(tok, "hotplug=", 8) == 0)
-    hotplug_uds_v = tok + 8;
-  else if (strncmp(tok, "hotplug_uds=", 12) == 0)
-    hotplug_uds_v = tok + 12;
-  else if (strncmp(tok, "hotplug-uds=", 12) == 0)
-    hotplug_uds_v = tok + 12;
-  if (hotplug_uds_v)
-  {
-    if (!*hotplug_uds_v || snprintf(opts->hotplug_uds_opt, sizeof(opts->hotplug_uds_opt), "%s",
-                                    hotplug_uds_v) >= (int)sizeof(opts->hotplug_uds_opt))
-    {
-      fprintf(stderr, "invalid -o hotplug uds path: '%s'\n", hotplug_uds_v);
-      return 2;
-    }
-    return 1;
-  }
+  rc = kafs_main_store_hotplug_token_path(opts->hotplug_uds_opt, sizeof(opts->hotplug_uds_opt),
+                                          kafs_main_hotplug_uds_value(tok), "hotplug", "uds path");
+  if (rc != 0)
+    return rc;
 
-  const char *hotplug_back_bin_v = NULL;
-  if (strncmp(tok, "hotplug_back_bin=", 17) == 0)
-    hotplug_back_bin_v = tok + 17;
-  else if (strncmp(tok, "hotplug-back-bin=", 17) == 0)
-    hotplug_back_bin_v = tok + 17;
-  if (hotplug_back_bin_v)
-  {
-    if (!*hotplug_back_bin_v ||
-        snprintf(opts->hotplug_back_bin_opt, sizeof(opts->hotplug_back_bin_opt), "%s",
-                 hotplug_back_bin_v) >= (int)sizeof(opts->hotplug_back_bin_opt))
-    {
-      fprintf(stderr, "invalid -o hotplug_back_bin path: '%s'\n", hotplug_back_bin_v);
-      return 2;
-    }
-    return 1;
-  }
-
-  return 0;
+  return kafs_main_store_hotplug_token_path(
+      opts->hotplug_back_bin_opt, sizeof(opts->hotplug_back_bin_opt),
+      kafs_main_hotplug_back_bin_value(tok), "hotplug_back_bin", "path");
 }
 
 static int kafs_main_handle_mt_token(kafs_main_options_t *opts, const char *tok, int *want_mt)

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -6382,6 +6382,117 @@ static int kafs_hotplug_call_getattr(struct fuse_context *fctx, kafs_context_t *
   return rc;
 }
 
+static void kafs_ctx_close_fd(kafs_context_t *ctx)
+{
+  if (ctx->c_fd >= 0)
+    close(ctx->c_fd);
+  ctx->c_fd = -1;
+}
+
+static void kafs_ctx_reset_mapping(kafs_context_t *ctx)
+{
+  ctx->c_img_base = NULL;
+  ctx->c_img_size = 0;
+  ctx->c_superblock = NULL;
+  ctx->c_inotbl = NULL;
+  ctx->c_blkmasktbl = NULL;
+  ctx->c_mapsize = 0;
+}
+
+static void kafs_ctx_unmap_image(kafs_context_t *ctx)
+{
+  if (ctx->c_img_base && ctx->c_img_base != MAP_FAILED)
+    munmap(ctx->c_img_base, ctx->c_img_size);
+  kafs_ctx_reset_mapping(ctx);
+}
+
+static int kafs_ctx_read_superblock_fd(kafs_context_t *ctx, kafs_ssuperblock_t *sbdisk)
+{
+  ssize_t r = pread(ctx->c_fd, sbdisk, sizeof(*sbdisk), 0);
+  if (r == (ssize_t)sizeof(*sbdisk))
+    return 0;
+
+  int err = -errno;
+  kafs_ctx_close_fd(ctx);
+  return err ? err : -EIO;
+}
+
+static void kafs_ctx_compute_map_layout(const kafs_ssuperblock_t *sbdisk, off_t *mapsize_out,
+                                        off_t *imgsize_out, intptr_t *blkmask_off_out,
+                                        intptr_t *inotbl_off_out)
+{
+  kafs_logblksize_t log_blksize = kafs_sb_log_blksize_get(sbdisk);
+  kafs_blksize_t blksize = 1u << log_blksize;
+  kafs_blksize_t blksizemask = blksize - 1u;
+  kafs_inocnt_t inocnt = kafs_inocnt_stoh(sbdisk->s_inocnt);
+  kafs_blkcnt_t r_blkcnt = kafs_blkcnt_stoh(sbdisk->s_r_blkcnt);
+
+  off_t mapsize = sizeof(kafs_ssuperblock_t);
+  mapsize = (mapsize + blksizemask) & ~blksizemask;
+  intptr_t blkmask_off = (intptr_t)mapsize;
+  mapsize += (r_blkcnt + 7) >> 3;
+  mapsize = (mapsize + 7) & ~7;
+  mapsize = (mapsize + blksizemask) & ~blksizemask;
+  intptr_t inotbl_off = (intptr_t)mapsize;
+  mapsize += (off_t)kafs_inode_table_bytes_for_format(kafs_sb_format_version_get(sbdisk), inocnt);
+  mapsize = (mapsize + blksizemask) & ~blksizemask;
+
+  off_t imgsize = (off_t)r_blkcnt << log_blksize;
+  uint64_t idx_off = kafs_sb_hrl_index_offset_get(sbdisk);
+  uint64_t idx_size = kafs_sb_hrl_index_size_get(sbdisk);
+  uint64_t ent_off = kafs_sb_hrl_entry_offset_get(sbdisk);
+  uint64_t ent_cnt = kafs_sb_hrl_entry_cnt_get(sbdisk);
+  uint64_t ent_size = ent_cnt * (uint64_t)sizeof(kafs_hrl_entry_t);
+  uint64_t j_off = kafs_sb_journal_offset_get(sbdisk);
+  uint64_t j_size = kafs_sb_journal_size_get(sbdisk);
+  uint64_t p_off = kafs_sb_pendinglog_offset_get(sbdisk);
+  uint64_t p_size = kafs_sb_pendinglog_size_get(sbdisk);
+  uint64_t end1 = (idx_off && idx_size) ? (idx_off + idx_size) : 0;
+  uint64_t end2 = (ent_off && ent_size) ? (ent_off + ent_size) : 0;
+  uint64_t end3 = (j_off && j_size) ? (j_off + j_size) : 0;
+  uint64_t end4 = (p_off && p_size) ? (p_off + p_size) : 0;
+  uint64_t max_end = end1;
+  if (end2 > max_end)
+    max_end = end2;
+  if (end3 > max_end)
+    max_end = end3;
+  if (end4 > max_end)
+    max_end = end4;
+  if ((off_t)max_end > imgsize)
+    imgsize = (off_t)max_end;
+  imgsize = (imgsize + blksizemask) & ~blksizemask;
+
+  *mapsize_out = mapsize;
+  *imgsize_out = imgsize;
+  *blkmask_off_out = blkmask_off;
+  *inotbl_off_out = inotbl_off;
+}
+
+static int kafs_ctx_map_image(kafs_context_t *ctx, const kafs_ssuperblock_t *sbdisk)
+{
+  off_t mapsize = 0;
+  off_t imgsize = 0;
+  intptr_t blkmask_off = 0;
+  intptr_t inotbl_off = 0;
+  kafs_ctx_compute_map_layout(sbdisk, &mapsize, &imgsize, &blkmask_off, &inotbl_off);
+
+  ctx->c_img_base = mmap(NULL, imgsize, PROT_READ | PROT_WRITE, MAP_SHARED, ctx->c_fd, 0);
+  if (ctx->c_img_base == MAP_FAILED)
+  {
+    int err = -errno;
+    kafs_ctx_reset_mapping(ctx);
+    kafs_ctx_close_fd(ctx);
+    return err;
+  }
+
+  ctx->c_img_size = (size_t)imgsize;
+  ctx->c_superblock = (kafs_ssuperblock_t *)ctx->c_img_base;
+  ctx->c_mapsize = (size_t)mapsize;
+  ctx->c_blkmasktbl = (void *)ctx->c_superblock + blkmask_off;
+  ctx->c_inotbl = (void *)ctx->c_superblock + inotbl_off;
+  return 0;
+}
+
 static int kafs_ctx_runtime_mount_supported(const kafs_context_t *ctx)
 {
   uint32_t fmt_ver;
@@ -6421,109 +6532,35 @@ int kafs_core_open_image(const char *image_path, kafs_context_t *ctx)
     return -errno;
 
   kafs_ssuperblock_t sbdisk;
-  ssize_t r = pread(ctx->c_fd, &sbdisk, sizeof(sbdisk), 0);
-  if (r != (ssize_t)sizeof(sbdisk))
-  {
-    int err = -errno;
-    close(ctx->c_fd);
-    ctx->c_fd = -1;
-    return err ? err : -EIO;
-  }
+  int rc = kafs_ctx_read_superblock_fd(ctx, &sbdisk);
+  if (rc != 0)
+    return rc;
   if (kafs_sb_magic_get(&sbdisk) != KAFS_MAGIC)
   {
-    close(ctx->c_fd);
-    ctx->c_fd = -1;
+    kafs_ctx_close_fd(ctx);
     return -EINVAL;
   }
   uint32_t fmt_ver = kafs_sb_format_version_get(&sbdisk);
   if (fmt_ver != KAFS_FORMAT_VERSION && fmt_ver != KAFS_FORMAT_VERSION_V5)
   {
-    close(ctx->c_fd);
-    ctx->c_fd = -1;
+    kafs_ctx_close_fd(ctx);
     return -EPROTONOSUPPORT;
   }
 
-  kafs_logblksize_t log_blksize = kafs_sb_log_blksize_get(&sbdisk);
-  kafs_blksize_t blksize = 1u << log_blksize;
-  kafs_blksize_t blksizemask = blksize - 1u;
-  kafs_inocnt_t inocnt = kafs_inocnt_stoh(sbdisk.s_inocnt);
   kafs_blkcnt_t r_blkcnt = kafs_blkcnt_stoh(sbdisk.s_r_blkcnt);
-
-  off_t mapsize = 0;
-  mapsize += sizeof(kafs_ssuperblock_t);
-  mapsize = (mapsize + blksizemask) & ~blksizemask;
-  void *blkmask_off = (void *)mapsize;
-  mapsize += (r_blkcnt + 7) >> 3;
-  mapsize = (mapsize + 7) & ~7;
-  mapsize = (mapsize + blksizemask) & ~blksizemask;
-  void *inotbl_off = (void *)mapsize;
-  mapsize += (off_t)kafs_inode_table_bytes_for_format(kafs_sb_format_version_get(&sbdisk), inocnt);
-  mapsize = (mapsize + blksizemask) & ~blksizemask;
-
-  off_t imgsize = (off_t)r_blkcnt << log_blksize;
-  {
-    uint64_t idx_off = kafs_sb_hrl_index_offset_get(&sbdisk);
-    uint64_t idx_size = kafs_sb_hrl_index_size_get(&sbdisk);
-    uint64_t ent_off = kafs_sb_hrl_entry_offset_get(&sbdisk);
-    uint64_t ent_cnt = kafs_sb_hrl_entry_cnt_get(&sbdisk);
-    uint64_t ent_size = ent_cnt * (uint64_t)sizeof(kafs_hrl_entry_t);
-    uint64_t j_off = kafs_sb_journal_offset_get(&sbdisk);
-    uint64_t j_size = kafs_sb_journal_size_get(&sbdisk);
-    uint64_t p_off = kafs_sb_pendinglog_offset_get(&sbdisk);
-    uint64_t p_size = kafs_sb_pendinglog_size_get(&sbdisk);
-    uint64_t end1 = (idx_off && idx_size) ? (idx_off + idx_size) : 0;
-    uint64_t end2 = (ent_off && ent_size) ? (ent_off + ent_size) : 0;
-    uint64_t end3 = (j_off && j_size) ? (j_off + j_size) : 0;
-    uint64_t end4 = (p_off && p_size) ? (p_off + p_size) : 0;
-    uint64_t max_end = end1;
-    if (end2 > max_end)
-      max_end = end2;
-    if (end3 > max_end)
-      max_end = end3;
-    if (end4 > max_end)
-      max_end = end4;
-    if ((off_t)max_end > imgsize)
-      imgsize = (off_t)max_end;
-    imgsize = (imgsize + blksizemask) & ~blksizemask;
-  }
-
-  ctx->c_img_base = mmap(NULL, imgsize, PROT_READ | PROT_WRITE, MAP_SHARED, ctx->c_fd, 0);
-  if (ctx->c_img_base == MAP_FAILED)
-  {
-    int err = -errno;
-    close(ctx->c_fd);
-    ctx->c_fd = -1;
-    return err;
-  }
-  ctx->c_img_size = (size_t)imgsize;
-  ctx->c_superblock = (kafs_ssuperblock_t *)ctx->c_img_base;
-  ctx->c_mapsize = (size_t)mapsize;
-  ctx->c_blkmasktbl = (void *)ctx->c_superblock + (intptr_t)blkmask_off;
-  ctx->c_inotbl = (void *)ctx->c_superblock + (intptr_t)inotbl_off;
+  rc = kafs_ctx_map_image(ctx, &sbdisk);
+  if (rc != 0)
+    return rc;
   if (!kafs_ctx_runtime_mount_supported(ctx))
   {
-    munmap(ctx->c_img_base, ctx->c_img_size);
-    ctx->c_img_base = NULL;
-    ctx->c_img_size = 0;
-    ctx->c_superblock = NULL;
-    ctx->c_inotbl = NULL;
-    ctx->c_blkmasktbl = NULL;
-    ctx->c_mapsize = 0;
-    close(ctx->c_fd);
-    ctx->c_fd = -1;
+    kafs_ctx_unmap_image(ctx);
+    kafs_ctx_close_fd(ctx);
     return -EPROTONOSUPPORT;
   }
   if (kafs_ctx_validate_runtime_mount_state(ctx) != 0)
   {
-    munmap(ctx->c_img_base, ctx->c_img_size);
-    ctx->c_img_base = NULL;
-    ctx->c_img_size = 0;
-    ctx->c_superblock = NULL;
-    ctx->c_inotbl = NULL;
-    ctx->c_blkmasktbl = NULL;
-    ctx->c_mapsize = 0;
-    close(ctx->c_fd);
-    ctx->c_fd = -1;
+    kafs_ctx_unmap_image(ctx);
+    kafs_ctx_close_fd(ctx);
     return -EPROTO;
   }
   ctx->c_alloc_v3_summary_dirty = 1;
@@ -10217,79 +10254,19 @@ static int kafs_migrate_ctx_open(const char *image_path, kafs_context_t *ctx,
   if (ctx->c_fd < 0)
     return -errno;
 
-  ssize_t r = pread(ctx->c_fd, sbdisk, sizeof(*sbdisk), 0);
-  if (r != (ssize_t)sizeof(*sbdisk))
-  {
-    int err = -errno;
-    close(ctx->c_fd);
-    ctx->c_fd = -1;
-    return err ? err : -EIO;
-  }
+  int rc = kafs_ctx_read_superblock_fd(ctx, sbdisk);
+  if (rc != 0)
+    return rc;
   if (kafs_sb_magic_get(sbdisk) != KAFS_MAGIC)
   {
-    close(ctx->c_fd);
-    ctx->c_fd = -1;
+    kafs_ctx_close_fd(ctx);
     return -EINVAL;
   }
 
-  kafs_logblksize_t log_blksize = kafs_sb_log_blksize_get(sbdisk);
-  kafs_blksize_t blksize = 1u << log_blksize;
-  kafs_blksize_t blksizemask = blksize - 1u;
   kafs_inocnt_t inocnt = kafs_inocnt_stoh(sbdisk->s_inocnt);
-  kafs_blkcnt_t r_blkcnt = kafs_blkcnt_stoh(sbdisk->s_r_blkcnt);
-
-  off_t mapsize = 0;
-  mapsize += sizeof(kafs_ssuperblock_t);
-  mapsize = (mapsize + blksizemask) & ~blksizemask;
-  void *blkmask_off = (void *)mapsize;
-  mapsize += (r_blkcnt + 7) >> 3;
-  mapsize = (mapsize + 7) & ~7;
-  mapsize = (mapsize + blksizemask) & ~blksizemask;
-  void *inotbl_off = (void *)mapsize;
-  mapsize += (off_t)kafs_inode_table_bytes_for_format(kafs_sb_format_version_get(sbdisk), inocnt);
-  mapsize = (mapsize + blksizemask) & ~blksizemask;
-
-  off_t imgsize = (off_t)r_blkcnt << log_blksize;
-  {
-    uint64_t idx_off = kafs_sb_hrl_index_offset_get(sbdisk);
-    uint64_t idx_size = kafs_sb_hrl_index_size_get(sbdisk);
-    uint64_t ent_off = kafs_sb_hrl_entry_offset_get(sbdisk);
-    uint64_t ent_cnt = kafs_sb_hrl_entry_cnt_get(sbdisk);
-    uint64_t ent_size = ent_cnt * (uint64_t)sizeof(kafs_hrl_entry_t);
-    uint64_t j_off = kafs_sb_journal_offset_get(sbdisk);
-    uint64_t j_size = kafs_sb_journal_size_get(sbdisk);
-    uint64_t p_off = kafs_sb_pendinglog_offset_get(sbdisk);
-    uint64_t p_size = kafs_sb_pendinglog_size_get(sbdisk);
-    uint64_t end1 = (idx_off && idx_size) ? (idx_off + idx_size) : 0;
-    uint64_t end2 = (ent_off && ent_size) ? (ent_off + ent_size) : 0;
-    uint64_t end3 = (j_off && j_size) ? (j_off + j_size) : 0;
-    uint64_t end4 = (p_off && p_size) ? (p_off + p_size) : 0;
-    uint64_t max_end = end1;
-    if (end2 > max_end)
-      max_end = end2;
-    if (end3 > max_end)
-      max_end = end3;
-    if (end4 > max_end)
-      max_end = end4;
-    if ((off_t)max_end > imgsize)
-      imgsize = (off_t)max_end;
-    imgsize = (imgsize + blksizemask) & ~blksizemask;
-  }
-
-  ctx->c_img_base = mmap(NULL, imgsize, PROT_READ | PROT_WRITE, MAP_SHARED, ctx->c_fd, 0);
-  if (ctx->c_img_base == MAP_FAILED)
-  {
-    int err = -errno;
-    close(ctx->c_fd);
-    ctx->c_fd = -1;
-    return err;
-  }
-
-  ctx->c_img_size = (size_t)imgsize;
-  ctx->c_superblock = (kafs_ssuperblock_t *)ctx->c_img_base;
-  ctx->c_mapsize = (size_t)mapsize;
-  ctx->c_blkmasktbl = (void *)ctx->c_superblock + (intptr_t)blkmask_off;
-  ctx->c_inotbl = (void *)ctx->c_superblock + (intptr_t)inotbl_off;
+  rc = kafs_ctx_map_image(ctx, sbdisk);
+  if (rc != 0)
+    return rc;
   ctx->c_alloc_v3_summary_dirty = 1;
   ctx->c_diag_log_fd = -1;
   ctx->c_ino_epoch = calloc((size_t)inocnt, sizeof(uint32_t));

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -5448,6 +5448,98 @@ static int kafs_dir_is_empty_locked(struct kafs_context *ctx, kafs_sinode_t *ino
 }
 
 // NOTE: caller holds dir inode lock. For rename(2) we must not change linkcount of the moved inode.
+static int kafs_dirent_find_existing_v4(struct kafs_context *ctx, const char *old,
+                                        const kafs_dir_snapshot_meta_t *meta, const char *filename,
+                                        kafs_filenamelen_t filenamelen, uint32_t target_hash,
+                                        kafs_dirent_view_t *tombstone_out, int *have_tombstone_out)
+{
+  size_t off = 0;
+  while (1)
+  {
+    kafs_dirent_view_t view;
+    __atomic_add_fetch(&ctx->c_stat_dirent_view_next_calls, 1u, __ATOMIC_RELAXED);
+    int step = kafs_dirent_view_next_meta(old, meta, off, &view);
+    if (step == 0)
+      return 0;
+    if (step < 0)
+      return -EIO;
+    if (view.name_hash == target_hash && view.name_len == filenamelen &&
+        memcmp(view.name, filename, filenamelen) == 0)
+    {
+      if ((view.flags & KAFS_DIRENT_FLAG_TOMBSTONE) != 0)
+      {
+        *tombstone_out = view;
+        *have_tombstone_out = 1;
+      }
+      else
+      {
+        return -EEXIST;
+      }
+    }
+    off = view.record_off + view.record_len;
+  }
+}
+
+static int kafs_dirent_reuse_tombstone(struct kafs_context *ctx, kafs_sinode_t *inoent_dir,
+                                       kafs_dirent_view_t tombstone, kafs_inocnt_t ino,
+                                       kafs_filenamelen_t filenamelen, uint32_t target_hash,
+                                       kafs_sdir_v4_hdr_t *hdr)
+{
+  uint32_t live_count = kafs_dir_v4_hdr_live_count_get(hdr);
+  uint32_t tombstone_count = kafs_dir_v4_hdr_tombstone_count_get(hdr);
+  int rc = kafs_dir_v4_write_record_head(ctx, inoent_dir, tombstone.record_off,
+                                         (uint16_t)tombstone.record_len, 0u, ino, filenamelen,
+                                         target_hash);
+  if (rc == 0)
+  {
+    kafs_dir_v4_hdr_live_count_set(hdr, live_count + 1u);
+    kafs_dir_v4_hdr_tombstone_count_set(hdr, tombstone_count - 1u);
+    rc = kafs_dir_v4_write_header(ctx, inoent_dir, hdr);
+  }
+  return rc;
+}
+
+static int kafs_dirent_append_new_v4(struct kafs_context *ctx, kafs_sinode_t *inoent_dir,
+                                     size_t old_len, const kafs_dir_snapshot_meta_t *meta,
+                                     kafs_sdir_v4_hdr_t *hdr, kafs_inocnt_t ino,
+                                     const char *filename, kafs_filenamelen_t filenamelen,
+                                     uint32_t target_hash)
+{
+  size_t rec_len = sizeof(kafs_sdirent_v4_t) + (size_t)filenamelen;
+  size_t append_off = (old_len == 0) ? sizeof(kafs_sdir_v4_hdr_t) : meta->logical_len;
+  if (old_len != 0 && append_off != old_len)
+    return -EIO;
+
+  char recbuf[sizeof(kafs_sdirent_v4_t) + FILENAME_MAX];
+  kafs_sdirent_v4_t *rec = (kafs_sdirent_v4_t *)recbuf;
+  memset(recbuf, 0, rec_len);
+  kafs_dirent_v4_rec_len_set(rec, (uint16_t)rec_len);
+  kafs_dirent_v4_flags_set(rec, 0u);
+  kafs_dirent_v4_ino_set(rec, ino);
+  kafs_dirent_v4_filenamelen_set(rec, filenamelen);
+  kafs_dirent_v4_name_hash_set(rec, target_hash);
+  memcpy(recbuf + sizeof(kafs_sdirent_v4_t), filename, filenamelen);
+
+  if (old_len == 0)
+  {
+    int rc = kafs_dir_v4_write_header(ctx, inoent_dir, hdr);
+    if (rc < 0)
+      return rc;
+  }
+
+  ssize_t w = kafs_pwrite(ctx, inoent_dir, recbuf, (kafs_off_t)rec_len, (kafs_off_t)append_off);
+  if (w < 0 || (size_t)w != rec_len)
+    return (w < 0) ? (int)w : -EIO;
+
+  uint32_t live_count = kafs_dir_v4_hdr_live_count_get(hdr);
+  uint32_t tombstone_count = kafs_dir_v4_hdr_tombstone_count_get(hdr);
+  uint32_t record_bytes = kafs_dir_v4_hdr_record_bytes_get(hdr);
+  kafs_dir_v4_hdr_live_count_set(hdr, live_count + 1u);
+  kafs_dir_v4_hdr_tombstone_count_set(hdr, tombstone_count);
+  kafs_dir_v4_hdr_record_bytes_set(hdr, record_bytes + (uint32_t)rec_len);
+  return kafs_dir_v4_write_header(ctx, inoent_dir, hdr);
+}
+
 static int kafs_dirent_add_nolink(struct kafs_context *ctx, kafs_sinode_t *inoent_dir,
                                   kafs_inocnt_t ino, const char *filename)
 {
@@ -5480,99 +5572,28 @@ static int kafs_dirent_add_nolink(struct kafs_context *ctx, kafs_sinode_t *inoen
   uint32_t target_hash = kafs_dirent_name_hash(filename, filenamelen);
   kafs_dirent_view_t tombstone = {0};
   int have_tombstone = 0;
-
-  size_t off = 0;
-  while (1)
+  rc = kafs_dirent_find_existing_v4(ctx, old, &meta, filename, filenamelen, target_hash, &tombstone,
+                                    &have_tombstone);
+  if (rc < 0)
   {
-    kafs_dirent_view_t view;
-    __atomic_add_fetch(&ctx->c_stat_dirent_view_next_calls, 1u, __ATOMIC_RELAXED);
-    int step = kafs_dirent_view_next_meta(old, &meta, off, &view);
-    if (step == 0)
-      break;
-    if (step < 0)
-    {
-      free(old);
-      return -EIO;
-    }
-    if (view.name_hash == target_hash && view.name_len == filenamelen &&
-        memcmp(view.name, filename, filenamelen) == 0)
-    {
-      if ((view.flags & KAFS_DIRENT_FLAG_TOMBSTONE) != 0)
-      {
-        tombstone = view;
-        have_tombstone = 1;
-      }
-      else
-      {
-        free(old);
-        return -EEXIST;
-      }
-    }
-    off = view.record_off + view.record_len;
+    free(old);
+    return rc;
   }
 
   kafs_sdir_v4_hdr_t hdr = meta.hdr;
   if (old_len == 0)
     kafs_dir_v4_hdr_init(&hdr);
 
-  uint32_t live_count = kafs_dir_v4_hdr_live_count_get(&hdr);
-  uint32_t tombstone_count = kafs_dir_v4_hdr_tombstone_count_get(&hdr);
-  uint32_t record_bytes = kafs_dir_v4_hdr_record_bytes_get(&hdr);
-
   if (have_tombstone)
   {
-    rc = kafs_dir_v4_write_record_head(ctx, inoent_dir, tombstone.record_off,
-                                       (uint16_t)tombstone.record_len, 0u, ino, filenamelen,
-                                       target_hash);
-    if (rc == 0)
-    {
-      kafs_dir_v4_hdr_live_count_set(&hdr, live_count + 1u);
-      kafs_dir_v4_hdr_tombstone_count_set(&hdr, tombstone_count - 1u);
-      rc = kafs_dir_v4_write_header(ctx, inoent_dir, &hdr);
-    }
+    rc = kafs_dirent_reuse_tombstone(ctx, inoent_dir, tombstone, ino, filenamelen, target_hash,
+                                     &hdr);
     free(old);
     return rc;
   }
 
-  size_t rec_len = sizeof(kafs_sdirent_v4_t) + (size_t)filenamelen;
-  size_t append_off = (old_len == 0) ? sizeof(kafs_sdir_v4_hdr_t) : meta.logical_len;
-  if (old_len != 0 && append_off != old_len)
-  {
-    free(old);
-    return -EIO;
-  }
-
-  char recbuf[sizeof(kafs_sdirent_v4_t) + FILENAME_MAX];
-  kafs_sdirent_v4_t *rec = (kafs_sdirent_v4_t *)recbuf;
-  memset(recbuf, 0, rec_len);
-  kafs_dirent_v4_rec_len_set(rec, (uint16_t)rec_len);
-  kafs_dirent_v4_flags_set(rec, 0u);
-  kafs_dirent_v4_ino_set(rec, ino);
-  kafs_dirent_v4_filenamelen_set(rec, filenamelen);
-  kafs_dirent_v4_name_hash_set(rec, target_hash);
-  memcpy(recbuf + sizeof(kafs_sdirent_v4_t), filename, filenamelen);
-
-  if (old_len == 0)
-  {
-    rc = kafs_dir_v4_write_header(ctx, inoent_dir, &hdr);
-    if (rc < 0)
-    {
-      free(old);
-      return rc;
-    }
-  }
-
-  ssize_t w = kafs_pwrite(ctx, inoent_dir, recbuf, (kafs_off_t)rec_len, (kafs_off_t)append_off);
-  if (w < 0 || (size_t)w != rec_len)
-  {
-    free(old);
-    return (w < 0) ? (int)w : -EIO;
-  }
-
-  kafs_dir_v4_hdr_live_count_set(&hdr, live_count + 1u);
-  kafs_dir_v4_hdr_tombstone_count_set(&hdr, tombstone_count);
-  kafs_dir_v4_hdr_record_bytes_set(&hdr, record_bytes + (uint32_t)rec_len);
-  rc = kafs_dir_v4_write_header(ctx, inoent_dir, &hdr);
+  rc = kafs_dirent_append_new_v4(ctx, inoent_dir, old_len, &meta, &hdr, ino, filename, filenamelen,
+                                 target_hash);
   free(old);
   return rc;
 }

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -3397,6 +3397,109 @@ static int kafs_ino_ibrk_run(struct kafs_context *ctx, kafs_sinode_t *inoent, ka
 // SET(NONE) 実施後に、空になった間接テーブルを親から切り離す。
 // - 呼び出しは inode ロック内で行うこと
 // - 解放すべきブロック番号（最大3段）を返し、物理解放は呼び出し側がロック外で行う
+static int kafs_ino_prune_empty_single(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                       kafs_blksize_t blksize, kafs_blkcnt_t blkrefs_pb,
+                                       kafs_blkcnt_t *free_blo1)
+{
+  kafs_blkcnt_t blo_tbl = kafs_blkcnt_stoh(inoent->i_blkreftbl[12]);
+  if (blo_tbl == KAFS_BLO_NONE)
+    return KAFS_SUCCESS;
+
+  kafs_sblkcnt_t tbl[blkrefs_pb];
+  KAFS_CALL(kafs_blk_read, ctx, blo_tbl, tbl);
+  if (!kafs_blk_is_zero(tbl, blksize))
+    return KAFS_SUCCESS;
+
+  *free_blo1 = blo_tbl;
+  inoent->i_blkreftbl[12] = kafs_blkcnt_htos(KAFS_BLO_NONE);
+  kafs_ino_blocks_adjust(inoent, -1);
+  return KAFS_SUCCESS;
+}
+
+static int kafs_ino_prune_empty_double(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                       kafs_iblkcnt_t rem, kafs_blksize_t blksize,
+                                       kafs_logblksize_t log_blkrefs_pb, kafs_blkcnt_t blkrefs_pb,
+                                       kafs_blkcnt_t *free_blo1, kafs_blkcnt_t *free_blo2)
+{
+  kafs_iblkcnt_t ib1 = rem >> log_blkrefs_pb;
+  kafs_blkcnt_t blo_tbl1 = kafs_blkcnt_stoh(inoent->i_blkreftbl[13]);
+  if (blo_tbl1 == KAFS_BLO_NONE)
+    return KAFS_SUCCESS;
+
+  kafs_sblkcnt_t tbl1[blkrefs_pb];
+  KAFS_CALL(kafs_blk_read, ctx, blo_tbl1, tbl1);
+  kafs_blkcnt_t blo_tbl2 = kafs_blkcnt_stoh(tbl1[ib1]);
+  if (blo_tbl2 == KAFS_BLO_NONE)
+    return KAFS_SUCCESS;
+
+  kafs_sblkcnt_t tbl2[blkrefs_pb];
+  KAFS_CALL(kafs_blk_read, ctx, blo_tbl2, tbl2);
+  if (!kafs_blk_is_zero(tbl2, blksize))
+    return KAFS_SUCCESS;
+
+  *free_blo1 = blo_tbl2;
+  tbl1[ib1] = kafs_blkcnt_htos(KAFS_BLO_NONE);
+  KAFS_CALL(kafs_blk_write, ctx, blo_tbl1, tbl1);
+  if (kafs_blk_is_zero(tbl1, blksize))
+  {
+    *free_blo2 = blo_tbl1;
+    inoent->i_blkreftbl[13] = kafs_blkcnt_htos(KAFS_BLO_NONE);
+    kafs_ino_blocks_adjust(inoent, -1);
+  }
+  kafs_ino_blocks_adjust(inoent, -1);
+  return KAFS_SUCCESS;
+}
+
+static int kafs_ino_prune_empty_triple(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                       kafs_iblkcnt_t rem, kafs_blksize_t blksize,
+                                       kafs_logblksize_t log_blkrefs_pb,
+                                       kafs_logblksize_t log_blkrefs_pb_sq,
+                                       kafs_blkcnt_t blkrefs_pb, kafs_blkcnt_t *free_blo1,
+                                       kafs_blkcnt_t *free_blo2, kafs_blkcnt_t *free_blo3)
+{
+  kafs_iblkcnt_t ib1 = rem >> log_blkrefs_pb_sq;
+  kafs_iblkcnt_t ib2 = (rem >> log_blkrefs_pb) & (blkrefs_pb - 1);
+  kafs_blkcnt_t blo_tbl1 = kafs_blkcnt_stoh(inoent->i_blkreftbl[14]);
+  if (blo_tbl1 == KAFS_BLO_NONE)
+    return KAFS_SUCCESS;
+
+  kafs_sblkcnt_t tbl1[blkrefs_pb];
+  KAFS_CALL(kafs_blk_read, ctx, blo_tbl1, tbl1);
+  kafs_blkcnt_t blo_tbl2 = kafs_blkcnt_stoh(tbl1[ib1]);
+  if (blo_tbl2 == KAFS_BLO_NONE)
+    return KAFS_SUCCESS;
+
+  kafs_sblkcnt_t tbl2[blkrefs_pb];
+  KAFS_CALL(kafs_blk_read, ctx, blo_tbl2, tbl2);
+  kafs_blkcnt_t blo_tbl3 = kafs_blkcnt_stoh(tbl2[ib2]);
+  if (blo_tbl3 == KAFS_BLO_NONE)
+    return KAFS_SUCCESS;
+
+  kafs_sblkcnt_t tbl3[blkrefs_pb];
+  KAFS_CALL(kafs_blk_read, ctx, blo_tbl3, tbl3);
+  if (!kafs_blk_is_zero(tbl3, blksize))
+    return KAFS_SUCCESS;
+
+  *free_blo1 = blo_tbl3;
+  tbl2[ib2] = kafs_blkcnt_htos(KAFS_BLO_NONE);
+  KAFS_CALL(kafs_blk_write, ctx, blo_tbl2, tbl2);
+  if (kafs_blk_is_zero(tbl2, blksize))
+  {
+    *free_blo2 = blo_tbl2;
+    tbl1[ib1] = kafs_blkcnt_htos(KAFS_BLO_NONE);
+    KAFS_CALL(kafs_blk_write, ctx, blo_tbl1, tbl1);
+    if (kafs_blk_is_zero(tbl1, blksize))
+    {
+      *free_blo3 = blo_tbl1;
+      inoent->i_blkreftbl[14] = kafs_blkcnt_htos(KAFS_BLO_NONE);
+      kafs_ino_blocks_adjust(inoent, -1);
+    }
+    kafs_ino_blocks_adjust(inoent, -1);
+  }
+  kafs_ino_blocks_adjust(inoent, -1);
+  return KAFS_SUCCESS;
+}
+
 static int kafs_ino_prune_empty_indirects(struct kafs_context *ctx, kafs_sinode_t *inoent,
                                           kafs_iblkcnt_t iblo, kafs_blkcnt_t *free_blo1,
                                           kafs_blkcnt_t *free_blo2, kafs_blkcnt_t *free_blo3)
@@ -3416,96 +3519,19 @@ static int kafs_ino_prune_empty_indirects(struct kafs_context *ctx, kafs_sinode_
 
   kafs_iblkcnt_t rem = iblo - 12;
   if (rem < blkrefs_pb)
-  {
-    // 単間接
-    kafs_blkcnt_t blo_tbl = kafs_blkcnt_stoh(inoent->i_blkreftbl[12]);
-    if (blo_tbl == KAFS_BLO_NONE)
-      return KAFS_SUCCESS;
-    kafs_sblkcnt_t tbl[blkrefs_pb];
-    KAFS_CALL(kafs_blk_read, ctx, blo_tbl, tbl);
-    if (kafs_blk_is_zero(tbl, blksize))
-    {
-      *free_blo1 = blo_tbl;
-      inoent->i_blkreftbl[12] = kafs_blkcnt_htos(KAFS_BLO_NONE);
-      kafs_ino_blocks_adjust(inoent, -1);
-    }
-    return KAFS_SUCCESS;
-  }
+    return kafs_ino_prune_empty_single(ctx, inoent, blksize, blkrefs_pb, free_blo1);
 
   rem -= blkrefs_pb;
   kafs_logblksize_t log_blkrefs_pb_sq = log_blkrefs_pb << 1;
   kafs_blkcnt_t blkrefs_pb_sq = 1u << log_blkrefs_pb_sq;
   if (rem < blkrefs_pb_sq)
-  {
-    // 二重間接
-    kafs_iblkcnt_t ib1 = rem >> log_blkrefs_pb;
-    kafs_blkcnt_t blo_tbl1 = kafs_blkcnt_stoh(inoent->i_blkreftbl[13]);
-    if (blo_tbl1 == KAFS_BLO_NONE)
-      return KAFS_SUCCESS;
-    kafs_sblkcnt_t tbl1[blkrefs_pb];
-    KAFS_CALL(kafs_blk_read, ctx, blo_tbl1, tbl1);
-    kafs_blkcnt_t blo_tbl2 = kafs_blkcnt_stoh(tbl1[ib1]);
-    if (blo_tbl2 == KAFS_BLO_NONE)
-      return KAFS_SUCCESS;
-    kafs_sblkcnt_t tbl2[blkrefs_pb];
-    KAFS_CALL(kafs_blk_read, ctx, blo_tbl2, tbl2);
-    if (kafs_blk_is_zero(tbl2, blksize))
-    {
-      *free_blo1 = blo_tbl2;
-      tbl1[ib1] = kafs_blkcnt_htos(KAFS_BLO_NONE);
-      KAFS_CALL(kafs_blk_write, ctx, blo_tbl1, tbl1);
-      // 親も空なら切り離し
-      if (kafs_blk_is_zero(tbl1, blksize))
-      {
-        *free_blo2 = blo_tbl1;
-        inoent->i_blkreftbl[13] = kafs_blkcnt_htos(KAFS_BLO_NONE);
-        kafs_ino_blocks_adjust(inoent, -1);
-      }
-      kafs_ino_blocks_adjust(inoent, -1);
-    }
-    return KAFS_SUCCESS;
-  }
+    return kafs_ino_prune_empty_double(ctx, inoent, rem, blksize, log_blkrefs_pb, blkrefs_pb,
+                                       free_blo1, free_blo2);
 
   // 三重間接
   rem -= blkrefs_pb_sq;
-  kafs_iblkcnt_t ib1 = rem >> log_blkrefs_pb_sq;
-  kafs_iblkcnt_t ib2 = (rem >> log_blkrefs_pb) & (blkrefs_pb - 1);
-  kafs_blkcnt_t blo_tbl1 = kafs_blkcnt_stoh(inoent->i_blkreftbl[14]);
-  if (blo_tbl1 == KAFS_BLO_NONE)
-    return KAFS_SUCCESS;
-  kafs_sblkcnt_t tbl1[blkrefs_pb];
-  KAFS_CALL(kafs_blk_read, ctx, blo_tbl1, tbl1);
-  kafs_blkcnt_t blo_tbl2 = kafs_blkcnt_stoh(tbl1[ib1]);
-  if (blo_tbl2 == KAFS_BLO_NONE)
-    return KAFS_SUCCESS;
-  kafs_sblkcnt_t tbl2[blkrefs_pb];
-  KAFS_CALL(kafs_blk_read, ctx, blo_tbl2, tbl2);
-  kafs_blkcnt_t blo_tbl3 = kafs_blkcnt_stoh(tbl2[ib2]);
-  if (blo_tbl3 == KAFS_BLO_NONE)
-    return KAFS_SUCCESS;
-  kafs_sblkcnt_t tbl3[blkrefs_pb];
-  KAFS_CALL(kafs_blk_read, ctx, blo_tbl3, tbl3);
-  if (kafs_blk_is_zero(tbl3, blksize))
-  {
-    *free_blo1 = blo_tbl3;
-    tbl2[ib2] = kafs_blkcnt_htos(KAFS_BLO_NONE);
-    KAFS_CALL(kafs_blk_write, ctx, blo_tbl2, tbl2);
-    if (kafs_blk_is_zero(tbl2, blksize))
-    {
-      *free_blo2 = blo_tbl2;
-      tbl1[ib1] = kafs_blkcnt_htos(KAFS_BLO_NONE);
-      KAFS_CALL(kafs_blk_write, ctx, blo_tbl1, tbl1);
-      if (kafs_blk_is_zero(tbl1, blksize))
-      {
-        *free_blo3 = blo_tbl1;
-        inoent->i_blkreftbl[14] = kafs_blkcnt_htos(KAFS_BLO_NONE);
-        kafs_ino_blocks_adjust(inoent, -1);
-      }
-      kafs_ino_blocks_adjust(inoent, -1);
-    }
-    kafs_ino_blocks_adjust(inoent, -1);
-  }
-  return KAFS_SUCCESS;
+  return kafs_ino_prune_empty_triple(ctx, inoent, rem, blksize, log_blkrefs_pb, log_blkrefs_pb_sq,
+                                     blkrefs_pb, free_blo1, free_blo2, free_blo3);
 }
 
 /// @brief inode毎のデータを読み出す（ブロック単位）

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -7708,6 +7708,167 @@ static void kafs_ctl_fill_status(const kafs_context_t *ctx, kafs_rpc_hotplug_sta
   out->pending_ttl_over_hard = ctx->c_pending_ttl_over_hard;
 }
 
+static void kafs_ctl_write_status_response(const kafs_context_t *ctx, unsigned char *resp_payload,
+                                           uint32_t *resp_len)
+{
+  kafs_rpc_hotplug_status_t st;
+  kafs_ctl_fill_status(ctx, &st);
+  memcpy(resp_payload, &st, sizeof(st));
+  *resp_len = (uint32_t)sizeof(st);
+}
+
+static int kafs_ctl_handle_set_timeout(kafs_context_t *ctx, uint32_t payload_len,
+                                       const unsigned char *payload)
+{
+  if (payload_len != sizeof(kafs_rpc_set_timeout_t))
+    return -EINVAL;
+
+  const kafs_rpc_set_timeout_t *req = (const kafs_rpc_set_timeout_t *)payload;
+  if (req->timeout_ms == 0)
+    return -EINVAL;
+
+  ctx->c_hotplug_wait_timeout_ms = req->timeout_ms;
+  return 0;
+}
+
+static void kafs_ctl_write_env_list_response(kafs_context_t *ctx, unsigned char *resp_payload,
+                                             uint32_t *resp_len)
+{
+  kafs_rpc_env_list_t env;
+  memset(&env, 0, sizeof(env));
+  kafs_hotplug_env_lock(ctx);
+  env.count = ctx->c_hotplug_env_count;
+  for (uint32_t i = 0; i < env.count; ++i)
+    env.entries[i] = ctx->c_hotplug_env[i];
+  kafs_hotplug_env_unlock(ctx);
+  memcpy(resp_payload, &env, sizeof(env));
+  *resp_len = (uint32_t)sizeof(env);
+}
+
+static int kafs_ctl_handle_env_update(kafs_context_t *ctx, uint32_t payload_len,
+                                      const unsigned char *payload, int unset)
+{
+  if (payload_len != sizeof(kafs_rpc_env_update_t))
+    return -EINVAL;
+
+  const kafs_rpc_env_update_t *req = (const kafs_rpc_env_update_t *)payload;
+  if (unset)
+    return kafs_hotplug_env_unset(ctx, req->key);
+  return kafs_hotplug_env_set(ctx, req->key, req->value);
+}
+
+static void kafs_ctl_apply_pending_worker_priority(kafs_context_t *ctx, uint32_t mode,
+                                                   int32_t nice_value, uint32_t flags)
+{
+  ctx->c_pending_worker_prio_mode = mode;
+  if ((flags & KAFS_RPC_SET_DEDUP_PRIO_F_HAS_NICE) != 0)
+    ctx->c_pending_worker_nice = nice_value;
+  ctx->c_pending_worker_prio_base_mode = mode;
+  if ((flags & KAFS_RPC_SET_DEDUP_PRIO_F_HAS_NICE) != 0)
+    ctx->c_pending_worker_nice_base = nice_value;
+
+  if (ctx->c_pending_worker_auto_boosted)
+  {
+    ctx->c_pending_worker_prio_mode = KAFS_PENDING_WORKER_PRIO_NORMAL;
+    ctx->c_pending_worker_nice = 0;
+  }
+  else
+  {
+    ctx->c_pending_worker_prio_mode = ctx->c_pending_worker_prio_base_mode;
+    ctx->c_pending_worker_nice = ctx->c_pending_worker_nice_base;
+  }
+  ctx->c_pending_worker_prio_dirty = 1;
+  kafs_pending_worker_notify_all(ctx);
+}
+
+static void kafs_ctl_apply_bg_dedup_worker_priority(kafs_context_t *ctx, uint32_t mode,
+                                                    int32_t nice_value, uint32_t flags)
+{
+  ctx->c_bg_dedup_worker_prio_base_mode = mode;
+  if ((flags & KAFS_RPC_SET_DEDUP_PRIO_F_HAS_NICE) != 0)
+    ctx->c_bg_dedup_worker_nice_base = nice_value;
+
+  if (ctx->c_bg_dedup_worker_auto_boosted)
+  {
+    ctx->c_bg_dedup_worker_prio_mode = KAFS_PENDING_WORKER_PRIO_NORMAL;
+    ctx->c_bg_dedup_worker_nice = 0;
+  }
+  else
+  {
+    ctx->c_bg_dedup_worker_prio_mode = ctx->c_bg_dedup_worker_prio_base_mode;
+    ctx->c_bg_dedup_worker_nice = ctx->c_bg_dedup_worker_nice_base;
+  }
+  ctx->c_bg_dedup_worker_prio_dirty = 1;
+  if (ctx->c_bg_dedup_worker_lock_init)
+  {
+    pthread_mutex_lock(&ctx->c_bg_dedup_worker_lock);
+    pthread_cond_broadcast(&ctx->c_bg_dedup_worker_cond);
+    pthread_mutex_unlock(&ctx->c_bg_dedup_worker_lock);
+  }
+}
+
+static int kafs_ctl_handle_set_dedup_prio(kafs_context_t *ctx, uint32_t payload_len,
+                                          const unsigned char *payload)
+{
+  if (payload_len != sizeof(kafs_rpc_set_dedup_prio_t))
+    return -EINVAL;
+
+  const kafs_rpc_set_dedup_prio_t *req = (const kafs_rpc_set_dedup_prio_t *)payload;
+  if (req->mode != KAFS_PENDING_WORKER_PRIO_NORMAL && req->mode != KAFS_PENDING_WORKER_PRIO_IDLE)
+    return -EINVAL;
+  if ((req->flags & KAFS_RPC_SET_DEDUP_PRIO_F_HAS_NICE) != 0 &&
+      (req->nice_value < 0 || req->nice_value > 19))
+    return -ERANGE;
+
+  kafs_ctl_apply_pending_worker_priority(ctx, req->mode, req->nice_value, req->flags);
+  kafs_ctl_apply_bg_dedup_worker_priority(ctx, req->mode, req->nice_value, req->flags);
+  return 0;
+}
+
+static int kafs_ctl_handle_set_runtime(kafs_context_t *ctx, uint32_t payload_len,
+                                       const unsigned char *payload)
+{
+  if (payload_len != sizeof(kafs_rpc_set_runtime_t))
+    return -EINVAL;
+
+  const kafs_rpc_set_runtime_t *req = (const kafs_rpc_set_runtime_t *)payload;
+  uint32_t next_policy = ctx->c_fsync_policy;
+  uint32_t next_soft = ctx->c_pending_ttl_soft_ms;
+  uint32_t next_hard = ctx->c_pending_ttl_hard_ms;
+
+  if ((req->flags & KAFS_RPC_SET_RUNTIME_F_HAS_FSYNC_POLICY) != 0)
+  {
+    if (req->fsync_policy != KAFS_FSYNC_POLICY_FULL &&
+        req->fsync_policy != KAFS_FSYNC_POLICY_JOURNAL_ONLY &&
+        req->fsync_policy != KAFS_FSYNC_POLICY_ADAPTIVE)
+      return -EINVAL;
+    next_policy = req->fsync_policy;
+  }
+
+  if ((req->flags & KAFS_RPC_SET_RUNTIME_F_HAS_PENDING_TTL_SOFT_MS) != 0)
+    next_soft = req->pending_ttl_soft_ms;
+
+  if ((req->flags & KAFS_RPC_SET_RUNTIME_F_HAS_PENDING_TTL_HARD_MS) != 0)
+    next_hard = req->pending_ttl_hard_ms;
+
+  if (next_soft > 0 && next_hard > 0 && next_hard < next_soft)
+    return -ERANGE;
+
+  ctx->c_fsync_policy = next_policy;
+  ctx->c_pending_ttl_soft_ms = next_soft;
+  ctx->c_pending_ttl_hard_ms = next_hard;
+
+  if (ctx->c_pending_worker_lock_init)
+  {
+    pthread_mutex_lock(&ctx->c_pending_worker_lock);
+    kafs_pending_worker_adjust_priority_locked(ctx);
+    if (ctx->c_pending_worker_prio_dirty)
+      pthread_cond_broadcast(&ctx->c_pending_worker_cond);
+    pthread_mutex_unlock(&ctx->c_pending_worker_lock);
+  }
+  return 0;
+}
+
 static int kafs_ctl_handle_request(kafs_context_t *ctx, kafs_ctl_session_t *sess,
                                    const unsigned char *buf, size_t size)
 {
@@ -7734,168 +7895,28 @@ static int kafs_ctl_handle_request(kafs_context_t *ctx, kafs_ctl_session_t *sess
   {
   case KAFS_RPC_OP_CTL_STATUS:
   case KAFS_RPC_OP_CTL_COMPAT:
-  {
-    kafs_rpc_hotplug_status_t st;
-    kafs_ctl_fill_status(ctx, &st);
-    memcpy(resp_payload, &st, sizeof(st));
-    resp_len = (uint32_t)sizeof(st);
+    kafs_ctl_write_status_response(ctx, resp_payload, &resp_len);
     break;
-  }
   case KAFS_RPC_OP_CTL_RESTART:
     result = kafs_hotplug_restart_back(ctx);
     break;
   case KAFS_RPC_OP_CTL_SET_TIMEOUT:
-    if (hdr.payload_len != sizeof(kafs_rpc_set_timeout_t))
-      result = -EINVAL;
-    else
-    {
-      const kafs_rpc_set_timeout_t *req = (const kafs_rpc_set_timeout_t *)payload;
-      if (req->timeout_ms == 0)
-        result = -EINVAL;
-      else
-        ctx->c_hotplug_wait_timeout_ms = req->timeout_ms;
-    }
+    result = kafs_ctl_handle_set_timeout(ctx, hdr.payload_len, payload);
     break;
   case KAFS_RPC_OP_CTL_ENV_LIST:
-  {
-    kafs_rpc_env_list_t env;
-    memset(&env, 0, sizeof(env));
-    kafs_hotplug_env_lock(ctx);
-    env.count = ctx->c_hotplug_env_count;
-    for (uint32_t i = 0; i < env.count; ++i)
-      env.entries[i] = ctx->c_hotplug_env[i];
-    kafs_hotplug_env_unlock(ctx);
-    memcpy(resp_payload, &env, sizeof(env));
-    resp_len = (uint32_t)sizeof(env);
+    kafs_ctl_write_env_list_response(ctx, resp_payload, &resp_len);
     break;
-  }
   case KAFS_RPC_OP_CTL_ENV_SET:
-    if (hdr.payload_len != sizeof(kafs_rpc_env_update_t))
-      result = -EINVAL;
-    else
-    {
-      const kafs_rpc_env_update_t *req = (const kafs_rpc_env_update_t *)payload;
-      result = kafs_hotplug_env_set(ctx, req->key, req->value);
-    }
+    result = kafs_ctl_handle_env_update(ctx, hdr.payload_len, payload, 0);
     break;
   case KAFS_RPC_OP_CTL_ENV_UNSET:
-    if (hdr.payload_len != sizeof(kafs_rpc_env_update_t))
-      result = -EINVAL;
-    else
-    {
-      const kafs_rpc_env_update_t *req = (const kafs_rpc_env_update_t *)payload;
-      result = kafs_hotplug_env_unset(ctx, req->key);
-    }
+    result = kafs_ctl_handle_env_update(ctx, hdr.payload_len, payload, 1);
     break;
   case KAFS_RPC_OP_CTL_SET_DEDUP_PRIO:
-    if (hdr.payload_len != sizeof(kafs_rpc_set_dedup_prio_t))
-      result = -EINVAL;
-    else
-    {
-      const kafs_rpc_set_dedup_prio_t *req = (const kafs_rpc_set_dedup_prio_t *)payload;
-      if (req->mode != KAFS_PENDING_WORKER_PRIO_NORMAL &&
-          req->mode != KAFS_PENDING_WORKER_PRIO_IDLE)
-      {
-        result = -EINVAL;
-      }
-      else if ((req->flags & KAFS_RPC_SET_DEDUP_PRIO_F_HAS_NICE) != 0 &&
-               (req->nice_value < 0 || req->nice_value > 19))
-      {
-        result = -ERANGE;
-      }
-      else
-      {
-        ctx->c_pending_worker_prio_mode = req->mode;
-        if ((req->flags & KAFS_RPC_SET_DEDUP_PRIO_F_HAS_NICE) != 0)
-          ctx->c_pending_worker_nice = req->nice_value;
-        ctx->c_pending_worker_prio_base_mode = req->mode;
-        if ((req->flags & KAFS_RPC_SET_DEDUP_PRIO_F_HAS_NICE) != 0)
-          ctx->c_pending_worker_nice_base = req->nice_value;
-
-        if (ctx->c_pending_worker_auto_boosted)
-        {
-          ctx->c_pending_worker_prio_mode = KAFS_PENDING_WORKER_PRIO_NORMAL;
-          ctx->c_pending_worker_nice = 0;
-        }
-        else
-        {
-          ctx->c_pending_worker_prio_mode = ctx->c_pending_worker_prio_base_mode;
-          ctx->c_pending_worker_nice = ctx->c_pending_worker_nice_base;
-        }
-        ctx->c_pending_worker_prio_dirty = 1;
-        kafs_pending_worker_notify_all(ctx);
-
-        ctx->c_bg_dedup_worker_prio_base_mode = req->mode;
-        if ((req->flags & KAFS_RPC_SET_DEDUP_PRIO_F_HAS_NICE) != 0)
-          ctx->c_bg_dedup_worker_nice_base = req->nice_value;
-
-        if (ctx->c_bg_dedup_worker_auto_boosted)
-        {
-          ctx->c_bg_dedup_worker_prio_mode = KAFS_PENDING_WORKER_PRIO_NORMAL;
-          ctx->c_bg_dedup_worker_nice = 0;
-        }
-        else
-        {
-          ctx->c_bg_dedup_worker_prio_mode = ctx->c_bg_dedup_worker_prio_base_mode;
-          ctx->c_bg_dedup_worker_nice = ctx->c_bg_dedup_worker_nice_base;
-        }
-        ctx->c_bg_dedup_worker_prio_dirty = 1;
-        if (ctx->c_bg_dedup_worker_lock_init)
-        {
-          pthread_mutex_lock(&ctx->c_bg_dedup_worker_lock);
-          pthread_cond_broadcast(&ctx->c_bg_dedup_worker_cond);
-          pthread_mutex_unlock(&ctx->c_bg_dedup_worker_lock);
-        }
-      }
-    }
+    result = kafs_ctl_handle_set_dedup_prio(ctx, hdr.payload_len, payload);
     break;
   case KAFS_RPC_OP_CTL_SET_RUNTIME:
-    if (hdr.payload_len != sizeof(kafs_rpc_set_runtime_t))
-      result = -EINVAL;
-    else
-    {
-      const kafs_rpc_set_runtime_t *req = (const kafs_rpc_set_runtime_t *)payload;
-      uint32_t next_policy = ctx->c_fsync_policy;
-      uint32_t next_soft = ctx->c_pending_ttl_soft_ms;
-      uint32_t next_hard = ctx->c_pending_ttl_hard_ms;
-
-      if ((req->flags & KAFS_RPC_SET_RUNTIME_F_HAS_FSYNC_POLICY) != 0)
-      {
-        if (req->fsync_policy != KAFS_FSYNC_POLICY_FULL &&
-            req->fsync_policy != KAFS_FSYNC_POLICY_JOURNAL_ONLY &&
-            req->fsync_policy != KAFS_FSYNC_POLICY_ADAPTIVE)
-        {
-          result = -EINVAL;
-          break;
-        }
-        next_policy = req->fsync_policy;
-      }
-
-      if ((req->flags & KAFS_RPC_SET_RUNTIME_F_HAS_PENDING_TTL_SOFT_MS) != 0)
-        next_soft = req->pending_ttl_soft_ms;
-
-      if ((req->flags & KAFS_RPC_SET_RUNTIME_F_HAS_PENDING_TTL_HARD_MS) != 0)
-        next_hard = req->pending_ttl_hard_ms;
-
-      if (next_soft > 0 && next_hard > 0 && next_hard < next_soft)
-      {
-        result = -ERANGE;
-        break;
-      }
-
-      ctx->c_fsync_policy = next_policy;
-      ctx->c_pending_ttl_soft_ms = next_soft;
-      ctx->c_pending_ttl_hard_ms = next_hard;
-
-      if (ctx->c_pending_worker_lock_init)
-      {
-        pthread_mutex_lock(&ctx->c_pending_worker_lock);
-        kafs_pending_worker_adjust_priority_locked(ctx);
-        if (ctx->c_pending_worker_prio_dirty)
-          pthread_cond_broadcast(&ctx->c_pending_worker_cond);
-        pthread_mutex_unlock(&ctx->c_pending_worker_lock);
-      }
-    }
+    result = kafs_ctl_handle_set_runtime(ctx, hdr.payload_len, payload);
     break;
   default:
     result = -ENOSYS;

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -2404,6 +2404,142 @@ static void kafs_bg_dedup_worker_adjust_priority_locked(kafs_context_t *ctx, int
   ctx->c_bg_dedup_worker_auto_boosted = pressure_mode ? 1u : 0u;
 }
 
+typedef struct kafs_bg_dedup_worker_plan
+{
+  uint32_t sleep_ms;
+  int run_scan;
+  int pressure_mode;
+  int apply_prio;
+  uint32_t mode;
+} kafs_bg_dedup_worker_plan_t;
+
+static void kafs_bg_dedup_worker_plan_locked(kafs_context_t *ctx, uint64_t now_ns,
+                                             kafs_bg_dedup_worker_plan_t *plan)
+{
+  plan->sleep_ms = ctx->c_bg_dedup_quiet_interval_ms;
+  plan->run_scan = 0;
+  plan->pressure_mode = 0;
+  plan->mode = KAFS_BG_DEDUP_MODE_COLD;
+
+  if (ctx->c_bg_dedup_enabled && ctx->c_bg_dedup_interval_ms > 0)
+  {
+    uint32_t used_pct = kafs_bg_dedup_used_pct(ctx);
+    int over_start =
+        (ctx->c_bg_dedup_start_used_pct == 0 || used_pct >= ctx->c_bg_dedup_start_used_pct);
+    plan->pressure_mode =
+        (ctx->c_bg_dedup_pressure_used_pct > 0 && used_pct >= ctx->c_bg_dedup_pressure_used_pct);
+
+    if (plan->pressure_mode)
+    {
+      plan->mode = KAFS_BG_DEDUP_MODE_PRESSURE;
+      plan->run_scan = 1;
+      plan->sleep_ms = ctx->c_bg_dedup_pressure_interval_ms;
+      ctx->c_bg_dedup_idle_skip_streak = 0;
+    }
+    else if (!ctx->c_bg_dedup_telemetry_valid)
+    {
+      if (ctx->c_bg_dedup_cold_start_due_ns == 0)
+        ctx->c_bg_dedup_cold_start_due_ns =
+            now_ns + (uint64_t)ctx->c_bg_dedup_quiet_interval_ms * 1000000ull;
+
+      if (over_start || now_ns >= ctx->c_bg_dedup_cold_start_due_ns)
+      {
+        plan->run_scan = 1;
+        plan->sleep_ms = ctx->c_bg_dedup_interval_ms;
+        ctx->c_bg_dedup_idle_skip_streak = 0;
+        ctx->c_bg_dedup_cold_start_due_ns =
+            now_ns + (uint64_t)ctx->c_bg_dedup_quiet_interval_ms * 1000000ull;
+      }
+    }
+    else
+    {
+      int should_run = 0;
+      plan->mode = KAFS_BG_DEDUP_MODE_ADAPTIVE;
+      if (ctx->c_bg_dedup_last_direct_candidates > 0 || ctx->c_bg_dedup_last_replacements > 0)
+        should_run = 1;
+      else
+      {
+        ctx->c_bg_dedup_idle_skip_streak++;
+        if (ctx->c_bg_dedup_idle_skip_streak >= KAFS_BG_DEDUP_RESAMPLE_QUIET_CYCLES)
+          should_run = 1;
+      }
+
+      if (should_run)
+      {
+        plan->run_scan = 1;
+        plan->sleep_ms = ctx->c_bg_dedup_interval_ms;
+        ctx->c_bg_dedup_idle_skip_streak = 0;
+      }
+    }
+
+    kafs_bg_dedup_worker_adjust_priority_locked(ctx, plan->pressure_mode);
+  }
+
+  ctx->c_bg_dedup_mode = plan->mode;
+  plan->apply_prio = (ctx->c_bg_dedup_worker_prio_dirty != 0);
+}
+
+static void kafs_bg_dedup_worker_run_scan(kafs_context_t *ctx, int pressure_mode)
+{
+  uint64_t before_steps = __atomic_load_n(&ctx->c_stat_bg_dedup_steps, __ATOMIC_RELAXED);
+  uint64_t before_scanned = __atomic_load_n(&ctx->c_stat_bg_dedup_scanned_blocks, __ATOMIC_RELAXED);
+  uint64_t before_candidates =
+      __atomic_load_n(&ctx->c_stat_bg_dedup_direct_candidates, __ATOMIC_RELAXED);
+  uint64_t before_repl = __atomic_load_n(&ctx->c_stat_bg_dedup_replacements, __ATOMIC_RELAXED);
+  uint32_t steps = pressure_mode ? KAFS_BG_DEDUP_PRESSURE_BURST_STEPS : 1u;
+
+  for (uint32_t i = 0; i < steps; ++i)
+    kafs_bg_dedup_step(ctx, pressure_mode);
+
+  uint64_t after_steps = __atomic_load_n(&ctx->c_stat_bg_dedup_steps, __ATOMIC_RELAXED);
+  uint64_t after_scanned = __atomic_load_n(&ctx->c_stat_bg_dedup_scanned_blocks, __ATOMIC_RELAXED);
+  uint64_t after_candidates =
+      __atomic_load_n(&ctx->c_stat_bg_dedup_direct_candidates, __ATOMIC_RELAXED);
+  uint64_t after_repl = __atomic_load_n(&ctx->c_stat_bg_dedup_replacements, __ATOMIC_RELAXED);
+
+  if (after_steps > before_steps)
+  {
+    pthread_mutex_lock(&ctx->c_bg_dedup_worker_lock);
+    ctx->c_bg_dedup_telemetry_valid = 1u;
+    ctx->c_bg_dedup_last_scanned_blocks =
+        (after_scanned >= before_scanned) ? (after_scanned - before_scanned) : 0u;
+    ctx->c_bg_dedup_last_direct_candidates =
+        (after_candidates >= before_candidates) ? (after_candidates - before_candidates) : 0u;
+    ctx->c_bg_dedup_last_replacements =
+        (after_repl >= before_repl) ? (after_repl - before_repl) : 0u;
+    pthread_mutex_unlock(&ctx->c_bg_dedup_worker_lock);
+  }
+}
+
+static int kafs_bg_dedup_worker_wait(kafs_context_t *ctx, int pressure_mode, uint32_t sleep_ms)
+{
+  uint32_t wait_ms =
+      pressure_mode ? sleep_ms : kafs_u32_min(sleep_ms, KAFS_BG_DEDUP_MONITOR_INTERVAL_MS);
+  if (wait_ms == 0)
+    wait_ms = 1;
+
+  pthread_mutex_lock(&ctx->c_bg_dedup_worker_lock);
+  if (ctx->c_bg_dedup_worker_stop)
+  {
+    pthread_mutex_unlock(&ctx->c_bg_dedup_worker_lock);
+    return 1;
+  }
+
+  struct timespec wake;
+  clock_gettime(CLOCK_REALTIME, &wake);
+  wake.tv_nsec += (long)(wait_ms % 1000u) * 1000000l;
+  wake.tv_sec += (time_t)(wait_ms / 1000u);
+  if (wake.tv_nsec >= 1000000000l)
+  {
+    wake.tv_sec += 1;
+    wake.tv_nsec -= 1000000000l;
+  }
+
+  (void)pthread_cond_timedwait(&ctx->c_bg_dedup_worker_cond, &ctx->c_bg_dedup_worker_lock, &wake);
+  pthread_mutex_unlock(&ctx->c_bg_dedup_worker_lock);
+  return 0;
+}
+
 static void *kafs_bg_dedup_worker_main(void *arg)
 {
   kafs_context_t *ctx = (kafs_context_t *)arg;
@@ -2414,11 +2550,7 @@ static void *kafs_bg_dedup_worker_main(void *arg)
 
   for (;;)
   {
-    uint32_t sleep_ms = ctx->c_bg_dedup_quiet_interval_ms;
-    int run_scan = 0;
-    int pressure_mode = 0;
-    int apply_prio = 0;
-    uint32_t mode = KAFS_BG_DEDUP_MODE_COLD;
+    kafs_bg_dedup_worker_plan_t plan;
     uint64_t now_ns = kafs_now_ns();
 
     pthread_mutex_lock(&ctx->c_bg_dedup_worker_lock);
@@ -2428,136 +2560,17 @@ static void *kafs_bg_dedup_worker_main(void *arg)
       return NULL;
     }
 
-    if (ctx->c_bg_dedup_enabled && ctx->c_bg_dedup_interval_ms > 0)
-    {
-      uint32_t used_pct = kafs_bg_dedup_used_pct(ctx);
-      pressure_mode =
-          (ctx->c_bg_dedup_pressure_used_pct > 0 && used_pct >= ctx->c_bg_dedup_pressure_used_pct);
-      int over_start =
-          (ctx->c_bg_dedup_start_used_pct == 0 || used_pct >= ctx->c_bg_dedup_start_used_pct);
-
-      if (pressure_mode)
-      {
-        mode = KAFS_BG_DEDUP_MODE_PRESSURE;
-        run_scan = 1;
-        sleep_ms = ctx->c_bg_dedup_pressure_interval_ms;
-        ctx->c_bg_dedup_idle_skip_streak = 0;
-      }
-      else if (!ctx->c_bg_dedup_telemetry_valid)
-      {
-        mode = KAFS_BG_DEDUP_MODE_COLD;
-        if (ctx->c_bg_dedup_cold_start_due_ns == 0)
-          ctx->c_bg_dedup_cold_start_due_ns =
-              now_ns + (uint64_t)ctx->c_bg_dedup_quiet_interval_ms * 1000000ull;
-
-        if (over_start || now_ns >= ctx->c_bg_dedup_cold_start_due_ns)
-        {
-          run_scan = 1;
-          sleep_ms = ctx->c_bg_dedup_interval_ms;
-          ctx->c_bg_dedup_idle_skip_streak = 0;
-          ctx->c_bg_dedup_cold_start_due_ns =
-              now_ns + (uint64_t)ctx->c_bg_dedup_quiet_interval_ms * 1000000ull;
-        }
-        else
-        {
-          run_scan = 0;
-          sleep_ms = ctx->c_bg_dedup_quiet_interval_ms;
-        }
-      }
-      else
-      {
-        mode = KAFS_BG_DEDUP_MODE_ADAPTIVE;
-        int should_run = 0;
-        if (ctx->c_bg_dedup_last_direct_candidates > 0 || ctx->c_bg_dedup_last_replacements > 0)
-          should_run = 1;
-        else
-        {
-          ctx->c_bg_dedup_idle_skip_streak++;
-          if (ctx->c_bg_dedup_idle_skip_streak >= KAFS_BG_DEDUP_RESAMPLE_QUIET_CYCLES)
-            should_run = 1;
-        }
-
-        if (should_run)
-        {
-          run_scan = 1;
-          sleep_ms = ctx->c_bg_dedup_interval_ms;
-          ctx->c_bg_dedup_idle_skip_streak = 0;
-        }
-        else
-        {
-          run_scan = 0;
-          sleep_ms = ctx->c_bg_dedup_quiet_interval_ms;
-        }
-      }
-
-      kafs_bg_dedup_worker_adjust_priority_locked(ctx, pressure_mode);
-    }
-    ctx->c_bg_dedup_mode = mode;
-
-    apply_prio = (ctx->c_bg_dedup_worker_prio_dirty != 0);
+    kafs_bg_dedup_worker_plan_locked(ctx, now_ns, &plan);
     pthread_mutex_unlock(&ctx->c_bg_dedup_worker_lock);
 
-    if (apply_prio)
+    if (plan.apply_prio)
       (void)kafs_bg_dedup_worker_apply_priority_self(ctx);
 
-    if (run_scan)
-    {
-      uint64_t before_steps = __atomic_load_n(&ctx->c_stat_bg_dedup_steps, __ATOMIC_RELAXED);
-      uint64_t before_scanned =
-          __atomic_load_n(&ctx->c_stat_bg_dedup_scanned_blocks, __ATOMIC_RELAXED);
-      uint64_t before_candidates =
-          __atomic_load_n(&ctx->c_stat_bg_dedup_direct_candidates, __ATOMIC_RELAXED);
-      uint64_t before_repl = __atomic_load_n(&ctx->c_stat_bg_dedup_replacements, __ATOMIC_RELAXED);
+    if (plan.run_scan)
+      kafs_bg_dedup_worker_run_scan(ctx, plan.pressure_mode);
 
-      uint32_t steps = pressure_mode ? KAFS_BG_DEDUP_PRESSURE_BURST_STEPS : 1u;
-      for (uint32_t i = 0; i < steps; ++i)
-        kafs_bg_dedup_step(ctx, pressure_mode);
-
-      uint64_t after_steps = __atomic_load_n(&ctx->c_stat_bg_dedup_steps, __ATOMIC_RELAXED);
-      uint64_t after_scanned =
-          __atomic_load_n(&ctx->c_stat_bg_dedup_scanned_blocks, __ATOMIC_RELAXED);
-      uint64_t after_candidates =
-          __atomic_load_n(&ctx->c_stat_bg_dedup_direct_candidates, __ATOMIC_RELAXED);
-      uint64_t after_repl = __atomic_load_n(&ctx->c_stat_bg_dedup_replacements, __ATOMIC_RELAXED);
-
-      if (after_steps > before_steps)
-      {
-        pthread_mutex_lock(&ctx->c_bg_dedup_worker_lock);
-        ctx->c_bg_dedup_telemetry_valid = 1u;
-        ctx->c_bg_dedup_last_scanned_blocks =
-            (after_scanned >= before_scanned) ? (after_scanned - before_scanned) : 0u;
-        ctx->c_bg_dedup_last_direct_candidates =
-            (after_candidates >= before_candidates) ? (after_candidates - before_candidates) : 0u;
-        ctx->c_bg_dedup_last_replacements =
-            (after_repl >= before_repl) ? (after_repl - before_repl) : 0u;
-        pthread_mutex_unlock(&ctx->c_bg_dedup_worker_lock);
-      }
-    }
-
-    pthread_mutex_lock(&ctx->c_bg_dedup_worker_lock);
-    if (ctx->c_bg_dedup_worker_stop)
-    {
-      pthread_mutex_unlock(&ctx->c_bg_dedup_worker_lock);
+    if (kafs_bg_dedup_worker_wait(ctx, plan.pressure_mode, plan.sleep_ms) != 0)
       return NULL;
-    }
-
-    uint32_t wait_ms =
-        pressure_mode ? sleep_ms : kafs_u32_min(sleep_ms, KAFS_BG_DEDUP_MONITOR_INTERVAL_MS);
-    if (wait_ms == 0)
-      wait_ms = 1;
-
-    struct timespec wake;
-    clock_gettime(CLOCK_REALTIME, &wake);
-    wake.tv_nsec += (long)(wait_ms % 1000u) * 1000000l;
-    wake.tv_sec += (time_t)(wait_ms / 1000u);
-    if (wake.tv_nsec >= 1000000000l)
-    {
-      wake.tv_sec += 1;
-      wake.tv_nsec -= 1000000000l;
-    }
-
-    (void)pthread_cond_timedwait(&ctx->c_bg_dedup_worker_cond, &ctx->c_bg_dedup_worker_lock, &wake);
-    pthread_mutex_unlock(&ctx->c_bg_dedup_worker_lock);
   }
 }
 

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -6551,15 +6551,8 @@ static int kafs_hotplug_wait_for_back(kafs_context_t *ctx, const char *uds_path,
   return 0;
 }
 
-static int kafs_hotplug_wait_ready(kafs_context_t *ctx)
+static int kafs_hotplug_wait_ready_init(kafs_context_t *ctx)
 {
-  if (!ctx || ctx->c_hotplug_state == KAFS_HOTPLUG_STATE_DISABLED)
-    return -ENOSYS;
-  if (kafs_hotplug_enabled(ctx))
-    return 0;
-  if (ctx->c_hotplug_wait_timeout_ms == 0 || ctx->c_hotplug_uds_path[0] == '\0')
-    return -EIO;
-
   if (!ctx->c_hotplug_wait_lock_init)
   {
     if (pthread_mutex_init(&ctx->c_hotplug_wait_lock, NULL) == 0 &&
@@ -6571,6 +6564,12 @@ static int kafs_hotplug_wait_ready(kafs_context_t *ctx)
   if (!ctx->c_hotplug_wait_lock_init)
     return -EIO;
 
+  return 0;
+}
+
+static int kafs_hotplug_wait_ready_begin(kafs_context_t *ctx, int *do_connect,
+                                         struct timespec *deadline)
+{
   pthread_mutex_lock(&ctx->c_hotplug_wait_lock);
   if (ctx->c_hotplug_wait_queue_len >= ctx->c_hotplug_wait_queue_limit)
   {
@@ -6579,33 +6578,34 @@ static int kafs_hotplug_wait_ready(kafs_context_t *ctx)
     return -EIO;
   }
   ctx->c_hotplug_wait_queue_len++;
-  int do_connect = 0;
+  *do_connect = 0;
   if (!ctx->c_hotplug_connecting)
   {
     ctx->c_hotplug_connecting = 1;
-    do_connect = 1;
+    *do_connect = 1;
   }
-  struct timespec deadline;
-  clock_gettime(CLOCK_REALTIME, &deadline);
-  kafs_timespec_add_ms(&deadline, ctx->c_hotplug_wait_timeout_ms);
+  clock_gettime(CLOCK_REALTIME, deadline);
+  kafs_timespec_add_ms(deadline, ctx->c_hotplug_wait_timeout_ms);
   pthread_mutex_unlock(&ctx->c_hotplug_wait_lock);
 
-  if (do_connect)
-  {
-    (void)kafs_hotplug_wait_for_back(ctx, ctx->c_hotplug_uds_path,
-                                     (int)ctx->c_hotplug_wait_timeout_ms);
-    pthread_mutex_lock(&ctx->c_hotplug_wait_lock);
-    ctx->c_hotplug_connecting = 0;
-    pthread_cond_broadcast(&ctx->c_hotplug_wait_cond);
-    pthread_mutex_unlock(&ctx->c_hotplug_wait_lock);
-  }
+  return 0;
+}
 
+static void kafs_hotplug_wait_ready_finish_connect(kafs_context_t *ctx)
+{
+  pthread_mutex_lock(&ctx->c_hotplug_wait_lock);
+  ctx->c_hotplug_connecting = 0;
+  pthread_cond_broadcast(&ctx->c_hotplug_wait_cond);
+  pthread_mutex_unlock(&ctx->c_hotplug_wait_lock);
+}
+
+static int kafs_hotplug_wait_ready_wait(kafs_context_t *ctx, const struct timespec *deadline)
+{
   int rc = 0;
   pthread_mutex_lock(&ctx->c_hotplug_wait_lock);
   while (!kafs_hotplug_enabled(ctx))
   {
-    int tw =
-        pthread_cond_timedwait(&ctx->c_hotplug_wait_cond, &ctx->c_hotplug_wait_lock, &deadline);
+    int tw = pthread_cond_timedwait(&ctx->c_hotplug_wait_cond, &ctx->c_hotplug_wait_lock, deadline);
     if (tw == ETIMEDOUT)
     {
       ctx->c_hotplug_last_error = -ETIMEDOUT;
@@ -6620,6 +6620,35 @@ static int kafs_hotplug_wait_ready(kafs_context_t *ctx)
   if (rc == 0 && !kafs_hotplug_enabled(ctx))
     rc = -EIO;
   return rc;
+}
+
+static int kafs_hotplug_wait_ready(kafs_context_t *ctx)
+{
+  if (!ctx || ctx->c_hotplug_state == KAFS_HOTPLUG_STATE_DISABLED)
+    return -ENOSYS;
+  if (kafs_hotplug_enabled(ctx))
+    return 0;
+  if (ctx->c_hotplug_wait_timeout_ms == 0 || ctx->c_hotplug_uds_path[0] == '\0')
+    return -EIO;
+
+  int rc = kafs_hotplug_wait_ready_init(ctx);
+  if (rc != 0)
+    return rc;
+
+  int do_connect = 0;
+  struct timespec deadline;
+  rc = kafs_hotplug_wait_ready_begin(ctx, &do_connect, &deadline);
+  if (rc != 0)
+    return rc;
+
+  if (do_connect)
+  {
+    (void)kafs_hotplug_wait_for_back(ctx, ctx->c_hotplug_uds_path,
+                                     (int)ctx->c_hotplug_wait_timeout_ms);
+    kafs_hotplug_wait_ready_finish_connect(ctx);
+  }
+
+  return kafs_hotplug_wait_ready_wait(ctx, &deadline);
 }
 
 static int kafs_hotplug_restart_back(kafs_context_t *ctx)

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -8493,25 +8493,21 @@ static int kafs_op_readdir(const char *path, void *buf, fuse_fill_dir_t filler, 
   return 0;
 }
 
-static int kafs_create(const char *path, kafs_mode_t mode, kafs_dev_t dev, kafs_inocnt_t *pino_dir,
-                       kafs_inocnt_t *pino_new)
+static void kafs_create_split_path(char *path_copy, const char **dirpath_out, char **basepath_out)
 {
-  assert(path != NULL);
-  assert(path[0] == '/');
-  assert(path[1] != '\0');
-  struct fuse_context *fctx = fuse_get_context();
-  struct kafs_context *ctx = fctx->private_data;
-  char path_copy[strlen(path) + 1];
-  strcpy(path_copy, path);
   const char *dirpath = path_copy;
   char *basepath = strrchr(path_copy, '/');
   if (dirpath == basepath)
     dirpath = "/";
   *basepath = '\0';
-  basepath++;
+  ++basepath;
+  *dirpath_out = dirpath;
+  *basepath_out = basepath;
+}
 
-  uint64_t jseq = kafs_journal_begin(ctx, "CREATE", "path=%s mode=%o", path, (unsigned)mode);
-  kafs_dlog(2, "%s: dirpath='%s' base='%s'\n", __func__, dirpath, basepath);
+static int kafs_create_ensure_absent(struct fuse_context *fctx, struct kafs_context *ctx,
+                                     const char *path, uint64_t jseq)
+{
   int ret = kafs_access(fctx, ctx, path, NULL, F_OK, NULL);
   kafs_dlog(2, "%s: access(path) rc=%d\n", __func__, ret);
   if (ret == KAFS_SUCCESS)
@@ -8524,9 +8520,15 @@ static int kafs_create(const char *path, kafs_mode_t mode, kafs_dev_t dev, kafs_
     kafs_journal_abort(ctx, jseq, "access=%d", ret);
     return ret;
   }
+  return 0;
+}
 
-  kafs_sinode_t *inoent_dir;
-  ret = kafs_access(fctx, ctx, dirpath, NULL, W_OK, &inoent_dir);
+static int kafs_create_resolve_parent(struct fuse_context *fctx, struct kafs_context *ctx,
+                                      const char *dirpath, uint64_t jseq,
+                                      kafs_sinode_t **inoent_dir_out)
+{
+  kafs_sinode_t *inoent_dir = NULL;
+  int ret = kafs_access(fctx, ctx, dirpath, NULL, W_OK, &inoent_dir);
   kafs_dlog(2, "%s: access(dirpath='%s') rc=%d ino_dir=%u\n", __func__, dirpath, ret,
             (unsigned)(inoent_dir ? kafs_ctx_ino_no(ctx, inoent_dir) : 0));
   if (ret < 0)
@@ -8534,16 +8536,24 @@ static int kafs_create(const char *path, kafs_mode_t mode, kafs_dev_t dev, kafs_
     kafs_journal_abort(ctx, jseq, "parent access=%d", ret);
     return ret;
   }
-  kafs_mode_t mode_dir = kafs_ino_mode_get(inoent_dir);
-  if (!S_ISDIR(mode_dir))
+  if (!S_ISDIR(kafs_ino_mode_get(inoent_dir)))
   {
     kafs_journal_abort(ctx, jseq, "ENOTDIR");
     return -ENOTDIR;
   }
+  *inoent_dir_out = inoent_dir;
+  return 0;
+}
+
+static int kafs_create_allocate_inode(struct fuse_context *fctx, struct kafs_context *ctx,
+                                      kafs_mode_t mode, kafs_dev_t dev, uint64_t jseq,
+                                      kafs_inocnt_t *ino_new_out,
+                                      struct kafs_sinode **inoent_new_out)
+{
   kafs_inocnt_t ino_new;
   kafs_inode_alloc_lock(ctx);
-  ret = kafs_ino_find_free(ctx->c_inotbl, kafs_ctx_inode_format(ctx), &ino_new, &ctx->c_ino_search,
-                           kafs_sb_inocnt_get(ctx->c_superblock));
+  int ret = kafs_ino_find_free(ctx->c_inotbl, kafs_ctx_inode_format(ctx), &ino_new,
+                               &ctx->c_ino_search, kafs_sb_inocnt_get(ctx->c_superblock));
   if (ret < 0)
   {
     kafs_inode_alloc_unlock(ctx);
@@ -8554,7 +8564,6 @@ static int kafs_create(const char *path, kafs_mode_t mode, kafs_dev_t dev, kafs_
   kafs_dlog(2, "%s: alloc ino=%u\n", __func__, (unsigned)ino_new);
   struct kafs_sinode *inoent_new = kafs_ctx_inode(ctx, ino_new);
 
-  // Reserve/initialize the inode while holding alloc lock so no other thread can allocate it.
   kafs_ctx_inode_zero(ctx, inoent_new);
   kafs_ino_mode_set(inoent_new, mode);
   kafs_ino_uid_set(inoent_new, fctx->uid);
@@ -8579,21 +8588,75 @@ static int kafs_create(const char *path, kafs_mode_t mode, kafs_dev_t dev, kafs_
   }
 
   kafs_inode_alloc_unlock(ctx);
+  *ino_new_out = ino_new;
+  *inoent_new_out = inoent_new;
+  return 0;
+}
 
-  uint32_t ino_dir_u32 = (uint32_t)kafs_ctx_ino_no(ctx, inoent_dir);
-  uint32_t ino_new_u32 = (uint32_t)ino_new;
-  // lock ordering: always by inode number to avoid deadlock with other ops
+static void kafs_create_lock_inodes(struct kafs_context *ctx, uint32_t ino_dir_u32,
+                                    uint32_t ino_new_u32)
+{
   if (ino_dir_u32 < ino_new_u32)
   {
     kafs_inode_lock(ctx, ino_dir_u32);
     kafs_inode_lock(ctx, ino_new_u32);
+    return;
   }
-  else
+
+  kafs_inode_lock(ctx, ino_new_u32);
+  if (ino_dir_u32 != ino_new_u32)
+    kafs_inode_lock(ctx, ino_dir_u32);
+}
+
+static void kafs_create_unlock_inodes(struct kafs_context *ctx, uint32_t ino_dir_u32,
+                                      uint32_t ino_new_u32)
+{
+  if (ino_dir_u32 < ino_new_u32)
   {
-    kafs_inode_lock(ctx, ino_new_u32);
-    if (ino_dir_u32 != ino_new_u32)
-      kafs_inode_lock(ctx, ino_dir_u32);
+    kafs_inode_unlock(ctx, ino_new_u32);
+    kafs_inode_unlock(ctx, ino_dir_u32);
+    return;
   }
+
+  if (ino_dir_u32 != ino_new_u32)
+    kafs_inode_unlock(ctx, ino_dir_u32);
+  kafs_inode_unlock(ctx, ino_new_u32);
+}
+
+static int kafs_create(const char *path, kafs_mode_t mode, kafs_dev_t dev, kafs_inocnt_t *pino_dir,
+                       kafs_inocnt_t *pino_new)
+{
+  assert(path != NULL);
+  assert(path[0] == '/');
+  assert(path[1] != '\0');
+  struct fuse_context *fctx = fuse_get_context();
+  struct kafs_context *ctx = fctx->private_data;
+  char path_copy[strlen(path) + 1];
+  strcpy(path_copy, path);
+  const char *dirpath = NULL;
+  char *basepath = NULL;
+  kafs_create_split_path(path_copy, &dirpath, &basepath);
+
+  uint64_t jseq = kafs_journal_begin(ctx, "CREATE", "path=%s mode=%o", path, (unsigned)mode);
+  kafs_dlog(2, "%s: dirpath='%s' base='%s'\n", __func__, dirpath, basepath);
+  int ret = kafs_create_ensure_absent(fctx, ctx, path, jseq);
+  if (ret < 0)
+    return ret;
+
+  kafs_sinode_t *inoent_dir = NULL;
+  ret = kafs_create_resolve_parent(fctx, ctx, dirpath, jseq, &inoent_dir);
+  if (ret < 0)
+    return ret;
+
+  kafs_inocnt_t ino_new;
+  struct kafs_sinode *inoent_new = NULL;
+  ret = kafs_create_allocate_inode(fctx, ctx, mode, dev, jseq, &ino_new, &inoent_new);
+  if (ret < 0)
+    return ret;
+
+  uint32_t ino_dir_u32 = (uint32_t)kafs_ctx_ino_no(ctx, inoent_dir);
+  uint32_t ino_new_u32 = (uint32_t)ino_new;
+  kafs_create_lock_inodes(ctx, ino_dir_u32, ino_new_u32);
 
   kafs_dlog(2, "%s: dirent_add start dir=%u name='%s'\n", __func__, (unsigned)ino_dir_u32,
             basepath);
@@ -8602,17 +8665,7 @@ static int kafs_create(const char *path, kafs_mode_t mode, kafs_dev_t dev, kafs_
   if (ret < 0)
   {
     kafs_ctx_inode_zero(ctx, inoent_new);
-    if (ino_dir_u32 < ino_new_u32)
-    {
-      kafs_inode_unlock(ctx, ino_new_u32);
-      kafs_inode_unlock(ctx, ino_dir_u32);
-    }
-    else
-    {
-      if (ino_dir_u32 != ino_new_u32)
-        kafs_inode_unlock(ctx, ino_dir_u32);
-      kafs_inode_unlock(ctx, ino_new_u32);
-    }
+    kafs_create_unlock_inodes(ctx, ino_dir_u32, ino_new_u32);
     kafs_journal_abort(ctx, jseq, "dirent_add=%d", ret);
     return ret;
   }
@@ -8622,20 +8675,8 @@ static int kafs_create(const char *path, kafs_mode_t mode, kafs_dev_t dev, kafs_
   if (pino_new != NULL)
     *pino_new = ino_new;
 
-  // unlock in reverse order
-  if (ino_dir_u32 < ino_new_u32)
-  {
-    kafs_inode_unlock(ctx, ino_new_u32);
-    kafs_inode_unlock(ctx, ino_dir_u32);
-  }
-  else
-  {
-    if (ino_dir_u32 != ino_new_u32)
-      kafs_inode_unlock(ctx, ino_dir_u32);
-    kafs_inode_unlock(ctx, ino_new_u32);
-  }
+  kafs_create_unlock_inodes(ctx, ino_dir_u32, ino_new_u32);
 
-  // Update free inode accounting after allocation (no inode locks held).
   kafs_inode_alloc_lock(ctx);
   (void)kafs_sb_inocnt_free_decr(ctx->c_superblock);
   kafs_sb_wtime_set(ctx->c_superblock, kafs_now());

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -10906,36 +10906,68 @@ static void kafs_migrate_ctx_close(kafs_context_t *ctx)
   ctx->c_fd = -1;
 }
 
-int kafs_core_migrate_image(const char *image_path, int assume_yes)
+static int kafs_migrate_read_superblock(const char *image_path, kafs_ssuperblock_t *sb,
+                                        uint32_t *fmt)
 {
-  if (!image_path)
-    return -EINVAL;
-
-  kafs_ssuperblock_t sb;
   int fd = open(image_path, O_RDWR, 0666);
   if (fd < 0)
     return -errno;
-  ssize_t r = pread(fd, &sb, sizeof(sb), 0);
-  if (r != (ssize_t)sizeof(sb))
+
+  ssize_t r = pread(fd, sb, sizeof(*sb), 0);
+  if (r != (ssize_t)sizeof(*sb))
   {
     int err = -errno;
     close(fd);
     return err ? err : -EIO;
   }
   close(fd);
-  if (kafs_sb_magic_get(&sb) != KAFS_MAGIC)
+
+  if (kafs_sb_magic_get(sb) != KAFS_MAGIC)
     return -EINVAL;
 
-  uint32_t fmt = kafs_sb_format_version_get(&sb);
-  if (fmt == KAFS_FORMAT_VERSION)
+  *fmt = kafs_sb_format_version_get(sb);
+  if (*fmt == KAFS_FORMAT_VERSION)
     return 1;
-  if (fmt != KAFS_FORMAT_VERSION_V2 && fmt != KAFS_FORMAT_VERSION_V3)
+  if (*fmt != KAFS_FORMAT_VERSION_V2 && *fmt != KAFS_FORMAT_VERSION_V3)
     return -EPROTONOSUPPORT;
+
+  return 0;
+}
+
+static int kafs_migrate_finalize_superblock(kafs_context_t *ctx, uint32_t fmt)
+{
+  if (fmt == KAFS_FORMAT_VERSION_V2 && kafs_sb_allocator_size_get(ctx->c_superblock) > 0)
+  {
+    if (kafs_sb_allocator_version_get(ctx->c_superblock) < 2u)
+      kafs_sb_allocator_version_set(ctx->c_superblock, 2u);
+    uint64_t ff = kafs_sb_feature_flags_get(ctx->c_superblock);
+    kafs_sb_feature_flags_set(ctx->c_superblock, ff | KAFS_FEATURE_ALLOC_V2);
+  }
+  kafs_sb_format_version_set(ctx->c_superblock, KAFS_FORMAT_VERSION);
+  kafs_sb_wtime_set(ctx->c_superblock, kafs_now());
+  if (msync(ctx->c_img_base, ctx->c_img_size, MS_SYNC) != 0)
+    return -errno;
+  if (fsync(ctx->c_fd) != 0)
+    return -errno;
+
+  return 0;
+}
+
+int kafs_core_migrate_image(const char *image_path, int assume_yes)
+{
+  if (!image_path)
+    return -EINVAL;
+
+  kafs_ssuperblock_t sb;
+  uint32_t fmt;
+  int rc = kafs_migrate_read_superblock(image_path, &sb, &fmt);
+  if (rc != 0)
+    return rc;
   if (!assume_yes && !kafs_confirm_yes_stdin())
     return -ECANCELED;
 
   kafs_context_t ctx;
-  int rc = kafs_migrate_ctx_open(image_path, &ctx, &sb);
+  rc = kafs_migrate_ctx_open(image_path, &ctx, &sb);
   if (rc != 0)
     return rc;
 
@@ -10955,21 +10987,7 @@ int kafs_core_migrate_image(const char *image_path, int assume_yes)
   }
 
   if (rc == 0)
-  {
-    if (fmt == KAFS_FORMAT_VERSION_V2 && kafs_sb_allocator_size_get(ctx.c_superblock) > 0)
-    {
-      if (kafs_sb_allocator_version_get(ctx.c_superblock) < 2u)
-        kafs_sb_allocator_version_set(ctx.c_superblock, 2u);
-      uint64_t ff = kafs_sb_feature_flags_get(ctx.c_superblock);
-      kafs_sb_feature_flags_set(ctx.c_superblock, ff | KAFS_FEATURE_ALLOC_V2);
-    }
-    kafs_sb_format_version_set(ctx.c_superblock, KAFS_FORMAT_VERSION);
-    kafs_sb_wtime_set(ctx.c_superblock, kafs_now());
-    if (msync(ctx.c_img_base, ctx.c_img_size, MS_SYNC) != 0)
-      rc = -errno;
-    else if (fsync(ctx.c_fd) != 0)
-      rc = -errno;
-  }
+    rc = kafs_migrate_finalize_superblock(&ctx, fmt);
 
   kafs_migrate_ctx_close(&ctx);
   return rc;

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -4848,6 +4848,98 @@ static int kafs_truncate_handle_growth(struct kafs_context *ctx, kafs_sinode_t *
   return KAFS_SUCCESS;
 }
 
+static int kafs_truncate_handle_direct_shrink(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                              kafs_off_t filesize_orig, kafs_off_t filesize_new)
+{
+  memset((void *)inoent->i_blkreftbl + filesize_new, 0, filesize_orig - filesize_new);
+  kafs_ino_size_set(inoent, filesize_new);
+  if (kafs_tailmeta_inode_is_regular_v5(ctx, inoent))
+    kafs_tailmeta_inode_taildesc_set_inline(ctx, inoent);
+  return KAFS_SUCCESS;
+}
+
+static int kafs_truncate_collect_batches(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                         kafs_iblkcnt_t start, kafs_iblkcnt_t end,
+                                         kafs_blkcnt_t **deferred_free, size_t *deferred_free_cnt,
+                                         size_t *deferred_free_cap)
+{
+  const kafs_iblkcnt_t trunc_batch = 64;
+  kafs_iblkcnt_t current = start;
+  while (current < end)
+  {
+    kafs_iblkcnt_t batch_end = current + trunc_batch;
+    if (batch_end > end)
+      batch_end = end;
+
+    int rc = kafs_truncate_collect_free_range(ctx, inoent, current, batch_end, deferred_free,
+                                              deferred_free_cnt, deferred_free_cap);
+    if (rc != 0)
+      return rc;
+    current = batch_end;
+  }
+  return 0;
+}
+
+static int kafs_truncate_handle_indirect_to_direct(
+    struct kafs_context *ctx, kafs_sinode_t *inoent, uint32_t ino_idx, kafs_off_t filesize_new,
+    kafs_iblkcnt_t iblocnt, kafs_blkcnt_t **deferred_free, size_t *deferred_free_cnt,
+    size_t *deferred_free_cap, kafs_blksize_t blksize)
+{
+  char buf[blksize];
+  KAFS_CALL(kafs_ino_iblk_read, ctx, inoent, 0, buf);
+
+  kafs_ino_size_set(inoent, filesize_new);
+  int rc = kafs_truncate_collect_batches(ctx, inoent, 0, iblocnt, deferred_free, deferred_free_cnt,
+                                         deferred_free_cap);
+  if (rc != 0)
+    return rc;
+
+  memcpy(inoent->i_blkreftbl, buf, (size_t)filesize_new);
+  if (filesize_new < KAFS_INODE_DIRECT_BYTES)
+    memset((void *)inoent->i_blkreftbl + filesize_new, 0, KAFS_INODE_DIRECT_BYTES - filesize_new);
+  if (kafs_tailmeta_inode_is_regular_v5(ctx, inoent))
+    kafs_tailmeta_inode_taildesc_set_inline(ctx, inoent);
+  kafs_truncate_release_deferred_refs(ctx, ino_idx, *deferred_free, *deferred_free_cnt);
+  return KAFS_SUCCESS;
+}
+
+static int kafs_truncate_handle_indirect_shrink(
+    struct kafs_context *ctx, kafs_sinode_t *inoent, uint32_t ino_idx, kafs_off_t filesize_new,
+    kafs_iblkcnt_t iblooff, kafs_iblkcnt_t iblocnt, kafs_blksize_t off, kafs_blksize_t blksize,
+    kafs_blkcnt_t **deferred_free, size_t *deferred_free_cnt, size_t *deferred_free_cap)
+{
+  kafs_ino_size_set(inoent, filesize_new);
+
+  if (off > 0)
+  {
+    char buf[blksize];
+    kafs_blkcnt_t cur_blo = KAFS_BLO_NONE;
+    (void)kafs_ino_ibrk_run(ctx, inoent, iblooff, &cur_blo, KAFS_IBLKREF_FUNC_GET);
+    kafs_dlog(2,
+              "%s: ino=%u partial-tail iblo=%" PRIuFAST32 " off=%" PRIuFAST16
+              " cur_blo=%" PRIuFAST32 "\n",
+              __func__, ino_idx, iblooff, off, cur_blo);
+    KAFS_CALL(kafs_ino_iblk_read, ctx, inoent, iblooff, buf);
+    memset(buf + off, 0, blksize - off);
+    KAFS_CALL(kafs_ino_iblk_write, ctx, inoent, iblooff, buf);
+    (void)kafs_ino_ibrk_run(ctx, inoent, iblooff, &cur_blo, KAFS_IBLKREF_FUNC_GET);
+    kafs_dlog(2, "%s: ino=%u partial-tail wrote iblo=%" PRIuFAST32 " new_blo=%" PRIuFAST32 "\n",
+              __func__, ino_idx, iblooff, cur_blo);
+    iblooff++;
+  }
+
+  if (kafs_tailmeta_inode_is_regular_v5(ctx, inoent))
+    kafs_tailmeta_inode_taildesc_set_full_block(ctx, inoent);
+
+  int rc = kafs_truncate_collect_batches(ctx, inoent, iblooff, iblocnt, deferred_free,
+                                         deferred_free_cnt, deferred_free_cap);
+  if (rc != 0)
+    return rc;
+
+  kafs_truncate_release_deferred_refs(ctx, ino_idx, *deferred_free, *deferred_free_cnt);
+  return kafs_tailmeta_normalize_block_layout(ctx, inoent);
+}
+
 static int kafs_truncate(struct kafs_context *ctx, kafs_sinode_t *inoent, kafs_off_t filesize_new)
 {
   uint32_t ino_idx = kafs_ctx_ino_no(ctx, inoent);
@@ -4891,101 +4983,22 @@ static int kafs_truncate(struct kafs_context *ctx, kafs_sinode_t *inoent, kafs_o
   kafs_blksize_t off = (kafs_blksize_t)(filesize_new & (blksize - 1));
 
   if (filesize_orig <= KAFS_INODE_DIRECT_BYTES)
-  {
-    memset((void *)inoent->i_blkreftbl + filesize_new, 0, filesize_orig - filesize_new);
-    kafs_ino_size_set(inoent, filesize_new);
-    if (kafs_tailmeta_inode_is_regular_v5(ctx, inoent))
-      kafs_tailmeta_inode_taildesc_set_inline(ctx, inoent);
-    return KAFS_SUCCESS;
-  }
+    return kafs_truncate_handle_direct_shrink(ctx, inoent, filesize_orig, filesize_new);
 
-  // Indirect -> direct: copy first block data to inode, then release all blocks.
   if (filesize_new <= KAFS_INODE_DIRECT_BYTES)
   {
-    char buf[blksize];
-    KAFS_CALL(kafs_ino_iblk_read, ctx, inoent, 0, buf);
-
-    // Update size first so readers won't access blocks being freed.
-    kafs_ino_size_set(inoent, filesize_new);
-
-    // Release blocks in batches: capture + clear refs under inode lock, dec_ref outside.
-    const kafs_iblkcnt_t TRUNC_BATCH = 64;
-    kafs_iblkcnt_t cur = 0;
-    while (cur < iblocnt)
-    {
-      kafs_iblkcnt_t end = cur + TRUNC_BATCH;
-      if (end > iblocnt)
-        end = iblocnt;
-
-      int rc = kafs_truncate_collect_free_range(ctx, inoent, cur, end, &deferred_free,
-                                                &deferred_free_cnt, &deferred_free_cap);
-      if (rc != 0)
-      {
-        free(deferred_free);
-        return rc;
-      }
-      cur = end;
-    }
-
-    memcpy(inoent->i_blkreftbl, buf, (size_t)filesize_new);
-    if (filesize_new < KAFS_INODE_DIRECT_BYTES)
-      memset((void *)inoent->i_blkreftbl + filesize_new, 0, KAFS_INODE_DIRECT_BYTES - filesize_new);
-    if (kafs_tailmeta_inode_is_regular_v5(ctx, inoent))
-      kafs_tailmeta_inode_taildesc_set_inline(ctx, inoent);
-    kafs_truncate_release_deferred_refs(ctx, ino_idx, deferred_free, deferred_free_cnt);
+    int rc = kafs_truncate_handle_indirect_to_direct(ctx, inoent, ino_idx, filesize_new, iblocnt,
+                                                     &deferred_free, &deferred_free_cnt,
+                                                     &deferred_free_cap, blksize);
     free(deferred_free);
-    return KAFS_SUCCESS;
+    return rc;
   }
 
-  // Shrink within indirect mode: update size first so readers won't access freed blocks.
-  kafs_ino_size_set(inoent, filesize_new);
-
-  if (off > 0)
-  {
-    char buf[blksize];
-    kafs_blkcnt_t cur_blo = KAFS_BLO_NONE;
-    (void)kafs_ino_ibrk_run(ctx, inoent, iblooff, &cur_blo, KAFS_IBLKREF_FUNC_GET);
-    kafs_dlog(2,
-              "%s: ino=%u partial-tail iblo=%" PRIuFAST32 " off=%" PRIuFAST16
-              " cur_blo=%" PRIuFAST32 "\n",
-              __func__, ino_idx, iblooff, off, cur_blo);
-    KAFS_CALL(kafs_ino_iblk_read, ctx, inoent, iblooff, buf);
-    memset(buf + off, 0, blksize - off);
-    KAFS_CALL(kafs_ino_iblk_write, ctx, inoent, iblooff, buf);
-    (void)kafs_ino_ibrk_run(ctx, inoent, iblooff, &cur_blo, KAFS_IBLKREF_FUNC_GET);
-    kafs_dlog(2, "%s: ino=%u partial-tail wrote iblo=%" PRIuFAST32 " new_blo=%" PRIuFAST32 "\n",
-              __func__, ino_idx, iblooff, cur_blo);
-    iblooff++;
-  }
-
-  if (kafs_tailmeta_inode_is_regular_v5(ctx, inoent))
-    kafs_tailmeta_inode_taildesc_set_full_block(ctx, inoent);
-
-  const kafs_iblkcnt_t TRUNC_BATCH = 64;
-  while (iblooff < iblocnt)
-  {
-    kafs_iblkcnt_t end = iblooff + TRUNC_BATCH;
-    if (end > iblocnt)
-      end = iblocnt;
-
-    int rc = kafs_truncate_collect_free_range(ctx, inoent, iblooff, end, &deferred_free,
-                                              &deferred_free_cnt, &deferred_free_cap);
-    if (rc != 0)
-    {
-      free(deferred_free);
-      return rc;
-    }
-    iblooff = end;
-  }
-
-  kafs_truncate_release_deferred_refs(ctx, ino_idx, deferred_free, deferred_free_cnt);
+  int rc = kafs_truncate_handle_indirect_shrink(ctx, inoent, ino_idx, filesize_new, iblooff,
+                                                iblocnt, off, blksize, &deferred_free,
+                                                &deferred_free_cnt, &deferred_free_cap);
   free(deferred_free);
-  {
-    int rc = kafs_tailmeta_normalize_block_layout(ctx, inoent);
-    if (rc != 0)
-      return rc;
-  }
-  return KAFS_SUCCESS;
+  return rc;
 }
 
 __attribute_maybe_unused__ static int kafs_trim(struct kafs_context *ctx, kafs_sinode_t *inoent,

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -9697,6 +9697,81 @@ static int kafs_op_flush(const char *path, struct fuse_file_info *fi)
   return 0;
 }
 
+static uint32_t kafs_fsync_resolve_inode(struct fuse_context *fctx, struct kafs_context *ctx,
+                                         const char *path, struct fuse_file_info *fi)
+{
+  if (fi)
+    return (uint32_t)fi->fh;
+  if (!path || path[0] == '\0')
+    return KAFS_INO_NONE;
+
+  kafs_sinode_t *inoent = NULL;
+  int arc = kafs_access(fctx, ctx, path, fi, F_OK, &inoent);
+  if (arc == 0 && inoent)
+    return (uint32_t)kafs_ctx_ino_no(ctx, inoent);
+  return KAFS_INO_NONE;
+}
+
+static int kafs_fsync_prepare_inode(struct kafs_context *ctx, const char *path, uint32_t ino)
+{
+  kafs_inode_lock(ctx, ino);
+  int nrc = kafs_tailmeta_normalize_block_layout(ctx, kafs_ctx_inode(ctx, ino));
+  kafs_inode_unlock(ctx, ino);
+  if (nrc < 0)
+  {
+    kafs_dlog(2, "%s: exit rc=%d normalize_failed path=%s ino=%" PRIuFAST32 "\n", __func__, nrc,
+              path ? path : "(null)", ino);
+    return nrc;
+  }
+
+  uint32_t saved_mode = KAFS_PENDING_WORKER_PRIO_NORMAL;
+  int saved_nice = 0;
+  int boosted = 0;
+  kafs_pending_worker_begin_boost(ctx, &saved_mode, &saved_nice, &boosted);
+
+  int drc = kafs_pendinglog_drain_inode(ctx, ino);
+  kafs_pending_worker_end_boost(ctx, saved_mode, saved_nice, boosted);
+  if (drc < 0 && drc != -ETIMEDOUT)
+  {
+    kafs_dlog(2, "%s: exit rc=%d drain_failed path=%s ino=%" PRIuFAST32 "\n", __func__, drc,
+              path ? path : "(null)", ino);
+    return drc;
+  }
+  if (drc == -ETIMEDOUT)
+  {
+    kafs_log(KAFS_LOG_WARNING, "%s: pending drain timeout path=%s ino=%" PRIuFAST32 " (continue)\n",
+             __func__, path ? path : "(null)", ino);
+  }
+  return 0;
+}
+
+static int kafs_fsync_use_journal_only(struct kafs_context *ctx, int isdatasync)
+{
+  if (!kafs_journal_is_enabled(ctx))
+    return 0;
+  if (ctx->c_fsync_policy == KAFS_FSYNC_POLICY_JOURNAL_ONLY)
+    return 1;
+  if (ctx->c_fsync_policy != KAFS_FSYNC_POLICY_ADAPTIVE)
+    return 0;
+  return isdatasync || ctx->c_pending_ttl_over_soft || ctx->c_pending_ttl_over_hard;
+}
+
+static int kafs_fsync_backing_sync(struct kafs_context *ctx, const char *path, uint32_t ino,
+                                   int isdatasync)
+{
+  int src = isdatasync ? fdatasync(ctx->c_fd) : fsync(ctx->c_fd);
+  if (src != 0)
+  {
+    int e = errno;
+    kafs_log(KAFS_LOG_WARNING, "%s: %s failed path=%s ino=%" PRIuFAST32 " errno=%d\n", __func__,
+             isdatasync ? "fdatasync" : "fsync", path ? path : "(null)", ino, e);
+    kafs_dlog(2, "%s: exit rc=%d path=%s ino=%" PRIuFAST32 "\n", __func__, -e,
+              path ? path : "(null)", ino);
+    return -e;
+  }
+  return 0;
+}
+
 static int kafs_op_fsync(const char *path, int isdatasync, struct fuse_file_info *fi)
 {
   struct fuse_context *fctx = fuse_get_context();
@@ -9708,73 +9783,16 @@ static int kafs_op_fsync(const char *path, int isdatasync, struct fuse_file_info
     return 0;
   }
 
-  uint32_t ino = KAFS_INO_NONE;
-  if (fi)
-    ino = (uint32_t)fi->fh;
-  else if (path && path[0] != '\0')
-  {
-    kafs_sinode_t *inoent = NULL;
-    int arc = kafs_access(fctx, ctx, path, fi, F_OK, &inoent);
-    if (arc == 0 && inoent)
-      ino = (uint32_t)kafs_ctx_ino_no(ctx, inoent);
-  }
+  uint32_t ino = kafs_fsync_resolve_inode(fctx, ctx, path, fi);
   if (ino != KAFS_INO_NONE)
   {
-    kafs_inode_lock(ctx, ino);
-    int nrc = kafs_tailmeta_normalize_block_layout(ctx, kafs_ctx_inode(ctx, ino));
-    kafs_inode_unlock(ctx, ino);
-    if (nrc < 0)
-    {
-      kafs_dlog(2, "%s: exit rc=%d normalize_failed path=%s ino=%" PRIuFAST32 "\n", __func__, nrc,
-                path ? path : "(null)", ino);
-      return nrc;
-    }
-
-    uint32_t saved_mode = KAFS_PENDING_WORKER_PRIO_NORMAL;
-    int saved_nice = 0;
-    int boosted = 0;
-    // If caller is about to block for pending-drain, temporarily boost worker priority.
-    kafs_pending_worker_begin_boost(ctx, &saved_mode, &saved_nice, &boosted);
-
-    int drc = kafs_pendinglog_drain_inode(ctx, ino);
-    kafs_pending_worker_end_boost(ctx, saved_mode, saved_nice, boosted);
-    if (drc < 0)
-    {
-      if (drc == -ETIMEDOUT)
-      {
-        // Keep fsync path robust under temporary pending-worker congestion.
-        kafs_log(KAFS_LOG_WARNING,
-                 "%s: pending drain timeout path=%s ino=%" PRIuFAST32 " (continue)\n", __func__,
-                 path ? path : "(null)", ino);
-      }
-      else
-      {
-        kafs_dlog(2, "%s: exit rc=%d drain_failed path=%s ino=%" PRIuFAST32 "\n", __func__, drc,
-                  path ? path : "(null)", ino);
-        return drc;
-      }
-    }
+    int prc = kafs_fsync_prepare_inode(ctx, path, ino);
+    if (prc < 0)
+      return prc;
   }
 
-  // Runtime fsync policy:
-  // - full: always issue backing fsync/fdatasync
-  // - journal_only: journal durability barrier only
-  // - adaptive: journal_only for fdatasync and during pending-TTL pressure, else full
   uint32_t policy = ctx->c_fsync_policy;
-  int journal_enabled = kafs_journal_is_enabled(ctx) ? 1 : 0;
-  int journal_only_mode = 0;
-  if (journal_enabled)
-  {
-    if (policy == KAFS_FSYNC_POLICY_JOURNAL_ONLY)
-      journal_only_mode = 1;
-    else if (policy == KAFS_FSYNC_POLICY_ADAPTIVE)
-    {
-      if (isdatasync || ctx->c_pending_ttl_over_soft || ctx->c_pending_ttl_over_hard)
-        journal_only_mode = 1;
-    }
-  }
-
-  if (journal_only_mode)
+  if (kafs_fsync_use_journal_only(ctx, isdatasync))
   {
     kafs_journal_force_flush(ctx);
     kafs_dlog(2,
@@ -9785,16 +9803,9 @@ static int kafs_op_fsync(const char *path, int isdatasync, struct fuse_file_info
   }
 
   kafs_journal_force_flush(ctx);
-  int src = isdatasync ? fdatasync(ctx->c_fd) : fsync(ctx->c_fd);
+  int src = kafs_fsync_backing_sync(ctx, path, ino, isdatasync);
   if (src != 0)
-  {
-    int e = errno;
-    kafs_log(KAFS_LOG_WARNING, "%s: %s failed path=%s ino=%" PRIuFAST32 " errno=%d\n", __func__,
-             isdatasync ? "fdatasync" : "fsync", path ? path : "(null)", ino, e);
-    kafs_dlog(2, "%s: exit rc=%d path=%s ino=%" PRIuFAST32 "\n", __func__, -e,
-              path ? path : "(null)", ino);
-    return -e;
-  }
+    return src;
   kafs_dlog(2, "%s: exit rc=0 path=%s ino=%" PRIuFAST32 "\n", __func__, path ? path : "(null)",
             ino);
   return 0;

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -10137,98 +10137,282 @@ int kafs_core_migrate_image(const char *image_path, int assume_yes)
   return rc;
 }
 
-#ifndef KAFS_NO_MAIN
-int main(int argc, char **argv)
+typedef struct kafs_main_options
 {
-  kafs_crash_diag_install("kafs");
-  // 画像ファイル指定を受け取る: --image <path> または --image=<path>、環境変数 KAFS_IMAGE
-  const char *image_path = getenv("KAFS_IMAGE");
-  kafs_bool_t auto_migrate = KAFS_FALSE;
-  kafs_bool_t migrate_yes = KAFS_FALSE;
-  kafs_bool_t writeback_cache_enabled = KAFS_TRUE;
-  kafs_bool_t writeback_cache_explicit = KAFS_FALSE;
-  kafs_bool_t trim_on_free_enabled = KAFS_FALSE;
-  kafs_bool_t trim_on_free_explicit = KAFS_FALSE;
+  const char *image_path;
+  kafs_bool_t auto_migrate;
+  kafs_bool_t migrate_yes;
+  kafs_bool_t writeback_cache_enabled;
+  kafs_bool_t writeback_cache_explicit;
+  kafs_bool_t trim_on_free_enabled;
+  kafs_bool_t trim_on_free_explicit;
+  kafs_bool_t show_help;
+  kafs_bool_t enable_mt;
   char hotplug_uds_opt[sizeof(((struct sockaddr_un *)0)->sun_path)];
-  hotplug_uds_opt[0] = '\0';
   char hotplug_back_bin_opt[PATH_MAX];
-  hotplug_back_bin_opt[0] = '\0';
+  unsigned mt_cnt_override;
+  int mt_cnt_override_set;
+  int saw_max_threads;
+  uint32_t pending_worker_prio_mode;
+  int pending_worker_nice;
+  uint32_t pending_ttl_soft_ms;
+  uint32_t pending_ttl_hard_ms;
+  uint32_t pending_cap_initial;
+  uint32_t pending_cap_min;
+  uint32_t pending_cap_max;
+  uint32_t bg_dedup_scan_enabled;
+  uint32_t bg_dedup_interval_ms;
+  uint32_t bg_dedup_quiet_interval_ms;
+  uint32_t bg_dedup_pressure_interval_ms;
+  uint32_t bg_dedup_start_used_pct;
+  uint32_t bg_dedup_pressure_used_pct;
+  uint32_t bg_dedup_worker_prio_mode;
+  int bg_dedup_worker_nice;
+  uint32_t fsync_policy;
+} kafs_main_options_t;
+
+static void kafs_main_options_init(kafs_main_options_t *opts)
+{
+  memset(opts, 0, sizeof(*opts));
+  opts->image_path = getenv("KAFS_IMAGE");
+  opts->writeback_cache_enabled = KAFS_TRUE;
+  opts->trim_on_free_enabled = KAFS_FALSE;
+  opts->hotplug_uds_opt[0] = '\0';
+  opts->hotplug_back_bin_opt[0] = '\0';
+  opts->pending_worker_prio_mode = KAFS_PENDING_WORKER_PRIO_NORMAL;
+  opts->pending_worker_nice = 0;
+  opts->pending_ttl_soft_ms = 5000;
+  opts->pending_ttl_hard_ms = 30000;
+  opts->bg_dedup_scan_enabled = 1u;
+  opts->bg_dedup_interval_ms = KAFS_BG_DEDUP_INTERVAL_MS_DEFAULT;
+  opts->bg_dedup_quiet_interval_ms = KAFS_BG_DEDUP_QUIET_INTERVAL_MS_DEFAULT;
+  opts->bg_dedup_pressure_interval_ms = KAFS_BG_DEDUP_PRESSURE_INTERVAL_MS_DEFAULT;
+  opts->bg_dedup_start_used_pct = KAFS_BG_DEDUP_START_USED_PCT_DEFAULT;
+  opts->bg_dedup_pressure_used_pct = KAFS_BG_DEDUP_PRESSURE_USED_PCT_DEFAULT;
+  opts->bg_dedup_worker_prio_mode = KAFS_PENDING_WORKER_PRIO_IDLE;
+  opts->bg_dedup_worker_nice = 19;
+  opts->fsync_policy = KAFS_FSYNC_POLICY_JOURNAL_ONLY;
+}
+
+static void kafs_main_apply_optional_bool_env(const char *value, kafs_bool_t *out)
+{
+  if (!value || !*value || !out)
+    return;
+  if (strcmp(value, "0") == 0 || strcasecmp(value, "false") == 0 || strcasecmp(value, "off") == 0 ||
+      strcasecmp(value, "no") == 0)
+    *out = KAFS_FALSE;
+  else if (strcmp(value, "1") == 0 || strcasecmp(value, "true") == 0 ||
+           strcasecmp(value, "on") == 0 || strcasecmp(value, "yes") == 0)
+    *out = KAFS_TRUE;
+}
+
+static int kafs_main_apply_env_overrides(kafs_main_options_t *opts)
+{
   const char *wbc_env = getenv("KAFS_WRITEBACK_CACHE");
-  if (wbc_env && *wbc_env)
-  {
-    if (strcmp(wbc_env, "0") == 0 || strcasecmp(wbc_env, "false") == 0 ||
-        strcasecmp(wbc_env, "off") == 0 || strcasecmp(wbc_env, "no") == 0)
-      writeback_cache_enabled = KAFS_FALSE;
-    else if (strcmp(wbc_env, "1") == 0 || strcasecmp(wbc_env, "true") == 0 ||
-             strcasecmp(wbc_env, "on") == 0 || strcasecmp(wbc_env, "yes") == 0)
-      writeback_cache_enabled = KAFS_TRUE;
-  }
   const char *trim_env = getenv("KAFS_TRIM_ON_FREE");
-  if (trim_env && *trim_env)
+  const char *pprio = getenv("KAFS_PENDING_WORKER_PRIO");
+  const char *pnice = getenv("KAFS_PENDING_WORKER_NICE");
+  const char *pttl_soft = getenv("KAFS_PENDING_TTL_SOFT_MS");
+  const char *pttl_hard = getenv("KAFS_PENDING_TTL_HARD_MS");
+  const char *pcap_initial = getenv("KAFS_PENDINGLOG_CAP_INITIAL");
+  const char *pcap_min = getenv("KAFS_PENDINGLOG_CAP_MIN");
+  const char *pcap_max = getenv("KAFS_PENDINGLOG_CAP_MAX");
+  const char *bg_scan = getenv("KAFS_BG_DEDUP_SCAN");
+  const char *bg_interval = getenv("KAFS_BG_DEDUP_INTERVAL_MS");
+  const char *bg_quiet_interval = getenv("KAFS_BG_DEDUP_QUIET_INTERVAL_MS");
+  const char *bg_pressure_interval = getenv("KAFS_BG_DEDUP_PRESSURE_INTERVAL_MS");
+  const char *bg_start_pct = getenv("KAFS_BG_DEDUP_START_USED_PCT");
+  const char *bg_pressure_pct = getenv("KAFS_BG_DEDUP_PRESSURE_USED_PCT");
+  const char *bg_prio = getenv("KAFS_BG_DEDUP_WORKER_PRIO");
+  const char *bg_nice = getenv("KAFS_BG_DEDUP_WORKER_NICE");
+  const char *fsp = getenv("KAFS_FSYNC_POLICY");
+  const char *mt = getenv("KAFS_MT");
+
+  kafs_main_apply_optional_bool_env(wbc_env, &opts->writeback_cache_enabled);
+  kafs_main_apply_optional_bool_env(trim_env, &opts->trim_on_free_enabled);
+  opts->enable_mt = (mt && strcmp(mt, "1") == 0) ? KAFS_TRUE : KAFS_FALSE;
+
+  if (pprio && *pprio &&
+      kafs_pending_worker_prio_mode_parse(pprio, &opts->pending_worker_prio_mode) != 0)
   {
-    if (strcmp(trim_env, "0") == 0 || strcasecmp(trim_env, "false") == 0 ||
-        strcasecmp(trim_env, "off") == 0 || strcasecmp(trim_env, "no") == 0)
-      trim_on_free_enabled = KAFS_FALSE;
-    else if (strcmp(trim_env, "1") == 0 || strcasecmp(trim_env, "true") == 0 ||
-             strcasecmp(trim_env, "on") == 0 || strcasecmp(trim_env, "yes") == 0)
-      trim_on_free_enabled = KAFS_TRUE;
+    fprintf(stderr, "invalid KAFS_PENDING_WORKER_PRIO: '%s'\n", pprio);
+    return 2;
   }
-  // argv から --image と --help を取り除き fuse_main へは渡さない
-  char *argv_clean[argc];
-  int argc_clean = 0;
-  kafs_bool_t show_help = KAFS_FALSE;
+
+  if (pnice && *pnice)
+  {
+    char *endp = NULL;
+    long v = strtol(pnice, &endp, 10);
+    if (!endp || *endp != '\0' || v < 0 || v > 19)
+    {
+      fprintf(stderr, "invalid KAFS_PENDING_WORKER_NICE: '%s'\n", pnice);
+      return 2;
+    }
+    opts->pending_worker_nice = (int)v;
+  }
+
+  if (pttl_soft && *pttl_soft &&
+      kafs_parse_u32_range(pttl_soft, 0, 3600000u, &opts->pending_ttl_soft_ms) != 0)
+  {
+    fprintf(stderr, "invalid KAFS_PENDING_TTL_SOFT_MS: '%s'\n", pttl_soft);
+    return 2;
+  }
+  if (pttl_hard && *pttl_hard &&
+      kafs_parse_u32_range(pttl_hard, 0, 3600000u, &opts->pending_ttl_hard_ms) != 0)
+  {
+    fprintf(stderr, "invalid KAFS_PENDING_TTL_HARD_MS: '%s'\n", pttl_hard);
+    return 2;
+  }
+
+  if ((!pcap_initial || !*pcap_initial) && getenv("KAFS_PENDING_CAP_INITIAL"))
+    pcap_initial = getenv("KAFS_PENDING_CAP_INITIAL");
+  if (pcap_initial && *pcap_initial &&
+      kafs_parse_u32_range(pcap_initial, 0, 1000000000u, &opts->pending_cap_initial) != 0)
+  {
+    fprintf(stderr, "invalid KAFS_PENDINGLOG_CAP_INITIAL: '%s'\n", pcap_initial);
+    return 2;
+  }
+
+  if ((!pcap_min || !*pcap_min) && getenv("KAFS_PENDING_CAP_MIN"))
+    pcap_min = getenv("KAFS_PENDING_CAP_MIN");
+  if (pcap_min && *pcap_min &&
+      kafs_parse_u32_range(pcap_min, 0, 1000000000u, &opts->pending_cap_min) != 0)
+  {
+    fprintf(stderr, "invalid KAFS_PENDINGLOG_CAP_MIN: '%s'\n", pcap_min);
+    return 2;
+  }
+
+  if ((!pcap_max || !*pcap_max) && getenv("KAFS_PENDING_CAP_MAX"))
+    pcap_max = getenv("KAFS_PENDING_CAP_MAX");
+  if (pcap_max && *pcap_max &&
+      kafs_parse_u32_range(pcap_max, 0, 1000000000u, &opts->pending_cap_max) != 0)
+  {
+    fprintf(stderr, "invalid KAFS_PENDINGLOG_CAP_MAX: '%s'\n", pcap_max);
+    return 2;
+  }
+
+  if (bg_scan && *bg_scan && kafs_parse_onoff(bg_scan, &opts->bg_dedup_scan_enabled) != 0)
+  {
+    fprintf(stderr, "invalid KAFS_BG_DEDUP_SCAN: '%s'\n", bg_scan);
+    return 2;
+  }
+  if (bg_interval && *bg_interval &&
+      kafs_parse_u32_range(bg_interval, KAFS_BG_DEDUP_INTERVAL_MS_MIN,
+                           KAFS_BG_DEDUP_INTERVAL_MS_MAX, &opts->bg_dedup_interval_ms) != 0)
+  {
+    fprintf(stderr, "invalid KAFS_BG_DEDUP_INTERVAL_MS: '%s'\n", bg_interval);
+    return 2;
+  }
+  if (bg_quiet_interval && *bg_quiet_interval &&
+      kafs_parse_u32_range(bg_quiet_interval, KAFS_BG_DEDUP_INTERVAL_MS_MIN,
+                           KAFS_BG_DEDUP_INTERVAL_MS_MAX, &opts->bg_dedup_quiet_interval_ms) != 0)
+  {
+    fprintf(stderr, "invalid KAFS_BG_DEDUP_QUIET_INTERVAL_MS: '%s'\n", bg_quiet_interval);
+    return 2;
+  }
+  if (bg_pressure_interval && *bg_pressure_interval &&
+      kafs_parse_u32_range(bg_pressure_interval, KAFS_BG_DEDUP_INTERVAL_MS_MIN,
+                           KAFS_BG_DEDUP_INTERVAL_MS_MAX,
+                           &opts->bg_dedup_pressure_interval_ms) != 0)
+  {
+    fprintf(stderr, "invalid KAFS_BG_DEDUP_PRESSURE_INTERVAL_MS: '%s'\n", bg_pressure_interval);
+    return 2;
+  }
+  if (bg_start_pct && *bg_start_pct &&
+      kafs_parse_u32_range(bg_start_pct, 0, 100u, &opts->bg_dedup_start_used_pct) != 0)
+  {
+    fprintf(stderr, "invalid KAFS_BG_DEDUP_START_USED_PCT: '%s'\n", bg_start_pct);
+    return 2;
+  }
+  if (bg_pressure_pct && *bg_pressure_pct &&
+      kafs_parse_u32_range(bg_pressure_pct, 0, 100u, &opts->bg_dedup_pressure_used_pct) != 0)
+  {
+    fprintf(stderr, "invalid KAFS_BG_DEDUP_PRESSURE_USED_PCT: '%s'\n", bg_pressure_pct);
+    return 2;
+  }
+  if (bg_prio && *bg_prio &&
+      kafs_pending_worker_prio_mode_parse(bg_prio, &opts->bg_dedup_worker_prio_mode) != 0)
+  {
+    fprintf(stderr, "invalid KAFS_BG_DEDUP_WORKER_PRIO: '%s'\n", bg_prio);
+    return 2;
+  }
+  if (bg_nice && *bg_nice)
+  {
+    char *endp = NULL;
+    long v = strtol(bg_nice, &endp, 10);
+    if (!endp || *endp != '\0' || v < 0 || v > 19)
+    {
+      fprintf(stderr, "invalid KAFS_BG_DEDUP_WORKER_NICE: '%s'\n", bg_nice);
+      return 2;
+    }
+    opts->bg_dedup_worker_nice = (int)v;
+  }
+  if (fsp && *fsp && kafs_fsync_policy_parse(fsp, &opts->fsync_policy) != 0)
+  {
+    fprintf(stderr, "invalid KAFS_FSYNC_POLICY: '%s'\n", fsp);
+    return 2;
+  }
+
+  return 0;
+}
+
+static int kafs_main_collect_args(int argc, char **argv, const char *prog,
+                                  kafs_main_options_t *opts, char **argv_clean, int *argc_clean)
+{
+  *argc_clean = 0;
   for (int i = 0; i < argc; ++i)
   {
     const char *a = argv[i];
     if (kafs_cli_is_help_arg(a))
     {
-      show_help = KAFS_TRUE;
+      opts->show_help = KAFS_TRUE;
       continue;
     }
     if (strcmp(a, "--migrate") == 0 || strcmp(a, "--migrate-v2") == 0)
     {
-      auto_migrate = KAFS_TRUE;
+      opts->auto_migrate = KAFS_TRUE;
       continue;
     }
     if (strcmp(a, "--yes") == 0)
     {
-      migrate_yes = KAFS_TRUE;
+      opts->migrate_yes = KAFS_TRUE;
       continue;
     }
     if (strcmp(a, "--no-writeback-cache") == 0)
     {
-      writeback_cache_enabled = KAFS_FALSE;
-      writeback_cache_explicit = KAFS_TRUE;
+      opts->writeback_cache_enabled = KAFS_FALSE;
+      opts->writeback_cache_explicit = KAFS_TRUE;
       continue;
     }
     if (strcmp(a, "--writeback-cache") == 0)
     {
-      writeback_cache_enabled = KAFS_TRUE;
-      writeback_cache_explicit = KAFS_TRUE;
+      opts->writeback_cache_enabled = KAFS_TRUE;
+      opts->writeback_cache_explicit = KAFS_TRUE;
       continue;
     }
     if (strcmp(a, "--trim-on-free") == 0)
     {
-      trim_on_free_enabled = KAFS_TRUE;
-      trim_on_free_explicit = KAFS_TRUE;
+      opts->trim_on_free_enabled = KAFS_TRUE;
+      opts->trim_on_free_explicit = KAFS_TRUE;
       continue;
     }
     if (strcmp(a, "--no-trim-on-free") == 0)
     {
-      trim_on_free_enabled = KAFS_FALSE;
-      trim_on_free_explicit = KAFS_TRUE;
+      opts->trim_on_free_enabled = KAFS_FALSE;
+      opts->trim_on_free_explicit = KAFS_TRUE;
       continue;
     }
     if (strcmp(a, "--hotplug") == 0)
     {
-      snprintf(hotplug_uds_opt, sizeof(hotplug_uds_opt), "%s", KAFS_HOTPLUG_UDS_DEFAULT);
+      snprintf(opts->hotplug_uds_opt, sizeof(opts->hotplug_uds_opt), "%s",
+               KAFS_HOTPLUG_UDS_DEFAULT);
       continue;
     }
     if (strncmp(a, "--hotplug=", 10) == 0)
     {
       const char *v = a + 10;
-      if (!*v || snprintf(hotplug_uds_opt, sizeof(hotplug_uds_opt), "%s", v) >=
-                     (int)sizeof(hotplug_uds_opt))
+      if (!*v || snprintf(opts->hotplug_uds_opt, sizeof(opts->hotplug_uds_opt), "%s", v) >=
+                     (int)sizeof(opts->hotplug_uds_opt))
       {
         fprintf(stderr, "invalid --hotplug value\n");
         return 2;
@@ -10240,8 +10424,8 @@ int main(int argc, char **argv)
       if (i + 1 < argc)
       {
         const char *v = argv[++i];
-        if (!*v || snprintf(hotplug_uds_opt, sizeof(hotplug_uds_opt), "%s", v) >=
-                       (int)sizeof(hotplug_uds_opt))
+        if (!*v || snprintf(opts->hotplug_uds_opt, sizeof(opts->hotplug_uds_opt), "%s", v) >=
+                       (int)sizeof(opts->hotplug_uds_opt))
         {
           fprintf(stderr, "invalid --hotplug-uds value\n");
           return 2;
@@ -10249,14 +10433,14 @@ int main(int argc, char **argv)
         continue;
       }
       fprintf(stderr, "--hotplug-uds requires a path argument.\n");
-      usage(argv[0]);
+      usage(prog);
       return 2;
     }
     if (strncmp(a, "--hotplug-uds=", 14) == 0)
     {
       const char *v = a + 14;
-      if (!*v || snprintf(hotplug_uds_opt, sizeof(hotplug_uds_opt), "%s", v) >=
-                     (int)sizeof(hotplug_uds_opt))
+      if (!*v || snprintf(opts->hotplug_uds_opt, sizeof(opts->hotplug_uds_opt), "%s", v) >=
+                     (int)sizeof(opts->hotplug_uds_opt))
       {
         fprintf(stderr, "invalid --hotplug-uds value\n");
         return 2;
@@ -10268,8 +10452,8 @@ int main(int argc, char **argv)
       if (i + 1 < argc)
       {
         const char *v = argv[++i];
-        if (!*v || snprintf(hotplug_back_bin_opt, sizeof(hotplug_back_bin_opt), "%s", v) >=
-                       (int)sizeof(hotplug_back_bin_opt))
+        if (!*v || snprintf(opts->hotplug_back_bin_opt, sizeof(opts->hotplug_back_bin_opt), "%s",
+                            v) >= (int)sizeof(opts->hotplug_back_bin_opt))
         {
           fprintf(stderr, "invalid --hotplug-back-bin value\n");
           return 2;
@@ -10277,14 +10461,14 @@ int main(int argc, char **argv)
         continue;
       }
       fprintf(stderr, "--hotplug-back-bin requires a path argument.\n");
-      usage(argv[0]);
+      usage(prog);
       return 2;
     }
     if (strncmp(a, "--hotplug-back-bin=", 19) == 0)
     {
       const char *v = a + 19;
-      if (!*v || snprintf(hotplug_back_bin_opt, sizeof(hotplug_back_bin_opt), "%s", v) >=
-                     (int)sizeof(hotplug_back_bin_opt))
+      if (!*v || snprintf(opts->hotplug_back_bin_opt, sizeof(opts->hotplug_back_bin_opt), "%s",
+                          v) >= (int)sizeof(opts->hotplug_back_bin_opt))
       {
         fprintf(stderr, "invalid --hotplug-back-bin value\n");
         return 2;
@@ -10295,783 +10479,624 @@ int main(int argc, char **argv)
     {
       if (i + 1 < argc)
       {
-        argv_clean[argc_clean++] = "-o";
-        argv_clean[argc_clean++] = argv[++i];
+        argv_clean[(*argc_clean)++] = "-o";
+        argv_clean[(*argc_clean)++] = argv[++i];
         continue;
       }
       fprintf(stderr, "--option requires an argument.\n");
-      usage(argv[0]);
+      usage(prog);
       return 2;
     }
     if (strncmp(a, "--option=", 9) == 0)
     {
-      argv_clean[argc_clean++] = "-o";
-      argv_clean[argc_clean++] = (char *)(a + 9);
+      argv_clean[(*argc_clean)++] = "-o";
+      argv_clean[(*argc_clean)++] = (char *)(a + 9);
       continue;
     }
     if (strcmp(a, "--image") == 0)
     {
       if (i + 1 < argc)
       {
-        image_path = argv[++i];
+        opts->image_path = argv[++i];
         continue;
       }
-      else
-      {
-        fprintf(stderr, "--image requires a path argument.\n");
-        usage(argv[0]);
-        return 2;
-      }
+      fprintf(stderr, "--image requires a path argument.\n");
+      usage(prog);
+      return 2;
     }
     if (strncmp(a, "--image=", 8) == 0)
     {
-      image_path = a + 8;
+      opts->image_path = a + 8;
       continue;
     }
-    // pass other args through to FUSE
-    argv_clean[argc_clean++] = argv[i];
+    argv_clean[(*argc_clean)++] = argv[i];
   }
-  // mount(8) helper compatibility: allow "kafs <image> <mountpoint> [FUSE options...]"
-  // When invoked via mount -t fuse.kafs, the image path is typically passed as the first argument.
-  if (image_path == NULL && argc_clean >= 3 && argv_clean[1][0] != '-')
-  {
-    image_path = argv_clean[1];
-    for (int i = 1; i + 1 < argc_clean; ++i)
-      argv_clean[i] = argv_clean[i + 1];
-    argc_clean--;
-  }
-  if (show_help)
-  {
-    usage(argv[0]);
-    return 0;
-  }
-  if (image_path == NULL || argc_clean < 2)
-  {
-    usage(argv[0]);
-    return 2;
-  }
+  return 0;
+}
 
-  // Raspi/低リソース前提: 既定は単一スレッド。MT は -o multi_thread[=N] か KAFS_MT=1 で有効化。
-  const char *mt = getenv("KAFS_MT");
-  kafs_bool_t enable_mt = (mt && strcmp(mt, "1") == 0) ? KAFS_TRUE : KAFS_FALSE;
-  unsigned mt_cnt_override = 0;
-  int mt_cnt_override_set = 0;
-  int saw_max_threads = 0;
-  uint32_t pending_worker_prio_mode = KAFS_PENDING_WORKER_PRIO_NORMAL;
-  int pending_worker_nice = 0;
-  uint32_t pending_ttl_soft_ms = 5000;
-  uint32_t pending_ttl_hard_ms = 30000;
-  uint32_t pending_cap_initial = 0;
-  uint32_t pending_cap_min = 0;
-  uint32_t pending_cap_max = 0;
-  uint32_t bg_dedup_scan_enabled = 1u;
-  uint32_t bg_dedup_interval_ms = KAFS_BG_DEDUP_INTERVAL_MS_DEFAULT;
-  uint32_t bg_dedup_quiet_interval_ms = KAFS_BG_DEDUP_QUIET_INTERVAL_MS_DEFAULT;
-  uint32_t bg_dedup_pressure_interval_ms = KAFS_BG_DEDUP_PRESSURE_INTERVAL_MS_DEFAULT;
-  uint32_t bg_dedup_start_used_pct = KAFS_BG_DEDUP_START_USED_PCT_DEFAULT;
-  uint32_t bg_dedup_pressure_used_pct = KAFS_BG_DEDUP_PRESSURE_USED_PCT_DEFAULT;
-  uint32_t bg_dedup_worker_prio_mode = KAFS_PENDING_WORKER_PRIO_IDLE;
-  int bg_dedup_worker_nice = 19;
-  uint32_t fsync_policy = KAFS_FSYNC_POLICY_JOURNAL_ONLY;
+static int kafs_main_filter_mount_options(kafs_main_options_t *opts, char **argv_clean,
+                                          int *argc_clean)
+{
+  char *argv_user[*argc_clean];
+  int argc_user = 0;
+  char *o_owned[*argc_clean];
+  int o_owned_cnt = 0;
 
-  const char *pprio = getenv("KAFS_PENDING_WORKER_PRIO");
-  if (pprio && *pprio)
+  for (int i = 0; i < *argc_clean; ++i)
   {
-    if (kafs_pending_worker_prio_mode_parse(pprio, &pending_worker_prio_mode) != 0)
+    const char *a = argv_clean[i];
+    const char *oval = NULL;
+    int is_compact = 0;
+    if (strcmp(a, "-o") == 0)
     {
-      fprintf(stderr, "invalid KAFS_PENDING_WORKER_PRIO: '%s'\n", pprio);
-      return 2;
-    }
-  }
-  const char *pnice = getenv("KAFS_PENDING_WORKER_NICE");
-  if (pnice && *pnice)
-  {
-    char *endp = NULL;
-    long v = strtol(pnice, &endp, 10);
-    if (!endp || *endp != '\0' || v < 0 || v > 19)
-    {
-      fprintf(stderr, "invalid KAFS_PENDING_WORKER_NICE: '%s'\n", pnice);
-      return 2;
-    }
-    pending_worker_nice = (int)v;
-  }
-
-  const char *pttl_soft = getenv("KAFS_PENDING_TTL_SOFT_MS");
-  if (pttl_soft && *pttl_soft)
-  {
-    if (kafs_parse_u32_range(pttl_soft, 0, 3600000u, &pending_ttl_soft_ms) != 0)
-    {
-      fprintf(stderr, "invalid KAFS_PENDING_TTL_SOFT_MS: '%s'\n", pttl_soft);
-      return 2;
-    }
-  }
-
-  const char *pttl_hard = getenv("KAFS_PENDING_TTL_HARD_MS");
-  if (pttl_hard && *pttl_hard)
-  {
-    if (kafs_parse_u32_range(pttl_hard, 0, 3600000u, &pending_ttl_hard_ms) != 0)
-    {
-      fprintf(stderr, "invalid KAFS_PENDING_TTL_HARD_MS: '%s'\n", pttl_hard);
-      return 2;
-    }
-  }
-
-  const char *pcap_initial = getenv("KAFS_PENDINGLOG_CAP_INITIAL");
-  if (!pcap_initial || !*pcap_initial)
-    pcap_initial = getenv("KAFS_PENDING_CAP_INITIAL");
-  if (pcap_initial && *pcap_initial)
-  {
-    if (kafs_parse_u32_range(pcap_initial, 0, 1000000000u, &pending_cap_initial) != 0)
-    {
-      fprintf(stderr, "invalid KAFS_PENDINGLOG_CAP_INITIAL: '%s'\n", pcap_initial);
-      return 2;
-    }
-  }
-
-  const char *pcap_min = getenv("KAFS_PENDINGLOG_CAP_MIN");
-  if (!pcap_min || !*pcap_min)
-    pcap_min = getenv("KAFS_PENDING_CAP_MIN");
-  if (pcap_min && *pcap_min)
-  {
-    if (kafs_parse_u32_range(pcap_min, 0, 1000000000u, &pending_cap_min) != 0)
-    {
-      fprintf(stderr, "invalid KAFS_PENDINGLOG_CAP_MIN: '%s'\n", pcap_min);
-      return 2;
-    }
-  }
-
-  const char *pcap_max = getenv("KAFS_PENDINGLOG_CAP_MAX");
-  if (!pcap_max || !*pcap_max)
-    pcap_max = getenv("KAFS_PENDING_CAP_MAX");
-  if (pcap_max && *pcap_max)
-  {
-    if (kafs_parse_u32_range(pcap_max, 0, 1000000000u, &pending_cap_max) != 0)
-    {
-      fprintf(stderr, "invalid KAFS_PENDINGLOG_CAP_MAX: '%s'\n", pcap_max);
-      return 2;
-    }
-  }
-
-  const char *bg_scan = getenv("KAFS_BG_DEDUP_SCAN");
-  if (bg_scan && *bg_scan)
-  {
-    if (kafs_parse_onoff(bg_scan, &bg_dedup_scan_enabled) != 0)
-    {
-      fprintf(stderr, "invalid KAFS_BG_DEDUP_SCAN: '%s'\n", bg_scan);
-      return 2;
-    }
-  }
-
-  const char *bg_interval = getenv("KAFS_BG_DEDUP_INTERVAL_MS");
-  if (bg_interval && *bg_interval)
-  {
-    if (kafs_parse_u32_range(bg_interval, KAFS_BG_DEDUP_INTERVAL_MS_MIN,
-                             KAFS_BG_DEDUP_INTERVAL_MS_MAX, &bg_dedup_interval_ms) != 0)
-    {
-      fprintf(stderr, "invalid KAFS_BG_DEDUP_INTERVAL_MS: '%s'\n", bg_interval);
-      return 2;
-    }
-  }
-
-  const char *bg_quiet_interval = getenv("KAFS_BG_DEDUP_QUIET_INTERVAL_MS");
-  if (bg_quiet_interval && *bg_quiet_interval)
-  {
-    if (kafs_parse_u32_range(bg_quiet_interval, KAFS_BG_DEDUP_INTERVAL_MS_MIN,
-                             KAFS_BG_DEDUP_INTERVAL_MS_MAX, &bg_dedup_quiet_interval_ms) != 0)
-    {
-      fprintf(stderr, "invalid KAFS_BG_DEDUP_QUIET_INTERVAL_MS: '%s'\n", bg_quiet_interval);
-      return 2;
-    }
-  }
-
-  const char *bg_pressure_interval = getenv("KAFS_BG_DEDUP_PRESSURE_INTERVAL_MS");
-  if (bg_pressure_interval && *bg_pressure_interval)
-  {
-    if (kafs_parse_u32_range(bg_pressure_interval, KAFS_BG_DEDUP_INTERVAL_MS_MIN,
-                             KAFS_BG_DEDUP_INTERVAL_MS_MAX, &bg_dedup_pressure_interval_ms) != 0)
-    {
-      fprintf(stderr, "invalid KAFS_BG_DEDUP_PRESSURE_INTERVAL_MS: '%s'\n", bg_pressure_interval);
-      return 2;
-    }
-  }
-
-  const char *bg_start_pct = getenv("KAFS_BG_DEDUP_START_USED_PCT");
-  if (bg_start_pct && *bg_start_pct)
-  {
-    if (kafs_parse_u32_range(bg_start_pct, 0, 100u, &bg_dedup_start_used_pct) != 0)
-    {
-      fprintf(stderr, "invalid KAFS_BG_DEDUP_START_USED_PCT: '%s'\n", bg_start_pct);
-      return 2;
-    }
-  }
-
-  const char *bg_pressure_pct = getenv("KAFS_BG_DEDUP_PRESSURE_USED_PCT");
-  if (bg_pressure_pct && *bg_pressure_pct)
-  {
-    if (kafs_parse_u32_range(bg_pressure_pct, 0, 100u, &bg_dedup_pressure_used_pct) != 0)
-    {
-      fprintf(stderr, "invalid KAFS_BG_DEDUP_PRESSURE_USED_PCT: '%s'\n", bg_pressure_pct);
-      return 2;
-    }
-  }
-
-  const char *bg_prio = getenv("KAFS_BG_DEDUP_WORKER_PRIO");
-  if (bg_prio && *bg_prio)
-  {
-    if (kafs_pending_worker_prio_mode_parse(bg_prio, &bg_dedup_worker_prio_mode) != 0)
-    {
-      fprintf(stderr, "invalid KAFS_BG_DEDUP_WORKER_PRIO: '%s'\n", bg_prio);
-      return 2;
-    }
-  }
-
-  const char *bg_nice = getenv("KAFS_BG_DEDUP_WORKER_NICE");
-  if (bg_nice && *bg_nice)
-  {
-    char *endp = NULL;
-    long v = strtol(bg_nice, &endp, 10);
-    if (!endp || *endp != '\0' || v < 0 || v > 19)
-    {
-      fprintf(stderr, "invalid KAFS_BG_DEDUP_WORKER_NICE: '%s'\n", bg_nice);
-      return 2;
-    }
-    bg_dedup_worker_nice = (int)v;
-  }
-
-  if (pending_ttl_soft_ms > 0 && pending_ttl_hard_ms > 0 &&
-      pending_ttl_hard_ms < pending_ttl_soft_ms)
-  {
-    fprintf(stderr, "invalid pending TTL env: hard must be >= soft\n");
-    return 2;
-  }
-
-  const char *fsp = getenv("KAFS_FSYNC_POLICY");
-  if (fsp && *fsp)
-  {
-    if (kafs_fsync_policy_parse(fsp, &fsync_policy) != 0)
-    {
-      fprintf(stderr, "invalid KAFS_FSYNC_POLICY: '%s'\n", fsp);
-      return 2;
-    }
-  }
-
-  // Custom -o option: multi_thread[=N] (alias: multi-thread, multithread).
-  // Strip it from argv before passing to libfuse, and translate to max_threads=.
-  {
-    char *argv_user[argc_clean];
-    int argc_user = 0;
-    char *o_owned[argc_clean];
-    int o_owned_cnt = 0;
-
-    for (int i = 0; i < argc_clean; ++i)
-    {
-      const char *a = argv_clean[i];
-      const char *oval = NULL;
-      int is_compact = 0;
-      if (strcmp(a, "-o") == 0)
+      if (i + 1 < *argc_clean)
+        oval = argv_clean[++i];
+      else
       {
-        if (i + 1 < argc_clean)
-          oval = argv_clean[++i];
-        else
+        argv_user[argc_user++] = argv_clean[i];
+        continue;
+      }
+    }
+    else if (strncmp(a, "-o", 2) == 0 && a[2] != '\0')
+    {
+      oval = a + 2;
+      is_compact = 1;
+    }
+
+    if (!oval)
+    {
+      argv_user[argc_user++] = argv_clean[i];
+      continue;
+    }
+
+    char *dup = strdup(oval);
+    if (!dup)
+    {
+      perror("strdup");
+      return 2;
+    }
+    char filtered[strlen(oval) + 1];
+    filtered[0] = '\0';
+    size_t used = 0;
+    int want_mt = 0;
+
+    char *saveptr = NULL;
+    for (char *tok = strtok_r(dup, ",", &saveptr); tok; tok = strtok_r(NULL, ",", &saveptr))
+    {
+      if (strncmp(tok, "max_threads=", 12) == 0 || strcmp(tok, "max_threads") == 0)
+        opts->saw_max_threads = 1;
+
+      if (strcmp(tok, "writeback_cache") == 0)
+      {
+        opts->writeback_cache_enabled = KAFS_TRUE;
+        opts->writeback_cache_explicit = KAFS_TRUE;
+        continue;
+      }
+      if (strcmp(tok, "no_writeback_cache") == 0)
+      {
+        opts->writeback_cache_enabled = KAFS_FALSE;
+        opts->writeback_cache_explicit = KAFS_TRUE;
+        continue;
+      }
+      if (strcmp(tok, "trim_on_free") == 0 || strcmp(tok, "trim-on-free") == 0)
+      {
+        opts->trim_on_free_enabled = KAFS_TRUE;
+        opts->trim_on_free_explicit = KAFS_TRUE;
+        continue;
+      }
+      if (strcmp(tok, "no_trim_on_free") == 0 || strcmp(tok, "no-trim-on-free") == 0)
+      {
+        opts->trim_on_free_enabled = KAFS_FALSE;
+        opts->trim_on_free_explicit = KAFS_TRUE;
+        continue;
+      }
+      if (strcmp(tok, "hotplug") == 0)
+      {
+        snprintf(opts->hotplug_uds_opt, sizeof(opts->hotplug_uds_opt), "%s",
+                 KAFS_HOTPLUG_UDS_DEFAULT);
+        continue;
+      }
+
+      const char *hotplug_uds_v = NULL;
+      if (strncmp(tok, "hotplug=", 8) == 0)
+        hotplug_uds_v = tok + 8;
+      else if (strncmp(tok, "hotplug_uds=", 12) == 0)
+        hotplug_uds_v = tok + 12;
+      else if (strncmp(tok, "hotplug-uds=", 12) == 0)
+        hotplug_uds_v = tok + 12;
+      if (hotplug_uds_v)
+      {
+        if (!*hotplug_uds_v || snprintf(opts->hotplug_uds_opt, sizeof(opts->hotplug_uds_opt), "%s",
+                                        hotplug_uds_v) >= (int)sizeof(opts->hotplug_uds_opt))
         {
-          argv_user[argc_user++] = argv_clean[i];
-          continue;
+          fprintf(stderr, "invalid -o hotplug uds path: '%s'\n", hotplug_uds_v);
+          free(dup);
+          return 2;
         }
-      }
-      else if (strncmp(a, "-o", 2) == 0 && a[2] != '\0')
-      {
-        oval = a + 2;
-        is_compact = 1;
+        continue;
       }
 
-      if (oval)
+      const char *hotplug_back_bin_v = NULL;
+      if (strncmp(tok, "hotplug_back_bin=", 17) == 0)
+        hotplug_back_bin_v = tok + 17;
+      else if (strncmp(tok, "hotplug-back-bin=", 17) == 0)
+        hotplug_back_bin_v = tok + 17;
+      if (hotplug_back_bin_v)
       {
-        char *dup = strdup(oval);
-        if (!dup)
+        if (!*hotplug_back_bin_v ||
+            snprintf(opts->hotplug_back_bin_opt, sizeof(opts->hotplug_back_bin_opt), "%s",
+                     hotplug_back_bin_v) >= (int)sizeof(opts->hotplug_back_bin_opt))
+        {
+          fprintf(stderr, "invalid -o hotplug_back_bin path: '%s'\n", hotplug_back_bin_v);
+          free(dup);
+          return 2;
+        }
+        continue;
+      }
+
+      if (strcmp(tok, "multi_thread") == 0 || strcmp(tok, "multi-thread") == 0 ||
+          strcmp(tok, "multithread") == 0)
+      {
+        want_mt = 1;
+        continue;
+      }
+
+      const char *vstr = NULL;
+      if (strncmp(tok, "multi_thread=", 13) == 0)
+        vstr = tok + 13;
+      else if (strncmp(tok, "multi-thread=", 13) == 0)
+        vstr = tok + 13;
+      else if (strncmp(tok, "multithread=", 12) == 0)
+        vstr = tok + 12;
+      if (vstr)
+      {
+        char *endp = NULL;
+        unsigned long v = strtoul(vstr, &endp, 10);
+        if (!endp || *endp != '\0')
+        {
+          fprintf(stderr, "invalid -o multi_thread=N: '%s'\n", vstr);
+          free(dup);
+          return 2;
+        }
+        if (v < 1)
+          v = 1;
+        if (v > 100000)
+          v = 100000;
+        opts->mt_cnt_override = (unsigned)v;
+        opts->mt_cnt_override_set = 1;
+        want_mt = 1;
+        continue;
+      }
+
+      const char *prio_str = NULL;
+      if (strncmp(tok, "pending_worker_prio=", 20) == 0)
+        prio_str = tok + 20;
+      else if (strncmp(tok, "dedup_worker_prio=", 18) == 0)
+        prio_str = tok + 18;
+      if (prio_str)
+      {
+        if (kafs_pending_worker_prio_mode_parse(prio_str, &opts->pending_worker_prio_mode) != 0)
+        {
+          fprintf(stderr, "invalid -o pending_worker_prio: '%s'\n", prio_str);
+          free(dup);
+          return 2;
+        }
+        continue;
+      }
+
+      const char *nice_str = NULL;
+      if (strncmp(tok, "pending_worker_nice=", 20) == 0)
+        nice_str = tok + 20;
+      else if (strncmp(tok, "dedup_worker_nice=", 18) == 0)
+        nice_str = tok + 18;
+      if (nice_str)
+      {
+        char *endp = NULL;
+        long v = strtol(nice_str, &endp, 10);
+        if (!endp || *endp != '\0' || v < 0 || v > 19)
+        {
+          fprintf(stderr, "invalid -o pending_worker_nice: '%s'\n", nice_str);
+          free(dup);
+          return 2;
+        }
+        opts->pending_worker_nice = (int)v;
+        continue;
+      }
+
+      const char *ttl_soft_str = NULL;
+      if (strncmp(tok, "pending_ttl_soft_ms=", 20) == 0)
+        ttl_soft_str = tok + 20;
+      if (ttl_soft_str)
+      {
+        if (kafs_parse_u32_range(ttl_soft_str, 0, 3600000u, &opts->pending_ttl_soft_ms) != 0)
+        {
+          fprintf(stderr, "invalid -o pending_ttl_soft_ms: '%s'\n", ttl_soft_str);
+          free(dup);
+          return 2;
+        }
+        continue;
+      }
+
+      const char *ttl_hard_str = NULL;
+      if (strncmp(tok, "pending_ttl_hard_ms=", 20) == 0)
+        ttl_hard_str = tok + 20;
+      if (ttl_hard_str)
+      {
+        if (kafs_parse_u32_range(ttl_hard_str, 0, 3600000u, &opts->pending_ttl_hard_ms) != 0)
+        {
+          fprintf(stderr, "invalid -o pending_ttl_hard_ms: '%s'\n", ttl_hard_str);
+          free(dup);
+          return 2;
+        }
+        continue;
+      }
+
+      const char *pcap_initial_str = NULL;
+      if (strncmp(tok, "pendinglog_cap_initial=", 23) == 0)
+        pcap_initial_str = tok + 23;
+      else if (strncmp(tok, "pending_cap_initial=", 20) == 0)
+        pcap_initial_str = tok + 20;
+      if (pcap_initial_str)
+      {
+        if (kafs_parse_u32_range(pcap_initial_str, 0, 1000000000u, &opts->pending_cap_initial) != 0)
+        {
+          fprintf(stderr, "invalid -o pendinglog_cap_initial: '%s'\n", pcap_initial_str);
+          free(dup);
+          return 2;
+        }
+        continue;
+      }
+
+      const char *pcap_min_str = NULL;
+      if (strncmp(tok, "pendinglog_cap_min=", 19) == 0)
+        pcap_min_str = tok + 19;
+      else if (strncmp(tok, "pending_cap_min=", 16) == 0)
+        pcap_min_str = tok + 16;
+      if (pcap_min_str)
+      {
+        if (kafs_parse_u32_range(pcap_min_str, 0, 1000000000u, &opts->pending_cap_min) != 0)
+        {
+          fprintf(stderr, "invalid -o pendinglog_cap_min: '%s'\n", pcap_min_str);
+          free(dup);
+          return 2;
+        }
+        continue;
+      }
+
+      const char *pcap_max_str = NULL;
+      if (strncmp(tok, "pendinglog_cap_max=", 19) == 0)
+        pcap_max_str = tok + 19;
+      else if (strncmp(tok, "pending_cap_max=", 16) == 0)
+        pcap_max_str = tok + 16;
+      if (pcap_max_str)
+      {
+        if (kafs_parse_u32_range(pcap_max_str, 0, 1000000000u, &opts->pending_cap_max) != 0)
+        {
+          fprintf(stderr, "invalid -o pendinglog_cap_max: '%s'\n", pcap_max_str);
+          free(dup);
+          return 2;
+        }
+        continue;
+      }
+
+      const char *fsp_str = NULL;
+      if (strncmp(tok, "fsync_policy=", 13) == 0)
+        fsp_str = tok + 13;
+      if (fsp_str)
+      {
+        if (kafs_fsync_policy_parse(fsp_str, &opts->fsync_policy) != 0)
+        {
+          fprintf(stderr, "invalid -o fsync_policy: '%s'\n", fsp_str);
+          free(dup);
+          return 2;
+        }
+        continue;
+      }
+
+      if (strcmp(tok, "bg_dedup_scan") == 0 || strcmp(tok, "bg_dedup_scan=on") == 0 ||
+          strcmp(tok, "dedup_scan") == 0 || strcmp(tok, "dedup_scan=on") == 0)
+      {
+        opts->bg_dedup_scan_enabled = 1u;
+        continue;
+      }
+      if (strcmp(tok, "no_bg_dedup_scan") == 0 || strcmp(tok, "bg_dedup_scan=off") == 0 ||
+          strcmp(tok, "no_dedup_scan") == 0 || strcmp(tok, "dedup_scan=off") == 0)
+      {
+        opts->bg_dedup_scan_enabled = 0u;
+        continue;
+      }
+
+      const char *bg_scan_str = NULL;
+      if (strncmp(tok, "bg_dedup_scan=", 14) == 0)
+        bg_scan_str = tok + 14;
+      else if (strncmp(tok, "dedup_scan=", 11) == 0)
+        bg_scan_str = tok + 11;
+      if (bg_scan_str)
+      {
+        if (kafs_parse_onoff(bg_scan_str, &opts->bg_dedup_scan_enabled) != 0)
+        {
+          fprintf(stderr, "invalid -o dedup_scan/bg_dedup_scan: '%s'\n", bg_scan_str);
+          free(dup);
+          return 2;
+        }
+        continue;
+      }
+
+      const char *bg_interval_str = NULL;
+      if (strncmp(tok, "bg_dedup_interval_ms=", 21) == 0)
+        bg_interval_str = tok + 21;
+      else if (strncmp(tok, "dedup_interval_ms=", 18) == 0)
+        bg_interval_str = tok + 18;
+      if (bg_interval_str)
+      {
+        if (kafs_parse_u32_range(bg_interval_str, KAFS_BG_DEDUP_INTERVAL_MS_MIN,
+                                 KAFS_BG_DEDUP_INTERVAL_MS_MAX, &opts->bg_dedup_interval_ms) != 0)
+        {
+          fprintf(stderr, "invalid -o dedup_interval_ms/bg_dedup_interval_ms: '%s'\n",
+                  bg_interval_str);
+          free(dup);
+          return 2;
+        }
+        continue;
+      }
+
+      const char *bg_quiet_interval_str = NULL;
+      if (strncmp(tok, "bg_dedup_quiet_interval_ms=", 27) == 0)
+        bg_quiet_interval_str = tok + 27;
+      else if (strncmp(tok, "dedup_quiet_interval_ms=", 24) == 0)
+        bg_quiet_interval_str = tok + 24;
+      if (bg_quiet_interval_str)
+      {
+        if (kafs_parse_u32_range(bg_quiet_interval_str, KAFS_BG_DEDUP_INTERVAL_MS_MIN,
+                                 KAFS_BG_DEDUP_INTERVAL_MS_MAX,
+                                 &opts->bg_dedup_quiet_interval_ms) != 0)
+        {
+          fprintf(stderr, "invalid -o dedup_quiet_interval_ms/bg_dedup_quiet_interval_ms: '%s'\n",
+                  bg_quiet_interval_str);
+          free(dup);
+          return 2;
+        }
+        continue;
+      }
+
+      const char *bg_pressure_interval_str = NULL;
+      if (strncmp(tok, "bg_dedup_pressure_interval_ms=", 30) == 0)
+        bg_pressure_interval_str = tok + 30;
+      else if (strncmp(tok, "dedup_pressure_interval_ms=", 27) == 0)
+        bg_pressure_interval_str = tok + 27;
+      if (bg_pressure_interval_str)
+      {
+        if (kafs_parse_u32_range(bg_pressure_interval_str, KAFS_BG_DEDUP_INTERVAL_MS_MIN,
+                                 KAFS_BG_DEDUP_INTERVAL_MS_MAX,
+                                 &opts->bg_dedup_pressure_interval_ms) != 0)
+        {
+          fprintf(stderr,
+                  "invalid -o dedup_pressure_interval_ms/bg_dedup_pressure_interval_ms: '%s'\n",
+                  bg_pressure_interval_str);
+          free(dup);
+          return 2;
+        }
+        continue;
+      }
+
+      const char *bg_start_pct_str = NULL;
+      if (strncmp(tok, "bg_dedup_start_used_pct=", 24) == 0)
+        bg_start_pct_str = tok + 24;
+      else if (strncmp(tok, "dedup_start_used_pct=", 21) == 0)
+        bg_start_pct_str = tok + 21;
+      if (bg_start_pct_str)
+      {
+        if (kafs_parse_u32_range(bg_start_pct_str, 0, 100u, &opts->bg_dedup_start_used_pct) != 0)
+        {
+          fprintf(stderr, "invalid -o dedup_start_used_pct/bg_dedup_start_used_pct: '%s'\n",
+                  bg_start_pct_str);
+          free(dup);
+          return 2;
+        }
+        continue;
+      }
+
+      const char *bg_pressure_pct_str = NULL;
+      if (strncmp(tok, "bg_dedup_pressure_used_pct=", 27) == 0)
+        bg_pressure_pct_str = tok + 27;
+      else if (strncmp(tok, "dedup_pressure_used_pct=", 24) == 0)
+        bg_pressure_pct_str = tok + 24;
+      if (bg_pressure_pct_str)
+      {
+        if (kafs_parse_u32_range(bg_pressure_pct_str, 0, 100u, &opts->bg_dedup_pressure_used_pct) !=
+            0)
+        {
+          fprintf(stderr, "invalid -o dedup_pressure_used_pct/bg_dedup_pressure_used_pct: '%s'\n",
+                  bg_pressure_pct_str);
+          free(dup);
+          return 2;
+        }
+        continue;
+      }
+
+      const char *bg_prio_str = NULL;
+      if (strncmp(tok, "bg_dedup_worker_prio=", 21) == 0)
+        bg_prio_str = tok + 21;
+      else if (strncmp(tok, "dedup_scan_worker_prio=", 23) == 0)
+        bg_prio_str = tok + 23;
+      if (bg_prio_str)
+      {
+        if (kafs_pending_worker_prio_mode_parse(bg_prio_str, &opts->bg_dedup_worker_prio_mode) != 0)
+        {
+          fprintf(stderr, "invalid -o bg_dedup_worker_prio/dedup_scan_worker_prio: '%s'\n",
+                  bg_prio_str);
+          free(dup);
+          return 2;
+        }
+        continue;
+      }
+
+      const char *bg_nice_str = NULL;
+      if (strncmp(tok, "bg_dedup_worker_nice=", 21) == 0)
+        bg_nice_str = tok + 21;
+      else if (strncmp(tok, "dedup_scan_worker_nice=", 23) == 0)
+        bg_nice_str = tok + 23;
+      if (bg_nice_str)
+      {
+        char *endp = NULL;
+        long v = strtol(bg_nice_str, &endp, 10);
+        if (!endp || *endp != '\0' || v < 0 || v > 19)
+        {
+          fprintf(stderr, "invalid -o bg_dedup_worker_nice/dedup_scan_worker_nice: '%s'\n",
+                  bg_nice_str);
+          free(dup);
+          return 2;
+        }
+        opts->bg_dedup_worker_nice = (int)v;
+        continue;
+      }
+
+      size_t tlen = strlen(tok);
+      size_t need = tlen + (used ? 1 : 0);
+      if (need)
+      {
+        if (used)
+          filtered[used++] = ',';
+        memcpy(filtered + used, tok, tlen);
+        used += tlen;
+        filtered[used] = '\0';
+      }
+    }
+
+    free(dup);
+    if (want_mt)
+      opts->enable_mt = KAFS_TRUE;
+
+    if (filtered[0] != '\0')
+    {
+      char *kept = NULL;
+      if (is_compact)
+      {
+        kept = (char *)malloc(strlen(filtered) + 3);
+        if (!kept)
+        {
+          perror("malloc");
+          return 2;
+        }
+        kept[0] = '-';
+        kept[1] = 'o';
+        strcpy(kept + 2, filtered);
+        argv_user[argc_user++] = kept;
+      }
+      else
+      {
+        kept = strdup(filtered);
+        if (!kept)
         {
           perror("strdup");
           return 2;
         }
-        char filtered[strlen(oval) + 1];
-        filtered[0] = '\0';
-        size_t used = 0;
-        int want_mt = 0;
-
-        char *saveptr = NULL;
-        for (char *tok = strtok_r(dup, ",", &saveptr); tok; tok = strtok_r(NULL, ",", &saveptr))
-        {
-          if (strncmp(tok, "max_threads=", 12) == 0 || strcmp(tok, "max_threads") == 0)
-            saw_max_threads = 1;
-
-          if (strcmp(tok, "writeback_cache") == 0)
-          {
-            writeback_cache_enabled = KAFS_TRUE;
-            writeback_cache_explicit = KAFS_TRUE;
-            continue;
-          }
-          if (strcmp(tok, "no_writeback_cache") == 0)
-          {
-            writeback_cache_enabled = KAFS_FALSE;
-            writeback_cache_explicit = KAFS_TRUE;
-            continue;
-          }
-          if (strcmp(tok, "trim_on_free") == 0 || strcmp(tok, "trim-on-free") == 0)
-          {
-            trim_on_free_enabled = KAFS_TRUE;
-            trim_on_free_explicit = KAFS_TRUE;
-            continue;
-          }
-          if (strcmp(tok, "no_trim_on_free") == 0 || strcmp(tok, "no-trim-on-free") == 0)
-          {
-            trim_on_free_enabled = KAFS_FALSE;
-            trim_on_free_explicit = KAFS_TRUE;
-            continue;
-          }
-
-          if (strcmp(tok, "hotplug") == 0)
-          {
-            snprintf(hotplug_uds_opt, sizeof(hotplug_uds_opt), "%s", KAFS_HOTPLUG_UDS_DEFAULT);
-            continue;
-          }
-
-          const char *hotplug_uds_v = NULL;
-          if (strncmp(tok, "hotplug=", 8) == 0)
-            hotplug_uds_v = tok + 8;
-          else if (strncmp(tok, "hotplug_uds=", 12) == 0)
-            hotplug_uds_v = tok + 12;
-          else if (strncmp(tok, "hotplug-uds=", 12) == 0)
-            hotplug_uds_v = tok + 12;
-          if (hotplug_uds_v)
-          {
-            if (!*hotplug_uds_v || snprintf(hotplug_uds_opt, sizeof(hotplug_uds_opt), "%s",
-                                            hotplug_uds_v) >= (int)sizeof(hotplug_uds_opt))
-            {
-              fprintf(stderr, "invalid -o hotplug uds path: '%s'\n", hotplug_uds_v);
-              free(dup);
-              return 2;
-            }
-            continue;
-          }
-
-          const char *hotplug_back_bin_v = NULL;
-          if (strncmp(tok, "hotplug_back_bin=", 17) == 0)
-            hotplug_back_bin_v = tok + 17;
-          else if (strncmp(tok, "hotplug-back-bin=", 17) == 0)
-            hotplug_back_bin_v = tok + 17;
-          if (hotplug_back_bin_v)
-          {
-            if (!*hotplug_back_bin_v ||
-                snprintf(hotplug_back_bin_opt, sizeof(hotplug_back_bin_opt), "%s",
-                         hotplug_back_bin_v) >= (int)sizeof(hotplug_back_bin_opt))
-            {
-              fprintf(stderr, "invalid -o hotplug_back_bin path: '%s'\n", hotplug_back_bin_v);
-              free(dup);
-              return 2;
-            }
-            continue;
-          }
-
-          if (strcmp(tok, "multi_thread") == 0 || strcmp(tok, "multi-thread") == 0 ||
-              strcmp(tok, "multithread") == 0)
-          {
-            want_mt = 1;
-            continue;
-          }
-
-          const char *vstr = NULL;
-          if (strncmp(tok, "multi_thread=", 13) == 0)
-            vstr = tok + 13;
-          else if (strncmp(tok, "multi-thread=", 13) == 0)
-            vstr = tok + 13;
-          else if (strncmp(tok, "multithread=", 12) == 0)
-            vstr = tok + 12;
-
-          if (vstr)
-          {
-            char *endp = NULL;
-            unsigned long v = strtoul(vstr, &endp, 10);
-            if (!endp || *endp != '\0')
-            {
-              fprintf(stderr, "invalid -o multi_thread=N: '%s'\n", vstr);
-              free(dup);
-              return 2;
-            }
-            if (v < 1)
-              v = 1;
-            if (v > 100000)
-              v = 100000;
-            mt_cnt_override = (unsigned)v;
-            mt_cnt_override_set = 1;
-            want_mt = 1;
-            continue;
-          }
-
-          const char *prio_str = NULL;
-          if (strncmp(tok, "pending_worker_prio=", 20) == 0)
-            prio_str = tok + 20;
-          else if (strncmp(tok, "dedup_worker_prio=", 18) == 0)
-            prio_str = tok + 18;
-          if (prio_str)
-          {
-            if (kafs_pending_worker_prio_mode_parse(prio_str, &pending_worker_prio_mode) != 0)
-            {
-              fprintf(stderr, "invalid -o pending_worker_prio: '%s'\n", prio_str);
-              free(dup);
-              return 2;
-            }
-            continue;
-          }
-
-          const char *nice_str = NULL;
-          if (strncmp(tok, "pending_worker_nice=", 20) == 0)
-            nice_str = tok + 20;
-          else if (strncmp(tok, "dedup_worker_nice=", 18) == 0)
-            nice_str = tok + 18;
-          if (nice_str)
-          {
-            char *endp = NULL;
-            long v = strtol(nice_str, &endp, 10);
-            if (!endp || *endp != '\0' || v < 0 || v > 19)
-            {
-              fprintf(stderr, "invalid -o pending_worker_nice: '%s'\n", nice_str);
-              free(dup);
-              return 2;
-            }
-            pending_worker_nice = (int)v;
-            continue;
-          }
-
-          const char *ttl_soft_str = NULL;
-          if (strncmp(tok, "pending_ttl_soft_ms=", 20) == 0)
-            ttl_soft_str = tok + 20;
-          if (ttl_soft_str)
-          {
-            if (kafs_parse_u32_range(ttl_soft_str, 0, 3600000u, &pending_ttl_soft_ms) != 0)
-            {
-              fprintf(stderr, "invalid -o pending_ttl_soft_ms: '%s'\n", ttl_soft_str);
-              free(dup);
-              return 2;
-            }
-            continue;
-          }
-
-          const char *ttl_hard_str = NULL;
-          if (strncmp(tok, "pending_ttl_hard_ms=", 20) == 0)
-            ttl_hard_str = tok + 20;
-          if (ttl_hard_str)
-          {
-            if (kafs_parse_u32_range(ttl_hard_str, 0, 3600000u, &pending_ttl_hard_ms) != 0)
-            {
-              fprintf(stderr, "invalid -o pending_ttl_hard_ms: '%s'\n", ttl_hard_str);
-              free(dup);
-              return 2;
-            }
-            continue;
-          }
-
-          const char *pcap_initial_str = NULL;
-          if (strncmp(tok, "pendinglog_cap_initial=", 23) == 0)
-            pcap_initial_str = tok + 23;
-          else if (strncmp(tok, "pending_cap_initial=", 20) == 0)
-            pcap_initial_str = tok + 20;
-          if (pcap_initial_str)
-          {
-            if (kafs_parse_u32_range(pcap_initial_str, 0, 1000000000u, &pending_cap_initial) != 0)
-            {
-              fprintf(stderr, "invalid -o pendinglog_cap_initial: '%s'\n", pcap_initial_str);
-              free(dup);
-              return 2;
-            }
-            continue;
-          }
-
-          const char *pcap_min_str = NULL;
-          if (strncmp(tok, "pendinglog_cap_min=", 19) == 0)
-            pcap_min_str = tok + 19;
-          else if (strncmp(tok, "pending_cap_min=", 16) == 0)
-            pcap_min_str = tok + 16;
-          if (pcap_min_str)
-          {
-            if (kafs_parse_u32_range(pcap_min_str, 0, 1000000000u, &pending_cap_min) != 0)
-            {
-              fprintf(stderr, "invalid -o pendinglog_cap_min: '%s'\n", pcap_min_str);
-              free(dup);
-              return 2;
-            }
-            continue;
-          }
-
-          const char *pcap_max_str = NULL;
-          if (strncmp(tok, "pendinglog_cap_max=", 19) == 0)
-            pcap_max_str = tok + 19;
-          else if (strncmp(tok, "pending_cap_max=", 16) == 0)
-            pcap_max_str = tok + 16;
-          if (pcap_max_str)
-          {
-            if (kafs_parse_u32_range(pcap_max_str, 0, 1000000000u, &pending_cap_max) != 0)
-            {
-              fprintf(stderr, "invalid -o pendinglog_cap_max: '%s'\n", pcap_max_str);
-              free(dup);
-              return 2;
-            }
-            continue;
-          }
-
-          const char *fsp_str = NULL;
-          if (strncmp(tok, "fsync_policy=", 13) == 0)
-            fsp_str = tok + 13;
-          if (fsp_str)
-          {
-            if (kafs_fsync_policy_parse(fsp_str, &fsync_policy) != 0)
-            {
-              fprintf(stderr, "invalid -o fsync_policy: '%s'\n", fsp_str);
-              free(dup);
-              return 2;
-            }
-            continue;
-          }
-
-          if (strcmp(tok, "bg_dedup_scan") == 0 || strcmp(tok, "bg_dedup_scan=on") == 0 ||
-              strcmp(tok, "dedup_scan") == 0 || strcmp(tok, "dedup_scan=on") == 0)
-          {
-            bg_dedup_scan_enabled = 1u;
-            continue;
-          }
-          if (strcmp(tok, "no_bg_dedup_scan") == 0 || strcmp(tok, "bg_dedup_scan=off") == 0 ||
-              strcmp(tok, "no_dedup_scan") == 0 || strcmp(tok, "dedup_scan=off") == 0)
-          {
-            bg_dedup_scan_enabled = 0u;
-            continue;
-          }
-
-          const char *bg_scan_str = NULL;
-          if (strncmp(tok, "bg_dedup_scan=", 14) == 0)
-            bg_scan_str = tok + 14;
-          else if (strncmp(tok, "dedup_scan=", 11) == 0)
-            bg_scan_str = tok + 11;
-          if (bg_scan_str)
-          {
-            if (kafs_parse_onoff(bg_scan_str, &bg_dedup_scan_enabled) != 0)
-            {
-              fprintf(stderr, "invalid -o dedup_scan/bg_dedup_scan: '%s'\n", bg_scan_str);
-              free(dup);
-              return 2;
-            }
-            continue;
-          }
-
-          const char *bg_interval_str = NULL;
-          if (strncmp(tok, "bg_dedup_interval_ms=", 21) == 0)
-            bg_interval_str = tok + 21;
-          else if (strncmp(tok, "dedup_interval_ms=", 18) == 0)
-            bg_interval_str = tok + 18;
-          if (bg_interval_str)
-          {
-            if (kafs_parse_u32_range(bg_interval_str, KAFS_BG_DEDUP_INTERVAL_MS_MIN,
-                                     KAFS_BG_DEDUP_INTERVAL_MS_MAX, &bg_dedup_interval_ms) != 0)
-            {
-              fprintf(stderr, "invalid -o dedup_interval_ms/bg_dedup_interval_ms: '%s'\n",
-                      bg_interval_str);
-              free(dup);
-              return 2;
-            }
-            continue;
-          }
-
-          const char *bg_quiet_interval_str = NULL;
-          if (strncmp(tok, "bg_dedup_quiet_interval_ms=", 27) == 0)
-            bg_quiet_interval_str = tok + 27;
-          else if (strncmp(tok, "dedup_quiet_interval_ms=", 24) == 0)
-            bg_quiet_interval_str = tok + 24;
-          if (bg_quiet_interval_str)
-          {
-            if (kafs_parse_u32_range(bg_quiet_interval_str, KAFS_BG_DEDUP_INTERVAL_MS_MIN,
-                                     KAFS_BG_DEDUP_INTERVAL_MS_MAX,
-                                     &bg_dedup_quiet_interval_ms) != 0)
-            {
-              fprintf(stderr,
-                      "invalid -o dedup_quiet_interval_ms/bg_dedup_quiet_interval_ms: '%s'\n",
-                      bg_quiet_interval_str);
-              free(dup);
-              return 2;
-            }
-            continue;
-          }
-
-          const char *bg_pressure_interval_str = NULL;
-          if (strncmp(tok, "bg_dedup_pressure_interval_ms=", 30) == 0)
-            bg_pressure_interval_str = tok + 30;
-          else if (strncmp(tok, "dedup_pressure_interval_ms=", 27) == 0)
-            bg_pressure_interval_str = tok + 27;
-          if (bg_pressure_interval_str)
-          {
-            if (kafs_parse_u32_range(bg_pressure_interval_str, KAFS_BG_DEDUP_INTERVAL_MS_MIN,
-                                     KAFS_BG_DEDUP_INTERVAL_MS_MAX,
-                                     &bg_dedup_pressure_interval_ms) != 0)
-            {
-              fprintf(stderr,
-                      "invalid -o dedup_pressure_interval_ms/bg_dedup_pressure_interval_ms: '%s'\n",
-                      bg_pressure_interval_str);
-              free(dup);
-              return 2;
-            }
-            continue;
-          }
-
-          const char *bg_start_pct_str = NULL;
-          if (strncmp(tok, "bg_dedup_start_used_pct=", 24) == 0)
-            bg_start_pct_str = tok + 24;
-          else if (strncmp(tok, "dedup_start_used_pct=", 21) == 0)
-            bg_start_pct_str = tok + 21;
-          if (bg_start_pct_str)
-          {
-            if (kafs_parse_u32_range(bg_start_pct_str, 0, 100u, &bg_dedup_start_used_pct) != 0)
-            {
-              fprintf(stderr, "invalid -o dedup_start_used_pct/bg_dedup_start_used_pct: '%s'\n",
-                      bg_start_pct_str);
-              free(dup);
-              return 2;
-            }
-            continue;
-          }
-
-          const char *bg_pressure_pct_str = NULL;
-          if (strncmp(tok, "bg_dedup_pressure_used_pct=", 27) == 0)
-            bg_pressure_pct_str = tok + 27;
-          else if (strncmp(tok, "dedup_pressure_used_pct=", 24) == 0)
-            bg_pressure_pct_str = tok + 24;
-          if (bg_pressure_pct_str)
-          {
-            if (kafs_parse_u32_range(bg_pressure_pct_str, 0, 100u, &bg_dedup_pressure_used_pct) !=
-                0)
-            {
-              fprintf(stderr,
-                      "invalid -o dedup_pressure_used_pct/bg_dedup_pressure_used_pct: '%s'\n",
-                      bg_pressure_pct_str);
-              free(dup);
-              return 2;
-            }
-            continue;
-          }
-
-          const char *bg_prio_str = NULL;
-          if (strncmp(tok, "bg_dedup_worker_prio=", 21) == 0)
-            bg_prio_str = tok + 21;
-          else if (strncmp(tok, "dedup_scan_worker_prio=", 23) == 0)
-            bg_prio_str = tok + 23;
-          if (bg_prio_str)
-          {
-            if (kafs_pending_worker_prio_mode_parse(bg_prio_str, &bg_dedup_worker_prio_mode) != 0)
-            {
-              fprintf(stderr, "invalid -o bg_dedup_worker_prio/dedup_scan_worker_prio: '%s'\n",
-                      bg_prio_str);
-              free(dup);
-              return 2;
-            }
-            continue;
-          }
-
-          const char *bg_nice_str = NULL;
-          if (strncmp(tok, "bg_dedup_worker_nice=", 21) == 0)
-            bg_nice_str = tok + 21;
-          else if (strncmp(tok, "dedup_scan_worker_nice=", 23) == 0)
-            bg_nice_str = tok + 23;
-          if (bg_nice_str)
-          {
-            char *endp = NULL;
-            long v = strtol(bg_nice_str, &endp, 10);
-            if (!endp || *endp != '\0' || v < 0 || v > 19)
-            {
-              fprintf(stderr, "invalid -o bg_dedup_worker_nice/dedup_scan_worker_nice: '%s'\n",
-                      bg_nice_str);
-              free(dup);
-              return 2;
-            }
-            bg_dedup_worker_nice = (int)v;
-            continue;
-          }
-
-          // keep other options
-          size_t tlen = strlen(tok);
-          size_t need = tlen + (used ? 1 : 0);
-          if (need)
-          {
-            if (used)
-              filtered[used++] = ',';
-            memcpy(filtered + used, tok, tlen);
-            used += tlen;
-            filtered[used] = '\0';
-          }
-        }
-
-        free(dup);
-        if (want_mt)
-          enable_mt = KAFS_TRUE;
-
-        if (filtered[0] != '\0')
-        {
-          char *kept = NULL;
-          if (is_compact)
-          {
-            kept = (char *)malloc(strlen(filtered) + 3);
-            if (!kept)
-            {
-              perror("malloc");
-              return 2;
-            }
-            kept[0] = '-';
-            kept[1] = 'o';
-            strcpy(kept + 2, filtered);
-            argv_user[argc_user++] = kept;
-          }
-          else
-          {
-            kept = strdup(filtered);
-            if (!kept)
-            {
-              perror("strdup");
-              return 2;
-            }
-            argv_user[argc_user++] = "-o";
-            argv_user[argc_user++] = kept;
-          }
-          o_owned[o_owned_cnt++] = kept;
-        }
-        continue;
+        argv_user[argc_user++] = "-o";
+        argv_user[argc_user++] = kept;
       }
-
-      argv_user[argc_user++] = argv_clean[i];
+      o_owned[o_owned_cnt++] = kept;
     }
-
-    // Copy back filtered argv
-    argc_clean = argc_user;
-    for (int i = 0; i < argc_clean; ++i)
-      argv_clean[i] = argv_user[i];
-
-    // Note: o_owned is intentionally not freed here; argv_clean references it.
-    (void)o_owned;
-    (void)o_owned_cnt;
   }
 
-  if (pending_ttl_soft_ms > 0 && pending_ttl_hard_ms > 0 &&
-      pending_ttl_hard_ms < pending_ttl_soft_ms)
+  *argc_clean = argc_user;
+  for (int i = 0; i < *argc_clean; ++i)
+    argv_clean[i] = argv_user[i];
+
+  (void)o_owned;
+  (void)o_owned_cnt;
+  return 0;
+}
+
+static int kafs_main_validate_options(const kafs_main_options_t *opts)
+{
+  if (opts->pending_ttl_soft_ms > 0 && opts->pending_ttl_hard_ms > 0 &&
+      opts->pending_ttl_hard_ms < opts->pending_ttl_soft_ms)
   {
     fprintf(stderr, "invalid pending TTL: hard must be >= soft\n");
     return 2;
   }
-
-  if (pending_cap_min > 0 && pending_cap_max > 0 && pending_cap_max < pending_cap_min)
+  if (opts->pending_cap_min > 0 && opts->pending_cap_max > 0 &&
+      opts->pending_cap_max < opts->pending_cap_min)
   {
     fprintf(stderr, "invalid pendinglog capacity: max must be >= min\n");
     return 2;
   }
-
-  if (bg_dedup_pressure_used_pct > 0 && bg_dedup_start_used_pct > 0 &&
-      bg_dedup_pressure_used_pct < bg_dedup_start_used_pct)
+  if (opts->bg_dedup_pressure_used_pct > 0 && opts->bg_dedup_start_used_pct > 0 &&
+      opts->bg_dedup_pressure_used_pct < opts->bg_dedup_start_used_pct)
   {
     fprintf(stderr, "invalid bg dedup thresholds: pressure_used_pct must be >= start_used_pct\n");
     return 2;
   }
+  return 0;
+}
+
+#ifndef KAFS_NO_MAIN
+int main(int argc, char **argv)
+{
+  kafs_crash_diag_install("kafs");
+  kafs_main_options_t opts;
+  char *argv_clean[argc];
+  int argc_clean = 0;
+
+  kafs_main_options_init(&opts);
+  if (kafs_main_apply_env_overrides(&opts) != 0 ||
+      kafs_main_collect_args(argc, argv, argv[0], &opts, argv_clean, &argc_clean) != 0)
+    return 2;
+
+  // mount(8) helper compatibility: allow "kafs <image> <mountpoint> [FUSE options...]"
+  // When invoked via mount -t fuse.kafs, the image path is typically passed as the first argument.
+  if (opts.image_path == NULL && argc_clean >= 3 && argv_clean[1][0] != '-')
+  {
+    opts.image_path = argv_clean[1];
+    for (int i = 1; i + 1 < argc_clean; ++i)
+      argv_clean[i] = argv_clean[i + 1];
+    argc_clean--;
+  }
+
+  if (opts.show_help)
+  {
+    usage(argv[0]);
+    return 0;
+  }
+  if (opts.image_path == NULL || argc_clean < 2)
+  {
+    usage(argv[0]);
+    return 2;
+  }
+
+  if (kafs_main_filter_mount_options(&opts, argv_clean, &argc_clean) != 0 ||
+      kafs_main_validate_options(&opts) != 0)
+    return 2;
+
+  const char *image_path = opts.image_path;
+  kafs_bool_t auto_migrate = opts.auto_migrate;
+  kafs_bool_t migrate_yes = opts.migrate_yes;
+  kafs_bool_t writeback_cache_enabled = opts.writeback_cache_enabled;
+  kafs_bool_t writeback_cache_explicit = opts.writeback_cache_explicit;
+  kafs_bool_t trim_on_free_enabled = opts.trim_on_free_enabled;
+  kafs_bool_t trim_on_free_explicit = opts.trim_on_free_explicit;
+  kafs_bool_t enable_mt = opts.enable_mt;
+  unsigned mt_cnt_override = opts.mt_cnt_override;
+  int mt_cnt_override_set = opts.mt_cnt_override_set;
+  int saw_max_threads = opts.saw_max_threads;
+  uint32_t pending_worker_prio_mode = opts.pending_worker_prio_mode;
+  int pending_worker_nice = opts.pending_worker_nice;
+  uint32_t pending_ttl_soft_ms = opts.pending_ttl_soft_ms;
+  uint32_t pending_ttl_hard_ms = opts.pending_ttl_hard_ms;
+  uint32_t pending_cap_initial = opts.pending_cap_initial;
+  uint32_t pending_cap_min = opts.pending_cap_min;
+  uint32_t pending_cap_max = opts.pending_cap_max;
+  uint32_t bg_dedup_scan_enabled = opts.bg_dedup_scan_enabled;
+  uint32_t bg_dedup_interval_ms = opts.bg_dedup_interval_ms;
+  uint32_t bg_dedup_quiet_interval_ms = opts.bg_dedup_quiet_interval_ms;
+  uint32_t bg_dedup_pressure_interval_ms = opts.bg_dedup_pressure_interval_ms;
+  uint32_t bg_dedup_start_used_pct = opts.bg_dedup_start_used_pct;
+  uint32_t bg_dedup_pressure_used_pct = opts.bg_dedup_pressure_used_pct;
+  uint32_t bg_dedup_worker_prio_mode = opts.bg_dedup_worker_prio_mode;
+  int bg_dedup_worker_nice = opts.bg_dedup_worker_nice;
+  uint32_t fsync_policy = opts.fsync_policy;
+  char *hotplug_uds_opt = opts.hotplug_uds_opt;
+  char *hotplug_back_bin_opt = opts.hotplug_back_bin_opt;
 
   static kafs_context_t ctx;
   static char mnt_abs[PATH_MAX];

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -1809,6 +1809,70 @@ static int kafs_bg_dedup_handle_scanned_block(struct kafs_context *ctx, uint32_t
   return 1;
 }
 
+static int kafs_bg_dedup_scan_inode(struct kafs_context *ctx, uint32_t ino, kafs_inocnt_t scanned,
+                                    kafs_inocnt_t inocnt, int pressure_mode, kafs_blksize_t bs,
+                                    uint32_t scan_window, uint32_t sweep_cap, uint32_t block_budget,
+                                    uint32_t *scanned_blocks_this_step,
+                                    kafs_bg_dedup_sweep_state_t *sweep_state)
+{
+  int inode_locked = 0;
+  kafs_inode_lock(ctx, ino);
+  inode_locked = 1;
+  kafs_sinode_t *inoent = kafs_ctx_inode(ctx, ino);
+  kafs_iblkcnt_t iblocnt = 0;
+  uint32_t direct_cnt = 0;
+  if (!kafs_bg_dedup_prepare_inode_scan(ctx, inoent, scanned, inocnt, pressure_mode, bs,
+                                        scan_window, &iblocnt, &direct_cnt))
+    return 0;
+
+  char buf[bs];
+  uint32_t start = (scanned == 0) ? (ctx->c_bg_dedup_iblk_cursor % direct_cnt) : 0u;
+  for (uint32_t delta = 0; delta < direct_cnt; ++delta)
+  {
+    uint32_t iblk = (start + delta) % direct_cnt;
+    uint32_t next_iblk = (iblk + 1u < direct_cnt) ? (iblk + 1u) : 0u;
+
+    kafs_blkcnt_t raw = KAFS_BLO_NONE;
+    if (kafs_ino_ibrk_run(ctx, inoent, (kafs_iblkcnt_t)iblk, &raw, KAFS_IBLKREF_FUNC_GET_RAW) != 0)
+      continue;
+    if (kafs_ref_is_pending(raw))
+      continue;
+
+    kafs_blkcnt_t old_blo = KAFS_BLO_NONE;
+    if (kafs_ref_resolve_data_blo(ctx, raw, &old_blo) != 0 || old_blo == KAFS_BLO_NONE)
+      continue;
+    if (kafs_blk_read(ctx, old_blo, buf) != 0)
+      continue;
+
+    __atomic_add_fetch(&ctx->c_stat_bg_dedup_scanned_blocks, 1u, __ATOMIC_RELAXED);
+    (*scanned_blocks_this_step)++;
+
+    kafs_bg_dedup_advance_or_cooldown(ctx, inocnt, next_iblk, pressure_mode);
+
+    kafs_blkcnt_t snapshot_raw = raw;
+    kafs_inode_unlock(ctx, ino);
+    inode_locked = 0;
+
+    int action = kafs_bg_dedup_handle_scanned_block(ctx, ino, (kafs_iblkcnt_t)iblk, snapshot_raw,
+                                                    old_blo, buf, bs, sweep_cap, block_budget,
+                                                    scanned_blocks_this_step, sweep_state);
+    if (action == 2)
+      return 2;
+    if (action == 1)
+      break;
+
+    kafs_inode_lock(ctx, ino);
+    inode_locked = 1;
+    inoent = kafs_ctx_inode(ctx, ino);
+  }
+
+  if (inode_locked)
+    kafs_inode_unlock(ctx, ino);
+  if (scanned == 0)
+    kafs_bg_dedup_advance_or_cooldown(ctx, inocnt, 0, pressure_mode);
+  return 0;
+}
+
 static void kafs_bg_dedup_step(struct kafs_context *ctx, int pressure_mode)
 {
   if (!ctx || !ctx->c_superblock)
@@ -1827,7 +1891,6 @@ static void kafs_bg_dedup_step(struct kafs_context *ctx, int pressure_mode)
   __atomic_add_fetch(&ctx->c_stat_bg_dedup_steps, 1u, __ATOMIC_RELAXED);
 
   kafs_blksize_t bs = kafs_sb_blksize_get(ctx->c_superblock);
-  char buf[bs];
   uint32_t block_budget =
       pressure_mode ? KAFS_BG_DEDUP_BLOCK_BUDGET_PRESSURE : KAFS_BG_DEDUP_BLOCK_BUDGET_DEFAULT;
   uint32_t scan_window =
@@ -1841,60 +1904,10 @@ static void kafs_bg_dedup_step(struct kafs_context *ctx, int pressure_mode)
   for (kafs_inocnt_t scanned = 0; scanned < inocnt; ++scanned)
   {
     uint32_t ino = (ctx->c_bg_dedup_ino_cursor + scanned) % inocnt;
-    int inode_locked = 0;
-    kafs_inode_lock(ctx, ino);
-    inode_locked = 1;
-    kafs_sinode_t *inoent = kafs_ctx_inode(ctx, ino);
-    kafs_iblkcnt_t iblocnt = 0;
-    uint32_t direct_cnt = 0;
-    if (!kafs_bg_dedup_prepare_inode_scan(ctx, inoent, scanned, inocnt, pressure_mode, bs,
-                                          scan_window, &iblocnt, &direct_cnt))
-    {
-      inode_locked = 0;
-      continue;
-    }
-
-    uint32_t start = (scanned == 0) ? (ctx->c_bg_dedup_iblk_cursor % direct_cnt) : 0u;
-    for (uint32_t delta = 0; delta < direct_cnt; ++delta)
-    {
-      uint32_t iblk = (start + delta) % direct_cnt;
-      uint32_t next_iblk = (iblk + 1u < direct_cnt) ? (iblk + 1u) : 0u;
-
-      kafs_blkcnt_t raw = KAFS_BLO_NONE;
-      if (kafs_ino_ibrk_run(ctx, inoent, (kafs_iblkcnt_t)iblk, &raw, KAFS_IBLKREF_FUNC_GET_RAW) !=
-          0)
-        continue;
-      if (kafs_ref_is_pending(raw))
-        continue;
-
-      kafs_blkcnt_t old_blo = KAFS_BLO_NONE;
-      if (kafs_ref_resolve_data_blo(ctx, raw, &old_blo) != 0 || old_blo == KAFS_BLO_NONE)
-        continue;
-      if (kafs_blk_read(ctx, old_blo, buf) != 0)
-        continue;
-
-      __atomic_add_fetch(&ctx->c_stat_bg_dedup_scanned_blocks, 1u, __ATOMIC_RELAXED);
-      scanned_blocks_this_step++;
-
-      kafs_bg_dedup_advance_or_cooldown(ctx, inocnt, next_iblk, pressure_mode);
-
-      kafs_blkcnt_t snapshot_raw = raw;
-      kafs_inode_unlock(ctx, ino);
-      inode_locked = 0;
-
-      int action = kafs_bg_dedup_handle_scanned_block(ctx, ino, (kafs_iblkcnt_t)iblk, snapshot_raw,
-                                                      old_blo, buf, bs, sweep_cap, block_budget,
-                                                      &scanned_blocks_this_step, &sweep_state);
-      if (action == 2)
-        return;
-      if (action == 1)
-        break;
-    }
-
-    if (inode_locked)
-      kafs_inode_unlock(ctx, ino);
-    if (scanned == 0)
-      kafs_bg_dedup_advance_or_cooldown(ctx, inocnt, 0, pressure_mode);
+    if (kafs_bg_dedup_scan_inode(ctx, ino, scanned, inocnt, pressure_mode, bs, scan_window,
+                                 sweep_cap, block_budget, &scanned_blocks_this_step,
+                                 &sweep_state) == 2)
+      return;
   }
 }
 

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -6078,43 +6078,49 @@ static void kafs_hotplug_set_fd_timeout_ms(int fd, uint32_t timeout_ms)
   (void)setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
 }
 
-static int kafs_hotplug_complete_handshake(kafs_context_t *ctx, int cli)
+static int kafs_hotplug_handshake_fail(kafs_context_t *ctx, int error)
+{
+  ctx->c_hotplug_state = KAFS_HOTPLUG_STATE_ERROR;
+  ctx->c_hotplug_last_error = error;
+  return error;
+}
+
+static int kafs_hotplug_handshake_reject(kafs_context_t *ctx, int error)
+{
+  ctx->c_hotplug_compat_result = KAFS_HOTPLUG_COMPAT_REJECT;
+  ctx->c_hotplug_compat_reason = error;
+  return kafs_hotplug_handshake_fail(ctx, error);
+}
+
+static int kafs_hotplug_recv_hello(int cli, kafs_rpc_hello_t *hello_out)
 {
   kafs_rpc_hdr_t hdr;
-  kafs_rpc_hello_t hello;
   uint32_t payload_len = 0;
-  int rc = kafs_rpc_recv_msg(cli, &hdr, &hello, sizeof(hello), &payload_len);
-  if (rc != 0 || hdr.op != KAFS_RPC_OP_HELLO)
-  {
-    ctx->c_hotplug_state = KAFS_HOTPLUG_STATE_ERROR;
-    ctx->c_hotplug_last_error = rc != 0 ? rc : -EBADMSG;
-    ctx->c_hotplug_compat_result = KAFS_HOTPLUG_COMPAT_REJECT;
-    ctx->c_hotplug_compat_reason = rc != 0 ? rc : -EBADMSG;
-    return rc != 0 ? rc : -EBADMSG;
-  }
-  if (payload_len != sizeof(hello))
-  {
-    ctx->c_hotplug_state = KAFS_HOTPLUG_STATE_ERROR;
-    ctx->c_hotplug_last_error = -EBADMSG;
-    ctx->c_hotplug_compat_result = KAFS_HOTPLUG_COMPAT_REJECT;
-    ctx->c_hotplug_compat_reason = -EBADMSG;
+  int rc = kafs_rpc_recv_msg(cli, &hdr, hello_out, sizeof(*hello_out), &payload_len);
+  if (rc != 0)
+    return rc;
+  if (hdr.op != KAFS_RPC_OP_HELLO || payload_len != sizeof(*hello_out))
     return -EBADMSG;
-  }
-  ctx->c_hotplug_back_major = hello.major;
-  ctx->c_hotplug_back_minor = hello.minor;
-  ctx->c_hotplug_back_features = hello.feature_flags;
-  if (hello.major != KAFS_RPC_HELLO_MAJOR || hello.minor != KAFS_RPC_HELLO_MINOR ||
-      (hello.feature_flags & ~KAFS_RPC_HELLO_FEATURES) != 0)
-  {
-    ctx->c_hotplug_state = KAFS_HOTPLUG_STATE_ERROR;
-    ctx->c_hotplug_last_error = -EPROTONOSUPPORT;
-    ctx->c_hotplug_compat_result = KAFS_HOTPLUG_COMPAT_REJECT;
-    ctx->c_hotplug_compat_reason = -EPROTONOSUPPORT;
-    return -EPROTONOSUPPORT;
-  }
+  return 0;
+}
+
+static int kafs_hotplug_accept_hello(kafs_context_t *ctx, const kafs_rpc_hello_t *hello)
+{
+  ctx->c_hotplug_back_major = hello->major;
+  ctx->c_hotplug_back_minor = hello->minor;
+  ctx->c_hotplug_back_features = hello->feature_flags;
+  if (hello->major != KAFS_RPC_HELLO_MAJOR || hello->minor != KAFS_RPC_HELLO_MINOR ||
+      (hello->feature_flags & ~KAFS_RPC_HELLO_FEATURES) != 0)
+    return kafs_hotplug_handshake_reject(ctx, -EPROTONOSUPPORT);
+
   ctx->c_hotplug_compat_result = KAFS_HOTPLUG_COMPAT_OK;
   ctx->c_hotplug_compat_reason = 0;
+  return 0;
+}
 
+static void kafs_hotplug_prepare_session(kafs_context_t *ctx, uint64_t *session_id_out,
+                                         uint32_t *next_epoch_out)
+{
   uint64_t session_id = ctx->c_hotplug_session_id;
   uint32_t next_epoch = ctx->c_hotplug_epoch;
   if (session_id == 0)
@@ -6126,35 +6132,38 @@ static int kafs_hotplug_complete_handshake(kafs_context_t *ctx, int cli)
   {
     next_epoch = ctx->c_hotplug_epoch + 1u;
   }
+  *session_id_out = session_id;
+  *next_epoch_out = next_epoch;
+}
 
+static int kafs_hotplug_send_session_restore(kafs_context_t *ctx, int cli, uint64_t session_id,
+                                             uint32_t next_epoch)
+{
   kafs_rpc_session_restore_t restore;
   restore.open_handle_count = 0u;
   uint64_t req_id = kafs_rpc_next_req_id();
-  rc = kafs_rpc_send_msg(cli, KAFS_RPC_OP_SESSION_RESTORE, KAFS_RPC_FLAG_ENDIAN_HOST, req_id,
-                         session_id, next_epoch, &restore, sizeof(restore));
+  int rc = kafs_rpc_send_msg(cli, KAFS_RPC_OP_SESSION_RESTORE, KAFS_RPC_FLAG_ENDIAN_HOST, req_id,
+                             session_id, next_epoch, &restore, sizeof(restore));
   if (rc != 0)
-  {
-    ctx->c_hotplug_state = KAFS_HOTPLUG_STATE_ERROR;
-    ctx->c_hotplug_last_error = rc;
-    return rc;
-  }
+    return kafs_hotplug_handshake_fail(ctx, rc);
+  return 0;
+}
 
+static int kafs_hotplug_recv_ready(kafs_context_t *ctx, int cli)
+{
   kafs_rpc_hdr_t ready_hdr;
   uint32_t ready_len = 0;
-  rc = kafs_rpc_recv_msg(cli, &ready_hdr, NULL, 0, &ready_len);
-  if (rc != 0 || ready_hdr.op != KAFS_RPC_OP_READY)
-  {
-    ctx->c_hotplug_state = KAFS_HOTPLUG_STATE_ERROR;
-    ctx->c_hotplug_last_error = rc != 0 ? rc : -EBADMSG;
-    return rc != 0 ? rc : -EBADMSG;
-  }
-  if (ready_len != 0)
-  {
-    ctx->c_hotplug_state = KAFS_HOTPLUG_STATE_ERROR;
-    ctx->c_hotplug_last_error = -EBADMSG;
-    return -EBADMSG;
-  }
+  int rc = kafs_rpc_recv_msg(cli, &ready_hdr, NULL, 0, &ready_len);
+  if (rc != 0)
+    return kafs_hotplug_handshake_fail(ctx, rc);
+  if (ready_hdr.op != KAFS_RPC_OP_READY || ready_len != 0)
+    return kafs_hotplug_handshake_fail(ctx, -EBADMSG);
+  return 0;
+}
 
+static void kafs_hotplug_finish_handshake(kafs_context_t *ctx, int cli, uint64_t session_id,
+                                          uint32_t next_epoch)
+{
   ctx->c_hotplug_fd = cli;
   ctx->c_hotplug_active = 1;
   ctx->c_hotplug_state = KAFS_HOTPLUG_STATE_CONNECTED;
@@ -6167,6 +6176,32 @@ static int kafs_hotplug_complete_handshake(kafs_context_t *ctx, int cli)
       ctx->c_hotplug_lock_init = 1;
   }
   kafs_hotplug_wait_notify(ctx);
+}
+
+static int kafs_hotplug_complete_handshake(kafs_context_t *ctx, int cli)
+{
+  kafs_rpc_hello_t hello;
+  int rc = kafs_hotplug_recv_hello(cli, &hello);
+  if (rc != 0)
+    return kafs_hotplug_handshake_reject(ctx, rc);
+
+  rc = kafs_hotplug_accept_hello(ctx, &hello);
+  if (rc != 0)
+    return rc;
+
+  uint64_t session_id;
+  uint32_t next_epoch;
+  kafs_hotplug_prepare_session(ctx, &session_id, &next_epoch);
+
+  rc = kafs_hotplug_send_session_restore(ctx, cli, session_id, next_epoch);
+  if (rc != 0)
+    return rc;
+
+  rc = kafs_hotplug_recv_ready(ctx, cli);
+  if (rc != 0)
+    return rc;
+
+  kafs_hotplug_finish_handshake(ctx, cli, session_id, next_epoch);
   return 0;
 }
 

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -6747,6 +6747,66 @@ ssize_t kafs_core_write(kafs_context_t *ctx, kafs_inocnt_t ino, const void *buf,
   return ww;
 }
 
+static int kafs_hotplug_read_validate_request(kafs_context_t *ctx, size_t size)
+{
+  int wait_rc = kafs_hotplug_wait_ready(ctx);
+  if (wait_rc != 0)
+    return wait_rc;
+  if (ctx->c_hotplug_data_mode == KAFS_RPC_DATA_SHM)
+    return -EOPNOTSUPP;
+  if (ctx->c_hotplug_data_mode == KAFS_RPC_DATA_INLINE &&
+      size > (KAFS_RPC_MAX_PAYLOAD - sizeof(kafs_rpc_read_resp_t)))
+    return -EOPNOTSUPP;
+  return 0;
+}
+
+static void kafs_hotplug_read_prepare_request(struct fuse_context *fctx, kafs_context_t *ctx,
+                                              kafs_inocnt_t ino, size_t size, off_t offset,
+                                              kafs_rpc_read_req_t *req)
+{
+  req->ino = (uint32_t)ino;
+  req->uid = (uint32_t)fctx->uid;
+  req->gid = (uint32_t)fctx->gid;
+  req->pid = (uint32_t)fctx->pid;
+  req->off = (uint64_t)offset;
+  req->size = (uint32_t)size;
+  req->data_mode = ctx->c_hotplug_data_mode;
+}
+
+static int kafs_hotplug_read_handle_inline(kafs_context_t *ctx, char *buf, size_t size,
+                                           uint8_t *resp_buf, uint32_t resp_len)
+{
+  kafs_rpc_read_resp_t *resp = (kafs_rpc_read_resp_t *)resp_buf;
+  if (ctx->c_hotplug_data_mode != KAFS_RPC_DATA_INLINE)
+  {
+    if (resp_len != sizeof(*resp))
+      return -EBADMSG;
+    return 1;
+  }
+
+  uint32_t data_len = resp_len - (uint32_t)sizeof(*resp);
+  if (resp->size > data_len || resp->size > size)
+    return -EBADMSG;
+  memcpy(buf, resp_buf + sizeof(*resp), resp->size);
+  return (int)resp->size;
+}
+
+static int kafs_hotplug_read_finish(kafs_context_t *ctx, int rc, int need_local, kafs_inocnt_t ino,
+                                    char *buf, size_t size, off_t offset)
+{
+  if (kafs_hotplug_is_disconnect_error(rc))
+  {
+    kafs_hotplug_mark_disconnected(ctx, rc);
+    rc = -EIO;
+  }
+  if (rc == 0 && need_local)
+  {
+    ssize_t rlen = kafs_core_read(ctx, ino, buf, size, offset);
+    rc = rlen < 0 ? (int)rlen : (int)rlen;
+  }
+  return rc;
+}
+
 int kafs_core_truncate(kafs_context_t *ctx, kafs_inocnt_t ino, off_t size)
 {
   if (!ctx)
@@ -6762,30 +6822,19 @@ int kafs_core_truncate(kafs_context_t *ctx, kafs_inocnt_t ino, off_t size)
 static ssize_t kafs_hotplug_call_read(struct fuse_context *fctx, kafs_context_t *ctx,
                                       kafs_inocnt_t ino, char *buf, size_t size, off_t offset)
 {
-  int wait_rc = kafs_hotplug_wait_ready(ctx);
-  if (wait_rc != 0)
-    return wait_rc;
-  if (ctx->c_hotplug_data_mode == KAFS_RPC_DATA_SHM)
-    return -EOPNOTSUPP;
-  if (ctx->c_hotplug_data_mode == KAFS_RPC_DATA_INLINE &&
-      size > (KAFS_RPC_MAX_PAYLOAD - sizeof(kafs_rpc_read_resp_t)))
-    return -EOPNOTSUPP;
+  int rc = kafs_hotplug_read_validate_request(ctx, size);
+  if (rc != 0)
+    return rc;
 
   kafs_rpc_read_req_t req;
-  req.ino = (uint32_t)ino;
-  req.uid = (uint32_t)fctx->uid;
-  req.gid = (uint32_t)fctx->gid;
-  req.pid = (uint32_t)fctx->pid;
-  req.off = (uint64_t)offset;
-  req.size = (uint32_t)size;
-  req.data_mode = ctx->c_hotplug_data_mode;
+  kafs_hotplug_read_prepare_request(fctx, ctx, ino, size, offset, &req);
   uint64_t req_id = kafs_rpc_next_req_id();
 
   uint8_t resp_buf[KAFS_RPC_MAX_PAYLOAD];
   if (ctx->c_hotplug_lock_init)
     pthread_mutex_lock(&ctx->c_hotplug_lock);
-  int rc = kafs_rpc_send_msg(ctx->c_hotplug_fd, KAFS_RPC_OP_READ, KAFS_RPC_FLAG_ENDIAN_HOST, req_id,
-                             ctx->c_hotplug_session_id, ctx->c_hotplug_epoch, &req, sizeof(req));
+  rc = kafs_rpc_send_msg(ctx->c_hotplug_fd, KAFS_RPC_OP_READ, KAFS_RPC_FLAG_ENDIAN_HOST, req_id,
+                         ctx->c_hotplug_session_id, ctx->c_hotplug_epoch, &req, sizeof(req));
   int need_local = 0;
   if (rc == 0)
   {
@@ -6800,44 +6849,17 @@ static ssize_t kafs_hotplug_call_read(struct fuse_context *fctx, kafs_context_t 
       rc = -EBADMSG;
     if (rc == 0)
     {
-      kafs_rpc_read_resp_t *resp = (kafs_rpc_read_resp_t *)resp_buf;
-      if (ctx->c_hotplug_data_mode == KAFS_RPC_DATA_INLINE)
+      rc = kafs_hotplug_read_handle_inline(ctx, buf, size, resp_buf, resp_len);
+      if (rc == 1)
       {
-        uint32_t data_len = resp_len - (uint32_t)sizeof(*resp);
-        if (resp->size > data_len || resp->size > size)
-          rc = -EBADMSG;
-        else
-        {
-          memcpy(buf, resp_buf + sizeof(*resp), resp->size);
-          rc = (int)resp->size;
-        }
-      }
-      else
-      {
-        if (resp_len != sizeof(*resp))
-        {
-          rc = -EBADMSG;
-        }
-        else
-        {
-          need_local = 1;
-        }
+        rc = 0;
+        need_local = 1;
       }
     }
   }
   if (ctx->c_hotplug_lock_init)
     pthread_mutex_unlock(&ctx->c_hotplug_lock);
-  if (kafs_hotplug_is_disconnect_error(rc))
-  {
-    kafs_hotplug_mark_disconnected(ctx, rc);
-    rc = -EIO;
-  }
-  if (rc == 0 && need_local)
-  {
-    ssize_t rlen = kafs_core_read(ctx, ino, buf, size, offset);
-    rc = rlen < 0 ? (int)rlen : (int)rlen;
-  }
-  return rc;
+  return kafs_hotplug_read_finish(ctx, rc, need_local, ino, buf, size, offset);
 }
 
 static int kafs_hotplug_write_validate_request(kafs_context_t *ctx, size_t size)

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -3140,6 +3140,156 @@ static int kafs_ino_ibrk_run_double(struct kafs_context *ctx, kafs_sinode_t *ino
   return KAFS_SUCCESS;
 }
 
+typedef struct kafs_ibrk_triple_path
+{
+  kafs_sblkcnt_t *blkreftbl1;
+  kafs_sblkcnt_t *blkreftbl2;
+  kafs_sblkcnt_t *blkreftbl3;
+  kafs_blkcnt_t blo_blkreftbl1;
+  kafs_blkcnt_t blo_blkreftbl2;
+  kafs_blkcnt_t blo_blkreftbl3;
+  kafs_blkcnt_t iblo1;
+  kafs_blkcnt_t iblo2;
+  kafs_blkcnt_t iblo3;
+} kafs_ibrk_triple_path_t;
+
+static int kafs_ino_ibrk_triple_read_leaf(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                          kafs_ibrk_triple_path_t *path, kafs_blkcnt_t *pblo)
+{
+  path->blo_blkreftbl1 = kafs_blkcnt_stoh(inoent->i_blkreftbl[14]);
+  if (path->blo_blkreftbl1 == KAFS_BLO_NONE)
+  {
+    *pblo = KAFS_BLO_NONE;
+    return KAFS_SUCCESS;
+  }
+
+  KAFS_CALL(kafs_blk_read, ctx, path->blo_blkreftbl1, path->blkreftbl1);
+  path->blo_blkreftbl2 = kafs_blkcnt_stoh(path->blkreftbl1[path->iblo1]);
+  if (path->blo_blkreftbl2 == KAFS_BLO_NONE)
+  {
+    *pblo = KAFS_BLO_NONE;
+    return KAFS_SUCCESS;
+  }
+
+  KAFS_CALL(kafs_blk_read, ctx, path->blo_blkreftbl2, path->blkreftbl2);
+  path->blo_blkreftbl3 = kafs_blkcnt_stoh(path->blkreftbl2[path->iblo2]);
+  if (path->blo_blkreftbl3 == KAFS_BLO_NONE)
+  {
+    *pblo = KAFS_BLO_NONE;
+    return KAFS_SUCCESS;
+  }
+
+  KAFS_CALL(kafs_blk_read, ctx, path->blo_blkreftbl3, path->blkreftbl3);
+  *pblo = kafs_blkcnt_stoh(path->blkreftbl3[path->iblo3]);
+  return KAFS_SUCCESS;
+}
+
+static int kafs_ino_ibrk_triple_prepare_leaf(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                             kafs_ibrk_triple_path_t *path, kafs_blksize_t blksize,
+                                             int adjust_inode_blocks)
+{
+  path->blo_blkreftbl1 = kafs_blkcnt_stoh(inoent->i_blkreftbl[14]);
+  if (path->blo_blkreftbl1 == KAFS_BLO_NONE)
+  {
+    KAFS_CALL(kafs_blk_alloc, ctx, &path->blo_blkreftbl1);
+    inoent->i_blkreftbl[14] = kafs_blkcnt_htos(path->blo_blkreftbl1);
+    if (adjust_inode_blocks)
+      kafs_ino_blocks_adjust(inoent, +1);
+    memset(path->blkreftbl1, 0, blksize);
+    path->blo_blkreftbl2 = KAFS_BLO_NONE;
+  }
+  else
+  {
+    KAFS_CALL(kafs_blk_read, ctx, path->blo_blkreftbl1, path->blkreftbl1);
+    path->blo_blkreftbl2 = kafs_blkcnt_stoh(path->blkreftbl1[path->iblo1]);
+  }
+
+  if (path->blo_blkreftbl2 == KAFS_BLO_NONE)
+  {
+    KAFS_CALL(kafs_blk_alloc, ctx, &path->blo_blkreftbl2);
+    path->blkreftbl1[path->iblo1] = kafs_blkcnt_htos(path->blo_blkreftbl2);
+    KAFS_CALL(kafs_blk_write, ctx, path->blo_blkreftbl1, path->blkreftbl1);
+    if (adjust_inode_blocks)
+      kafs_ino_blocks_adjust(inoent, +1);
+    memset(path->blkreftbl2, 0, blksize);
+    path->blo_blkreftbl3 = KAFS_BLO_NONE;
+  }
+  else
+  {
+    KAFS_CALL(kafs_blk_read, ctx, path->blo_blkreftbl2, path->blkreftbl2);
+    path->blo_blkreftbl3 = kafs_blkcnt_stoh(path->blkreftbl2[path->iblo2]);
+  }
+
+  if (path->blo_blkreftbl3 == KAFS_BLO_NONE)
+  {
+    KAFS_CALL(kafs_blk_alloc, ctx, &path->blo_blkreftbl3);
+    path->blkreftbl2[path->iblo2] = kafs_blkcnt_htos(path->blo_blkreftbl3);
+    KAFS_CALL(kafs_blk_write, ctx, path->blo_blkreftbl2, path->blkreftbl2);
+    if (adjust_inode_blocks)
+      kafs_ino_blocks_adjust(inoent, +1);
+    memset(path->blkreftbl3, 0, blksize);
+  }
+  else
+  {
+    KAFS_CALL(kafs_blk_read, ctx, path->blo_blkreftbl3, path->blkreftbl3);
+  }
+
+  return KAFS_SUCCESS;
+}
+
+static int kafs_ino_ibrk_run_triple_get_raw(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                            kafs_ibrk_triple_path_t *path, kafs_blkcnt_t *pblo)
+{
+  return kafs_ino_ibrk_triple_read_leaf(ctx, inoent, path, pblo);
+}
+
+static int kafs_ino_ibrk_run_triple_get(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                        kafs_ibrk_triple_path_t *path, kafs_blkcnt_t *pblo)
+{
+  KAFS_CALL(kafs_ino_ibrk_triple_read_leaf, ctx, inoent, path, pblo);
+  if (*pblo == KAFS_BLO_NONE)
+    return KAFS_SUCCESS;
+  KAFS_CALL(kafs_ref_resolve_data_blo, ctx, *pblo, pblo);
+  return KAFS_SUCCESS;
+}
+
+static int kafs_ino_ibrk_run_triple_put(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                        kafs_ibrk_triple_path_t *path, kafs_blkcnt_t *pblo,
+                                        kafs_blksize_t blksize)
+{
+  kafs_blkcnt_t blo_data;
+
+  KAFS_CALL(kafs_ino_ibrk_triple_prepare_leaf, ctx, inoent, path, blksize, 0);
+  KAFS_CALL(kafs_ref_resolve_data_blo, ctx, kafs_blkcnt_stoh(path->blkreftbl3[path->iblo3]),
+            &blo_data);
+  if (blo_data == KAFS_BLO_NONE)
+  {
+    KAFS_CALL(kafs_blk_alloc, ctx, &blo_data);
+    path->blkreftbl3[path->iblo3] = kafs_blkcnt_htos(blo_data);
+    KAFS_CALL(kafs_blk_write, ctx, path->blo_blkreftbl3, path->blkreftbl3);
+  }
+  *pblo = blo_data;
+  return KAFS_SUCCESS;
+}
+
+static int kafs_ino_ibrk_run_triple_set(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                        kafs_ibrk_triple_path_t *path, kafs_iblkcnt_t iblo_orig,
+                                        kafs_blkcnt_t *pblo, kafs_blksize_t blksize)
+{
+  kafs_blkcnt_t blo_data;
+
+  KAFS_CALL(kafs_ino_ibrk_triple_prepare_leaf, ctx, inoent, path, blksize, 1);
+  blo_data = kafs_blkcnt_stoh(path->blkreftbl3[path->iblo3]);
+  kafs_diag_log_dir_ref_set("ibrk_set_triple", ctx, inoent, iblo_orig, blo_data, *pblo);
+  if (blo_data == KAFS_BLO_NONE && *pblo != KAFS_BLO_NONE)
+    kafs_ino_blocks_adjust(inoent, +1);
+  else if (blo_data != KAFS_BLO_NONE && *pblo == KAFS_BLO_NONE)
+    kafs_ino_blocks_adjust(inoent, -1);
+  path->blkreftbl3[path->iblo3] = kafs_blkcnt_htos(*pblo);
+  KAFS_CALL(kafs_blk_write, ctx, path->blo_blkreftbl3, path->blkreftbl3);
+  return KAFS_SUCCESS;
+}
+
 static int kafs_ino_ibrk_run_triple(struct kafs_context *ctx, kafs_sinode_t *inoent,
                                     kafs_iblkcnt_t iblo, kafs_iblkcnt_t iblo_orig,
                                     kafs_blkcnt_t *pblo, kafs_iblkref_func_t ifunc,
@@ -3149,161 +3299,31 @@ static int kafs_ino_ibrk_run_triple(struct kafs_context *ctx, kafs_sinode_t *ino
   kafs_sblkcnt_t blkreftbl1[blkrefs_pb];
   kafs_sblkcnt_t blkreftbl2[blkrefs_pb];
   kafs_sblkcnt_t blkreftbl3[blkrefs_pb];
-  kafs_blkcnt_t blo_blkreftbl1 = kafs_blkcnt_stoh(inoent->i_blkreftbl[14]);
-  kafs_blkcnt_t blo_blkreftbl2;
-  kafs_blkcnt_t blo_blkreftbl3;
-  kafs_blkcnt_t blo_data;
-  kafs_blkcnt_t iblo1 = iblo >> log_blkrefs_pb_sq;
-  kafs_blkcnt_t iblo2 = (iblo >> log_blkrefs_pb) & (blkrefs_pb - 1);
-  kafs_blkcnt_t iblo3 = iblo & (blkrefs_pb - 1);
+  kafs_ibrk_triple_path_t path = {
+      .blkreftbl1 = blkreftbl1,
+      .blkreftbl2 = blkreftbl2,
+      .blkreftbl3 = blkreftbl3,
+      .blo_blkreftbl1 = KAFS_BLO_NONE,
+      .blo_blkreftbl2 = KAFS_BLO_NONE,
+      .blo_blkreftbl3 = KAFS_BLO_NONE,
+      .iblo1 = iblo >> log_blkrefs_pb_sq,
+      .iblo2 = (iblo >> log_blkrefs_pb) & (blkrefs_pb - 1),
+      .iblo3 = iblo & (blkrefs_pb - 1),
+  };
 
   switch (ifunc)
   {
   case KAFS_IBLKREF_FUNC_GET_RAW:
-    if (blo_blkreftbl1 == KAFS_BLO_NONE)
-    {
-      *pblo = KAFS_BLO_NONE;
-      return KAFS_SUCCESS;
-    }
-    KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl1, blkreftbl1);
-    blo_blkreftbl2 = kafs_blkcnt_stoh(blkreftbl1[iblo1]);
-    if (blo_blkreftbl2 == KAFS_BLO_NONE)
-    {
-      *pblo = KAFS_BLO_NONE;
-      return KAFS_SUCCESS;
-    }
-    KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl2, blkreftbl2);
-    blo_blkreftbl3 = kafs_blkcnt_stoh(blkreftbl2[iblo2]);
-    if (blo_blkreftbl3 == KAFS_BLO_NONE)
-    {
-      *pblo = KAFS_BLO_NONE;
-      return KAFS_SUCCESS;
-    }
-    KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl3, blkreftbl3);
-    *pblo = kafs_blkcnt_stoh(blkreftbl3[iblo3]);
-    return KAFS_SUCCESS;
+    return kafs_ino_ibrk_run_triple_get_raw(ctx, inoent, &path, pblo);
 
   case KAFS_IBLKREF_FUNC_GET:
-    if (blo_blkreftbl1 == KAFS_BLO_NONE)
-    {
-      *pblo = KAFS_BLO_NONE;
-      return KAFS_SUCCESS;
-    }
-    KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl1, blkreftbl1);
-    blo_blkreftbl2 = kafs_blkcnt_stoh(blkreftbl1[iblo1]);
-    if (blo_blkreftbl2 == KAFS_BLO_NONE)
-    {
-      *pblo = KAFS_BLO_NONE;
-      return KAFS_SUCCESS;
-    }
-    KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl2, blkreftbl2);
-    blo_blkreftbl3 = kafs_blkcnt_stoh(blkreftbl2[iblo2]);
-    if (blo_blkreftbl3 == KAFS_BLO_NONE)
-    {
-      *pblo = KAFS_BLO_NONE;
-      return KAFS_SUCCESS;
-    }
-    KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl3, blkreftbl3);
-    KAFS_CALL(kafs_ref_resolve_data_blo, ctx, kafs_blkcnt_stoh(blkreftbl3[iblo3]), pblo);
-    return KAFS_SUCCESS;
+    return kafs_ino_ibrk_run_triple_get(ctx, inoent, &path, pblo);
 
   case KAFS_IBLKREF_FUNC_PUT:
-    if (blo_blkreftbl1 == KAFS_BLO_NONE)
-    {
-      KAFS_CALL(kafs_blk_alloc, ctx, &blo_blkreftbl1);
-      inoent->i_blkreftbl[14] = kafs_blkcnt_htos(blo_blkreftbl1);
-      memset(blkreftbl1, 0, blksize);
-      blo_blkreftbl2 = KAFS_BLO_NONE;
-    }
-    else
-    {
-      KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl1, blkreftbl1);
-      blo_blkreftbl2 = kafs_blkcnt_stoh(blkreftbl1[iblo1]);
-    }
-    if (blo_blkreftbl2 == KAFS_BLO_NONE)
-    {
-      KAFS_CALL(kafs_blk_alloc, ctx, &blo_blkreftbl2);
-      blkreftbl1[iblo1] = kafs_blkcnt_htos(blo_blkreftbl2);
-      KAFS_CALL(kafs_blk_write, ctx, blo_blkreftbl1, blkreftbl1);
-      memset(blkreftbl2, 0, blksize);
-      blo_blkreftbl3 = KAFS_BLO_NONE;
-    }
-    else
-    {
-      KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl2, blkreftbl2);
-      blo_blkreftbl3 = kafs_blkcnt_stoh(blkreftbl2[iblo2]);
-    }
-    if (blo_blkreftbl3 == KAFS_BLO_NONE)
-    {
-      KAFS_CALL(kafs_blk_alloc, ctx, &blo_blkreftbl3);
-      blkreftbl2[iblo2] = kafs_blkcnt_htos(blo_blkreftbl3);
-      KAFS_CALL(kafs_blk_write, ctx, blo_blkreftbl2, blkreftbl2);
-      memset(blkreftbl3, 0, blksize);
-      blo_data = KAFS_BLO_NONE;
-    }
-    else
-    {
-      KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl3, blkreftbl3);
-      KAFS_CALL(kafs_ref_resolve_data_blo, ctx, kafs_blkcnt_stoh(blkreftbl3[iblo3]), &blo_data);
-    }
-    if (blo_data == KAFS_BLO_NONE)
-    {
-      KAFS_CALL(kafs_blk_alloc, ctx, &blo_data);
-      blkreftbl3[iblo3] = kafs_blkcnt_htos(blo_data);
-      KAFS_CALL(kafs_blk_write, ctx, blo_blkreftbl3, blkreftbl3);
-    }
-    *pblo = blo_data;
-    return KAFS_SUCCESS;
+    return kafs_ino_ibrk_run_triple_put(ctx, inoent, &path, pblo, blksize);
 
   case KAFS_IBLKREF_FUNC_SET:
-    if (blo_blkreftbl1 == KAFS_BLO_NONE)
-    {
-      KAFS_CALL(kafs_blk_alloc, ctx, &blo_blkreftbl1);
-      inoent->i_blkreftbl[14] = kafs_blkcnt_htos(blo_blkreftbl1);
-      kafs_ino_blocks_adjust(inoent, +1);
-      memset(blkreftbl1, 0, blksize);
-      blo_blkreftbl2 = KAFS_BLO_NONE;
-    }
-    else
-    {
-      KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl1, blkreftbl1);
-      blo_blkreftbl2 = kafs_blkcnt_stoh(blkreftbl1[iblo1]);
-    }
-    if (blo_blkreftbl2 == KAFS_BLO_NONE)
-    {
-      KAFS_CALL(kafs_blk_alloc, ctx, &blo_blkreftbl2);
-      blkreftbl1[iblo1] = kafs_blkcnt_htos(blo_blkreftbl2);
-      KAFS_CALL(kafs_blk_write, ctx, blo_blkreftbl1, blkreftbl1);
-      kafs_ino_blocks_adjust(inoent, +1);
-      memset(blkreftbl2, 0, blksize);
-      blo_blkreftbl3 = KAFS_BLO_NONE;
-    }
-    else
-    {
-      KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl2, blkreftbl2);
-      blo_blkreftbl3 = kafs_blkcnt_stoh(blkreftbl2[iblo2]);
-    }
-    if (blo_blkreftbl3 == KAFS_BLO_NONE)
-    {
-      KAFS_CALL(kafs_blk_alloc, ctx, &blo_blkreftbl3);
-      blkreftbl2[iblo2] = kafs_blkcnt_htos(blo_blkreftbl3);
-      KAFS_CALL(kafs_blk_write, ctx, blo_blkreftbl2, blkreftbl2);
-      kafs_ino_blocks_adjust(inoent, +1);
-      memset(blkreftbl3, 0, blksize);
-    }
-    else
-    {
-      KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl3, blkreftbl3);
-    }
-    blo_data = kafs_blkcnt_stoh(blkreftbl3[iblo3]);
-    kafs_diag_log_dir_ref_set("ibrk_set_triple", ctx, inoent, iblo_orig, blo_data, *pblo);
-    if (blo_data == KAFS_BLO_NONE && *pblo != KAFS_BLO_NONE)
-      kafs_ino_blocks_adjust(inoent, +1);
-    else if (blo_data != KAFS_BLO_NONE && *pblo == KAFS_BLO_NONE)
-      kafs_ino_blocks_adjust(inoent, -1);
-    blkreftbl3[iblo3] = kafs_blkcnt_htos(*pblo);
-    KAFS_CALL(kafs_blk_write, ctx, blo_blkreftbl3, blkreftbl3);
-    return KAFS_SUCCESS;
+    return kafs_ino_ibrk_run_triple_set(ctx, inoent, &path, iblo_orig, pblo, blksize);
   }
 
   return KAFS_SUCCESS;

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -7313,9 +7313,8 @@ static inline kafs_hrl_entry_t *kafs_hrl_entries_tbl(kafs_context_t *ctx)
   return (kafs_hrl_entry_t *)(base + (uintptr_t)off);
 }
 
-static void kafs_stats_snapshot(kafs_context_t *ctx, kafs_stats_t *out, uint32_t request_flags)
+static void kafs_stats_snapshot_fs(kafs_context_t *ctx, kafs_stats_t *out, uint32_t request_flags)
 {
-  memset(out, 0, sizeof(*out));
   out->struct_size = (uint32_t)sizeof(*out);
   out->version = KAFS_STATS_VERSION;
   out->request_flags = request_flags;
@@ -7327,67 +7326,74 @@ static void kafs_stats_snapshot(kafs_context_t *ctx, kafs_stats_t *out, uint32_t
   kafs_bitmap_unlock(ctx);
   out->fs_inodes_total = (uint64_t)kafs_sb_inocnt_get(ctx->c_superblock);
   out->fs_inodes_free = (uint64_t)(kafs_inocnt_t)kafs_sb_inocnt_free_get(ctx->c_superblock);
-
   out->hrl_entries_total = (uint64_t)kafs_sb_hrl_entry_cnt_get(ctx->c_superblock);
+}
 
-  if ((request_flags & KAFS_STATS_F_VERBOSE_SCAN) != 0)
+static void kafs_stats_snapshot_verbose_scan(kafs_context_t *ctx, kafs_stats_t *out,
+                                             uint32_t request_flags)
+{
+  if ((request_flags & KAFS_STATS_F_VERBOSE_SCAN) == 0)
+    return;
+
+  out->result_flags |= KAFS_STATS_R_VERBOSE_SCAN;
+
+  kafs_time_t oldest_tombstone = {0};
+  int have_oldest_tombstone = 0;
+  for (kafs_inocnt_t ino = KAFS_INO_ROOTDIR; ino < (kafs_inocnt_t)out->fs_inodes_total; ++ino)
   {
-    out->result_flags |= KAFS_STATS_R_VERBOSE_SCAN;
+    kafs_time_t dtime = {0};
+    int is_tombstone = 0;
 
-    kafs_time_t oldest_tombstone = {0};
-    int have_oldest_tombstone = 0;
-    for (kafs_inocnt_t ino = KAFS_INO_ROOTDIR; ino < (kafs_inocnt_t)out->fs_inodes_total; ++ino)
+    kafs_inode_lock(ctx, ino);
+    const kafs_sinode_t *inoent = kafs_ctx_inode_const(ctx, ino);
+    if (kafs_inode_is_tombstone(inoent))
     {
-      kafs_time_t dtime = {0};
-      int is_tombstone = 0;
-
-      kafs_inode_lock(ctx, ino);
-      const kafs_sinode_t *inoent = kafs_ctx_inode_const(ctx, ino);
-      if (kafs_inode_is_tombstone(inoent))
-      {
-        dtime = kafs_ino_dtime_get(inoent);
-        is_tombstone = 1;
-      }
-      kafs_inode_unlock(ctx, ino);
-
-      if (!is_tombstone)
-        continue;
-
-      out->tombstone_inodes++;
-      if (!have_oldest_tombstone || kafs_time_before(dtime, oldest_tombstone))
-      {
-        oldest_tombstone = dtime;
-        have_oldest_tombstone = 1;
-      }
+      dtime = kafs_ino_dtime_get(inoent);
+      is_tombstone = 1;
     }
-    if (have_oldest_tombstone)
-    {
-      out->tombstone_oldest_dtime_sec = (uint64_t)oldest_tombstone.tv_sec;
-      out->tombstone_oldest_dtime_nsec = (uint64_t)oldest_tombstone.tv_nsec;
-    }
+    kafs_inode_unlock(ctx, ino);
 
-    uint32_t entry_cnt = kafs_sb_hrl_entry_cnt_get(ctx->c_superblock);
-    kafs_hrl_entry_t *ents = kafs_hrl_entries_tbl(ctx);
-    if (ents)
+    if (!is_tombstone)
+      continue;
+
+    out->tombstone_inodes++;
+    if (!have_oldest_tombstone || kafs_time_before(dtime, oldest_tombstone))
     {
-      uint64_t used = 0, dup = 0, refsum = 0;
-      for (uint32_t i = 0; i < entry_cnt; ++i)
-      {
-        uint32_t r = ents[i].refcnt;
-        if (r)
-        {
-          used++;
-          refsum += r;
-          if (r > 1)
-            dup++;
-        }
-      }
-      out->hrl_entries_used = used;
-      out->hrl_entries_duplicated = dup;
-      out->hrl_refcnt_sum = refsum;
+      oldest_tombstone = dtime;
+      have_oldest_tombstone = 1;
     }
   }
+  if (have_oldest_tombstone)
+  {
+    out->tombstone_oldest_dtime_sec = (uint64_t)oldest_tombstone.tv_sec;
+    out->tombstone_oldest_dtime_nsec = (uint64_t)oldest_tombstone.tv_nsec;
+  }
 
+  uint32_t entry_cnt = kafs_sb_hrl_entry_cnt_get(ctx->c_superblock);
+  kafs_hrl_entry_t *ents = kafs_hrl_entries_tbl(ctx);
+  if (!ents)
+    return;
+
+  uint64_t used = 0;
+  uint64_t dup = 0;
+  uint64_t refsum = 0;
+  for (uint32_t i = 0; i < entry_cnt; ++i)
+  {
+    uint32_t refcnt = ents[i].refcnt;
+    if (refcnt == 0)
+      continue;
+    used++;
+    refsum += refcnt;
+    if (refcnt > 1)
+      dup++;
+  }
+  out->hrl_entries_used = used;
+  out->hrl_entries_duplicated = dup;
+  out->hrl_refcnt_sum = refsum;
+}
+
+static void kafs_stats_snapshot_hrl(kafs_context_t *ctx, kafs_stats_t *out)
+{
   out->hrl_put_calls = ctx->c_stat_hrl_put_calls;
   out->hrl_put_hits = ctx->c_stat_hrl_put_hits;
   out->hrl_put_misses = ctx->c_stat_hrl_put_misses;
@@ -7403,7 +7409,10 @@ static void kafs_stats_snapshot(kafs_context_t *ctx, kafs_stats_t *out, uint32_t
   out->hrl_rescue_attempts = ctx->c_stat_hrl_rescue_attempts;
   out->hrl_rescue_hits = ctx->c_stat_hrl_rescue_hits;
   out->hrl_rescue_evicts = ctx->c_stat_hrl_rescue_evicts;
+}
 
+static void kafs_stats_snapshot_locks(kafs_context_t *ctx, kafs_stats_t *out)
+{
   out->lock_hrl_bucket_acquire = ctx->c_stat_lock_hrl_bucket_acquire;
   out->lock_hrl_bucket_contended = ctx->c_stat_lock_hrl_bucket_contended;
   out->lock_hrl_bucket_wait_ns = ctx->c_stat_lock_hrl_bucket_wait_ns;
@@ -7419,7 +7428,10 @@ static void kafs_stats_snapshot(kafs_context_t *ctx, kafs_stats_t *out, uint32_t
   out->lock_inode_alloc_acquire = ctx->c_stat_lock_inode_alloc_acquire;
   out->lock_inode_alloc_contended = ctx->c_stat_lock_inode_alloc_contended;
   out->lock_inode_alloc_wait_ns = ctx->c_stat_lock_inode_alloc_wait_ns;
+}
 
+static void kafs_stats_snapshot_access(kafs_context_t *ctx, kafs_stats_t *out)
+{
   out->access_calls = ctx->c_stat_access_calls;
   out->access_path_walk_calls = ctx->c_stat_access_path_walk_calls;
   out->access_fh_fastpath_hits = ctx->c_stat_access_fh_fastpath_hits;
@@ -7428,7 +7440,10 @@ static void kafs_stats_snapshot(kafs_context_t *ctx, kafs_stats_t *out, uint32_t
   out->dir_snapshot_bytes = ctx->c_stat_dir_snapshot_bytes;
   out->dir_snapshot_meta_load_calls = ctx->c_stat_dir_snapshot_meta_load_calls;
   out->dirent_view_next_calls = ctx->c_stat_dirent_view_next_calls;
+}
 
+static void kafs_stats_snapshot_pwrite(kafs_context_t *ctx, kafs_stats_t *out)
+{
   out->pwrite_calls = ctx->c_stat_pwrite_calls;
   out->pwrite_bytes = ctx->c_stat_pwrite_bytes;
   out->pwrite_ns_iblk_read = ctx->c_stat_pwrite_ns_iblk_read;
@@ -7453,7 +7468,10 @@ static void kafs_stats_snapshot(kafs_context_t *ctx, kafs_stats_t *out, uint32_t
   out->iblk_write_ns_hrl_put = ctx->c_stat_iblk_write_ns_hrl_put;
   out->iblk_write_ns_legacy_blk_write = ctx->c_stat_iblk_write_ns_legacy_blk_write;
   out->iblk_write_ns_dec_ref = ctx->c_stat_iblk_write_ns_dec_ref;
+}
 
+static void kafs_stats_snapshot_alloc(kafs_context_t *ctx, kafs_stats_t *out)
+{
   out->blk_alloc_calls = ctx->c_stat_blk_alloc_calls;
   out->blk_alloc_claim_retries = ctx->c_stat_blk_alloc_claim_retries;
   out->blk_alloc_ns_scan = ctx->c_stat_blk_alloc_ns_scan;
@@ -7466,7 +7484,10 @@ static void kafs_stats_snapshot(kafs_context_t *ctx, kafs_stats_t *out, uint32_t
   out->blk_set_usage_ns_bit_update = ctx->c_stat_blk_set_usage_ns_bit_update;
   out->blk_set_usage_ns_freecnt_update = ctx->c_stat_blk_set_usage_ns_freecnt_update;
   out->blk_set_usage_ns_wtime_update = ctx->c_stat_blk_set_usage_ns_wtime_update;
+}
 
+static void kafs_stats_snapshot_bg_dedup(kafs_context_t *ctx, kafs_stats_t *out)
+{
   out->copy_share_attempt_blocks = ctx->c_stat_copy_share_attempt_blocks;
   out->copy_share_done_blocks = ctx->c_stat_copy_share_done_blocks;
   out->copy_share_fallback_blocks = ctx->c_stat_copy_share_fallback_blocks;
@@ -7487,12 +7508,16 @@ static void kafs_stats_snapshot(kafs_context_t *ctx, kafs_stats_t *out, uint32_t
   out->bg_dedup_last_direct_candidates = ctx->c_bg_dedup_last_direct_candidates;
   out->bg_dedup_last_replacements = ctx->c_bg_dedup_last_replacements;
   out->bg_dedup_idle_skip_streak = ctx->c_bg_dedup_idle_skip_streak;
+
   uint64_t now_ns = kafs_now_ns();
   if (ctx->c_bg_dedup_cold_start_due_ns > now_ns)
     out->bg_dedup_cold_start_due_ms = (ctx->c_bg_dedup_cold_start_due_ns - now_ns) / 1000000ull;
   else
     out->bg_dedup_cold_start_due_ms = 0;
+}
 
+static void kafs_stats_snapshot_pending_worker(kafs_context_t *ctx, kafs_stats_t *out)
+{
   out->pending_worker_start_calls =
       __atomic_load_n(&ctx->c_stat_pending_worker_start_calls, __ATOMIC_RELAXED);
   out->pending_worker_start_failures =
@@ -7521,6 +7546,20 @@ static void kafs_stats_snapshot(kafs_context_t *ctx, kafs_stats_t *out, uint32_t
     out->pending_queue_tail = hdr->tail;
   }
   pthread_mutex_unlock(&ctx->c_pending_worker_lock);
+}
+
+static void kafs_stats_snapshot(kafs_context_t *ctx, kafs_stats_t *out, uint32_t request_flags)
+{
+  memset(out, 0, sizeof(*out));
+  kafs_stats_snapshot_fs(ctx, out, request_flags);
+  kafs_stats_snapshot_verbose_scan(ctx, out, request_flags);
+  kafs_stats_snapshot_hrl(ctx, out);
+  kafs_stats_snapshot_locks(ctx, out);
+  kafs_stats_snapshot_access(ctx, out);
+  kafs_stats_snapshot_pwrite(ctx, out);
+  kafs_stats_snapshot_alloc(ctx, out);
+  kafs_stats_snapshot_bg_dedup(ctx, out);
+  kafs_stats_snapshot_pending_worker(ctx, out);
 }
 
 #ifdef __linux__

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -4568,6 +4568,162 @@ static int kafs_pwrite_commit_block(struct kafs_context *ctx, kafs_sinode_t *ino
   return kafs_ino_iblk_write(ctx, inoent, iblo, buf);
 }
 
+static void kafs_pwrite_record_write_latency(struct kafs_context *ctx, uint64_t t_w0, uint64_t t_w1)
+{
+  uint64_t d = t_w1 - t_w0;
+  __atomic_add_fetch(&ctx->c_stat_pwrite_ns_iblk_write, d, __ATOMIC_RELAXED);
+  kafs_stat_record_pwrite_iblk_write_latency(ctx, d);
+}
+
+static int kafs_pwrite_commit_block_timed(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                          kafs_iblkcnt_t iblo, const void *buf)
+{
+  uint64_t t_w0 = kafs_now_ns();
+  int rc = kafs_pwrite_commit_block(ctx, inoent, iblo, buf);
+  uint64_t t_w1 = kafs_now_ns();
+  kafs_pwrite_record_write_latency(ctx, t_w0, t_w1);
+  return rc;
+}
+
+static int kafs_pwrite_read_block_timed(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                        kafs_iblkcnt_t iblo, void *buf)
+{
+  uint64_t t_r0 = kafs_now_ns();
+  int rc = kafs_ino_iblk_read_or_zero(ctx, inoent, iblo, buf);
+  uint64_t t_r1 = kafs_now_ns();
+  __atomic_add_fetch(&ctx->c_stat_pwrite_ns_iblk_read, t_r1 - t_r0, __ATOMIC_RELAXED);
+  return rc;
+}
+
+static int kafs_pwrite_try_tail_only_store(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                           const void *buf, kafs_off_t size, kafs_off_t offset,
+                                           kafs_off_t filesize_new)
+{
+  kafs_blksize_t blksize = kafs_sb_blksize_get(ctx->c_superblock);
+  char smallbuf[blksize];
+  int rc = kafs_tailmeta_load_small_file_bytes(ctx, inoent, smallbuf, filesize_new);
+  if (rc < 0)
+    return rc;
+  memcpy(smallbuf + offset, buf, (size_t)size);
+  return kafs_tailmeta_store_tail_only(ctx, inoent, smallbuf, filesize_new);
+}
+
+static int kafs_pwrite_prepare_tail_layout(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                           const void *buf, kafs_off_t size, kafs_off_t offset,
+                                           kafs_off_t filesize, kafs_off_t filesize_new,
+                                           int *completed_out)
+{
+  kafs_blksize_t blksize = kafs_sb_blksize_get(ctx->c_superblock);
+  const kafs_sinode_taildesc_v5_t *taildesc = kafs_ctx_inode_taildesc_v5_const(ctx, inoent);
+
+  *completed_out = 0;
+  if (taildesc &&
+      kafs_ino_taildesc_v5_layout_kind_get(taildesc) == KAFS_TAIL_LAYOUT_MIXED_FULL_TAIL)
+  {
+    int rc = kafs_tailmeta_materialize_mixed_to_full_block(ctx, inoent);
+    if (rc < 0)
+      return rc;
+    taildesc = kafs_ctx_inode_taildesc_v5_const(ctx, inoent);
+  }
+
+  if (taildesc && kafs_ino_taildesc_v5_layout_kind_get(taildesc) == KAFS_TAIL_LAYOUT_TAIL_ONLY)
+  {
+    if (filesize_new < (kafs_off_t)blksize)
+    {
+      int rc = kafs_pwrite_try_tail_only_store(ctx, inoent, buf, size, offset, filesize_new);
+      if (rc < 0)
+        return rc;
+      *completed_out = 1;
+      return 0;
+    }
+
+    int rc = kafs_tailmeta_promote_tail_only_to_full_block(ctx, inoent);
+    if (rc < 0)
+      return rc;
+  }
+
+  if (kafs_tailmeta_inode_is_regular_v5(ctx, inoent) &&
+      filesize_new > (kafs_off_t)KAFS_INODE_DIRECT_BYTES && filesize_new < (kafs_off_t)blksize &&
+      filesize <= (kafs_off_t)KAFS_INODE_DIRECT_BYTES)
+  {
+    int rc = kafs_pwrite_try_tail_only_store(ctx, inoent, buf, size, offset, filesize_new);
+    if (rc < 0)
+      return rc;
+    *completed_out = 1;
+  }
+  return 0;
+}
+
+static int kafs_pwrite_extend_inode_size(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                         kafs_off_t *filesize, kafs_off_t filesize_new)
+{
+  if (*filesize >= filesize_new)
+    return 0;
+
+  kafs_blksize_t blksize = kafs_sb_blksize_get(ctx->c_superblock);
+  kafs_ino_size_set(inoent, filesize_new);
+  if (*filesize != 0 && *filesize <= KAFS_INODE_DIRECT_BYTES &&
+      filesize_new > KAFS_INODE_DIRECT_BYTES)
+  {
+    char wbuf[blksize];
+    memset(wbuf, 0, blksize);
+    memcpy(wbuf, inoent->i_blkreftbl, *filesize);
+    memset(inoent->i_blkreftbl, 0, sizeof(inoent->i_blkreftbl));
+    int rc = kafs_ino_iblk_write(ctx, inoent, 0, wbuf);
+    if (rc < 0)
+      return rc;
+  }
+
+  *filesize = filesize_new;
+  return 0;
+}
+
+static void kafs_pwrite_sync_regular_taildesc(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                              kafs_off_t filesize)
+{
+  if (!kafs_tailmeta_inode_is_regular_v5(ctx, inoent))
+    return;
+  if (filesize <= (kafs_off_t)KAFS_INODE_DIRECT_BYTES)
+    kafs_tailmeta_inode_taildesc_set_inline(ctx, inoent);
+  else
+    kafs_tailmeta_inode_taildesc_set_full_block(ctx, inoent);
+}
+
+static int kafs_pwrite_write_head_fragment(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                           const char *buf, kafs_off_t size, kafs_off_t offset,
+                                           size_t *size_written_out, int *completed_out)
+{
+  kafs_logblksize_t log_blksize = kafs_sb_log_blksize_get(ctx->c_superblock);
+  kafs_blksize_t blksize = kafs_sb_blksize_get(ctx->c_superblock);
+  kafs_blksize_t offset_blksize = offset & (blksize - 1);
+
+  *completed_out = 0;
+  if (offset_blksize == 0 && size - *size_written_out >= blksize)
+    return 0;
+
+  kafs_iblkcnt_t iblo = offset >> log_blksize;
+  char wbuf[blksize];
+  int rc = kafs_pwrite_read_block_timed(ctx, inoent, iblo, wbuf);
+  if (rc < 0)
+    return rc;
+  if (size < blksize - offset_blksize)
+  {
+    memcpy(wbuf + offset_blksize, buf, (size_t)size);
+    rc = kafs_pwrite_commit_block_timed(ctx, inoent, iblo, wbuf);
+    if (rc < 0)
+      return rc;
+    *completed_out = 1;
+    return 0;
+  }
+
+  memcpy(wbuf + offset_blksize, buf, blksize - offset_blksize);
+  rc = kafs_pwrite_commit_block_timed(ctx, inoent, iblo, wbuf);
+  if (rc < 0)
+    return rc;
+  *size_written_out += blksize - offset_blksize;
+  return 0;
+}
+
 /// @brief inode 毎にデータを読み出す
 /// @param ctx コンテキスト
 /// @param inoent inode テーブルエントリ
@@ -4597,7 +4753,7 @@ static ssize_t kafs_pwrite(struct kafs_context *ctx, kafs_sinode_t *inoent, cons
   kafs_logblksize_t log_blksize = kafs_sb_log_blksize_get(ctx->c_superblock);
   kafs_blksize_t blksize = kafs_sb_blksize_get(ctx->c_superblock);
   kafs_off_t filesize_new = offset + size;
-  const kafs_sinode_taildesc_v5_t *taildesc = kafs_ctx_inode_taildesc_v5_const(ctx, inoent);
+  const char *srcbuf = (const char *)buf;
 
   if (size == 0)
     return 0;
@@ -4606,61 +4762,14 @@ static ssize_t kafs_pwrite(struct kafs_context *ctx, kafs_sinode_t *inoent, cons
   __atomic_add_fetch(&ctx->c_stat_pwrite_bytes, (uint64_t)size, __ATOMIC_RELAXED);
   kafs_diag_log_first_pwrite_after_create(ctx, inoent, buf, size, offset);
 
-  if (taildesc &&
-      kafs_ino_taildesc_v5_layout_kind_get(taildesc) == KAFS_TAIL_LAYOUT_MIXED_FULL_TAIL)
-  {
-    KAFS_PWRITE_TRY(kafs_tailmeta_materialize_mixed_to_full_block(ctx, inoent));
-    taildesc = kafs_ctx_inode_taildesc_v5_const(ctx, inoent);
-  }
-
-  if (taildesc && kafs_ino_taildesc_v5_layout_kind_get(taildesc) == KAFS_TAIL_LAYOUT_TAIL_ONLY)
-  {
-    if (filesize_new < (kafs_off_t)blksize)
-    {
-      char smallbuf[blksize];
-      KAFS_PWRITE_TRY(kafs_tailmeta_load_small_file_bytes(ctx, inoent, smallbuf, filesize_new));
-      memcpy(smallbuf + offset, buf, (size_t)size);
-      KAFS_PWRITE_TRY(kafs_tailmeta_store_tail_only(ctx, inoent, smallbuf, filesize_new));
-      return size;
-    }
-    KAFS_PWRITE_TRY(kafs_tailmeta_promote_tail_only_to_full_block(ctx, inoent));
-    taildesc = kafs_ctx_inode_taildesc_v5_const(ctx, inoent);
-  }
-
-  if (kafs_tailmeta_inode_is_regular_v5(ctx, inoent) &&
-      filesize_new > (kafs_off_t)KAFS_INODE_DIRECT_BYTES && filesize_new < (kafs_off_t)blksize &&
-      filesize <= (kafs_off_t)KAFS_INODE_DIRECT_BYTES)
-  {
-    char smallbuf[blksize];
-    KAFS_PWRITE_TRY(kafs_tailmeta_load_small_file_bytes(ctx, inoent, smallbuf, filesize_new));
-    memcpy(smallbuf + offset, buf, (size_t)size);
-    KAFS_PWRITE_TRY(kafs_tailmeta_store_tail_only(ctx, inoent, smallbuf, filesize_new));
+  int completed = 0;
+  KAFS_PWRITE_TRY(kafs_pwrite_prepare_tail_layout(ctx, inoent, buf, size, offset, filesize,
+                                                  filesize_new, &completed));
+  if (completed)
     return size;
-  }
 
-  if (filesize < filesize_new)
-  {
-    // サイズ拡大時
-    kafs_ino_size_set(inoent, filesize_new);
-    if (filesize != 0 && filesize <= KAFS_INODE_DIRECT_BYTES &&
-        filesize_new > KAFS_INODE_DIRECT_BYTES)
-    {
-      char wbuf[blksize];
-      memset(wbuf, 0, blksize);
-      memcpy(wbuf, inoent->i_blkreftbl, filesize);
-      memset(inoent->i_blkreftbl, 0, sizeof(inoent->i_blkreftbl));
-      KAFS_PWRITE_TRY(kafs_ino_iblk_write(ctx, inoent, 0, wbuf));
-    }
-    filesize = filesize_new;
-  }
-
-  if (kafs_tailmeta_inode_is_regular_v5(ctx, inoent))
-  {
-    if (filesize <= (kafs_off_t)KAFS_INODE_DIRECT_BYTES)
-      kafs_tailmeta_inode_taildesc_set_inline(ctx, inoent);
-    else
-      kafs_tailmeta_inode_taildesc_set_full_block(ctx, inoent);
-  }
+  KAFS_PWRITE_TRY(kafs_pwrite_extend_inode_size(ctx, inoent, &filesize, filesize_new));
+  kafs_pwrite_sync_regular_taildesc(ctx, inoent, filesize);
 
   size_t size_written = 0;
   // 60バイト以下は直接
@@ -4670,39 +4779,10 @@ static ssize_t kafs_pwrite(struct kafs_context *ctx, kafs_sinode_t *inoent, cons
     return size;
   }
 
-  kafs_blksize_t offset_blksize = offset & (blksize - 1);
-  if (offset_blksize > 0 || size - size_written < blksize)
-  {
-    // 1ブロック目で端数が出る場合
-    kafs_iblkcnt_t iblo = offset >> log_blksize;
-    // 書き戻しバッファ
-    char wbuf[blksize];
-    uint64_t t_r0 = kafs_now_ns();
-    KAFS_PWRITE_TRY(kafs_ino_iblk_read_or_zero(ctx, inoent, iblo, wbuf));
-    uint64_t t_r1 = kafs_now_ns();
-    __atomic_add_fetch(&ctx->c_stat_pwrite_ns_iblk_read, t_r1 - t_r0, __ATOMIC_RELAXED);
-    if (size < blksize - offset_blksize)
-    {
-      // 1ブロックのみの場合
-      memcpy(wbuf + offset_blksize, buf, size);
-      uint64_t t_w0 = kafs_now_ns();
-      KAFS_PWRITE_TRY(kafs_pwrite_commit_block(ctx, inoent, iblo, wbuf));
-      uint64_t t_w1 = kafs_now_ns();
-      uint64_t d = t_w1 - t_w0;
-      __atomic_add_fetch(&ctx->c_stat_pwrite_ns_iblk_write, d, __ATOMIC_RELAXED);
-      kafs_stat_record_pwrite_iblk_write_latency(ctx, d);
-      goto out_success;
-    }
-    // ブロックの残り分を書き込む
-    memcpy(wbuf + offset_blksize, buf, blksize - offset_blksize);
-    uint64_t t_w0 = kafs_now_ns();
-    KAFS_PWRITE_TRY(kafs_pwrite_commit_block(ctx, inoent, iblo, wbuf));
-    uint64_t t_w1 = kafs_now_ns();
-    uint64_t d = t_w1 - t_w0;
-    __atomic_add_fetch(&ctx->c_stat_pwrite_ns_iblk_write, d, __ATOMIC_RELAXED);
-    kafs_stat_record_pwrite_iblk_write_latency(ctx, d);
-    size_written += blksize - offset_blksize;
-  }
+  KAFS_PWRITE_TRY(kafs_pwrite_write_head_fragment(ctx, inoent, srcbuf, size, offset, &size_written,
+                                                  &completed));
+  if (completed)
+    goto out_success;
 
   while (size_written < size)
   {
@@ -4710,25 +4790,12 @@ static ssize_t kafs_pwrite(struct kafs_context *ctx, kafs_sinode_t *inoent, cons
     if (size - size_written < blksize)
     {
       char wbuf[blksize];
-      uint64_t t_r0 = kafs_now_ns();
-      KAFS_PWRITE_TRY(kafs_ino_iblk_read_or_zero(ctx, inoent, iblo, wbuf));
-      uint64_t t_r1 = kafs_now_ns();
-      __atomic_add_fetch(&ctx->c_stat_pwrite_ns_iblk_read, t_r1 - t_r0, __ATOMIC_RELAXED);
-      memcpy(wbuf, buf + size_written, size - size_written);
-      uint64_t t_w0 = kafs_now_ns();
-      KAFS_PWRITE_TRY(kafs_pwrite_commit_block(ctx, inoent, iblo, wbuf));
-      uint64_t t_w1 = kafs_now_ns();
-      uint64_t d = t_w1 - t_w0;
-      __atomic_add_fetch(&ctx->c_stat_pwrite_ns_iblk_write, d, __ATOMIC_RELAXED);
-      kafs_stat_record_pwrite_iblk_write_latency(ctx, d);
+      KAFS_PWRITE_TRY(kafs_pwrite_read_block_timed(ctx, inoent, iblo, wbuf));
+      memcpy(wbuf, srcbuf + size_written, size - size_written);
+      KAFS_PWRITE_TRY(kafs_pwrite_commit_block_timed(ctx, inoent, iblo, wbuf));
       goto out_success;
     }
-    uint64_t t_w0 = kafs_now_ns();
-    KAFS_PWRITE_TRY(kafs_pwrite_commit_block(ctx, inoent, iblo, buf + size_written));
-    uint64_t t_w1 = kafs_now_ns();
-    uint64_t d = t_w1 - t_w0;
-    __atomic_add_fetch(&ctx->c_stat_pwrite_ns_iblk_write, d, __ATOMIC_RELAXED);
-    kafs_stat_record_pwrite_iblk_write_latency(ctx, d);
+    KAFS_PWRITE_TRY(kafs_pwrite_commit_block_timed(ctx, inoent, iblo, srcbuf + size_written));
     size_written += blksize;
   }
 out_success:

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -5669,6 +5669,30 @@ static int kafs_dirent_remove(struct kafs_context *ctx, kafs_sinode_t *inoent_di
   return rc;
 }
 
+static kafs_bool_t kafs_access_group_match(gid_t file_gid, gid_t gid, size_t ngroups,
+                                           const gid_t groups[])
+{
+  if (gid == file_gid)
+    return KAFS_TRUE;
+  for (size_t i = 0; i < ngroups; ++i)
+    if (file_gid == groups[i])
+      return KAFS_TRUE;
+  return KAFS_FALSE;
+}
+
+static kafs_bool_t kafs_access_allowed(mode_t mode, mode_t other_bit, mode_t user_bit,
+                                       mode_t group_bit, uid_t uid, uid_t file_uid, gid_t gid,
+                                       gid_t file_gid, size_t ngroups, const gid_t groups[])
+{
+  if (mode & other_bit)
+    return KAFS_TRUE;
+  if ((mode & user_bit) && uid == file_uid)
+    return KAFS_TRUE;
+  if ((mode & group_bit) && kafs_access_group_match(file_gid, gid, ngroups, groups))
+    return KAFS_TRUE;
+  return KAFS_FALSE;
+}
+
 // cppcheck-suppress constParameterCallback
 static int kafs_access_check(int ok, kafs_sinode_t *inoent, kafs_bool_t is_dir, uid_t uid,
                              gid_t gid, size_t ngroups,
@@ -5703,71 +5727,17 @@ static int kafs_access_check(int ok, kafs_sinode_t *inoent, kafs_bool_t is_dir, 
   }
 
   if (ok & R_OK)
-  {
-    kafs_bool_t result = KAFS_FALSE;
-    if (mode & S_IROTH)
-      result = KAFS_TRUE;
-    else if (mode & S_IRUSR && uid == fuid)
-      result = KAFS_TRUE;
-    else if (mode & S_IRGRP)
-    {
-      if (gid == fgid)
-        result = KAFS_TRUE;
-      else
-        for (size_t i = 0; i < ngroups; i++)
-          if (fgid == groups[i])
-          {
-            result = KAFS_TRUE;
-            break;
-          }
-    }
-    if (!result)
+    if (!kafs_access_allowed(mode, S_IROTH, S_IRUSR, S_IRGRP, uid, fuid, gid, fgid, ngroups,
+                             groups))
       return -EACCES;
-  }
   if (ok & W_OK)
-  {
-    kafs_bool_t result = KAFS_FALSE;
-    if (mode & S_IWOTH)
-      result = KAFS_TRUE;
-    else if (mode & S_IWUSR && uid == fuid)
-      result = KAFS_TRUE;
-    else if (mode & S_IWGRP)
-    {
-      if (gid == fgid)
-        result = KAFS_TRUE;
-      else
-        for (size_t i = 0; i < ngroups; i++)
-          if (fgid == groups[i])
-          {
-            result = KAFS_TRUE;
-            break;
-          }
-    }
-    if (!result)
+    if (!kafs_access_allowed(mode, S_IWOTH, S_IWUSR, S_IWGRP, uid, fuid, gid, fgid, ngroups,
+                             groups))
       return -EACCES;
-  }
   if (ok & X_OK)
-  {
-    kafs_bool_t result = KAFS_FALSE;
-    if (mode & S_IXOTH)
-      result = KAFS_TRUE;
-    else if (mode & S_IXUSR && uid == fuid)
-      result = KAFS_TRUE;
-    else if (mode & S_IXGRP)
-    {
-      if (gid == fgid)
-        result = KAFS_TRUE;
-      else
-        for (size_t i = 0; i < ngroups; i++)
-          if (fgid == groups[i])
-          {
-            result = KAFS_TRUE;
-            break;
-          }
-    }
-    if (!result)
+    if (!kafs_access_allowed(mode, S_IXOTH, S_IXUSR, S_IXGRP, uid, fuid, gid, fgid, ngroups,
+                             groups))
       return -EACCES;
-  }
   return KAFS_SUCCESS;
 }
 

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -9070,6 +9070,190 @@ static int kafs_op_access(const char *path, int mode)
   return 0;
 }
 
+static int kafs_split_parent_basename(const char *path, char *path_copy, const char **dir,
+                                      char **base)
+{
+  strcpy(path_copy, path);
+  *dir = path_copy;
+  *base = strrchr(path_copy, '/');
+  if (*dir == *base)
+    *dir = "/";
+  **base = '\0';
+  (*base)++;
+  if ((*base)[0] == '\0')
+    return -EINVAL;
+  if (strcmp(*base, ".") == 0 || strcmp(*base, "..") == 0)
+    return -EINVAL;
+  return 0;
+}
+
+static size_t kafs_rename_prepare_lock_list(uint32_t lock_list[4], uint32_t ino_from_dir,
+                                            uint32_t ino_to_dir, uint32_t ino_src_u32,
+                                            uint32_t ino_dst_u32)
+{
+  size_t lock_n = 0;
+  lock_list[lock_n++] = ino_from_dir;
+  if (ino_to_dir != ino_from_dir)
+    lock_list[lock_n++] = ino_to_dir;
+  if (ino_src_u32 != ino_from_dir && ino_src_u32 != ino_to_dir)
+    lock_list[lock_n++] = ino_src_u32;
+  if (ino_dst_u32 != UINT32_MAX && ino_dst_u32 != ino_from_dir && ino_dst_u32 != ino_to_dir &&
+      ino_dst_u32 != ino_src_u32)
+    lock_list[lock_n++] = ino_dst_u32;
+
+  for (size_t i = 0; i < lock_n; ++i)
+    for (size_t j = i + 1; j < lock_n; ++j)
+      if (lock_list[j] < lock_list[i])
+      {
+        uint32_t tmp = lock_list[i];
+        lock_list[i] = lock_list[j];
+        lock_list[j] = tmp;
+      }
+
+  return lock_n;
+}
+
+static void kafs_rename_lock_list_acquire(struct kafs_context *ctx, const uint32_t *lock_list,
+                                          size_t lock_n)
+{
+  for (size_t i = 0; i < lock_n; ++i)
+    kafs_inode_lock(ctx, lock_list[i]);
+}
+
+static void kafs_rename_lock_list_release(struct kafs_context *ctx, const uint32_t *lock_list,
+                                          size_t lock_n)
+{
+  for (size_t i = lock_n; i > 0; --i)
+    kafs_inode_unlock(ctx, lock_list[i - 1]);
+}
+
+static int kafs_rename_prepare_existing_destination_locked(struct kafs_context *ctx, uint64_t jseq,
+                                                           const uint32_t *lock_list, size_t lock_n,
+                                                           int src_is_dir, int exists_to,
+                                                           kafs_sinode_t *inoent_to_exist)
+{
+  if (!src_is_dir || exists_to != 0 || !inoent_to_exist)
+    return 0;
+
+  int empty_rc = kafs_dir_is_empty_locked(ctx, inoent_to_exist);
+  if (empty_rc < 0)
+  {
+    kafs_journal_abort(ctx, jseq, "dst_dir_empty=%d", empty_rc);
+    kafs_rename_lock_list_release(ctx, lock_list, lock_n);
+    return empty_rc;
+  }
+  if (empty_rc == 0)
+  {
+    kafs_journal_abort(ctx, jseq, "DST_DIR_NOT_EMPTY");
+    kafs_rename_lock_list_release(ctx, lock_list, lock_n);
+    return -ENOTEMPTY;
+  }
+
+  int rr = kafs_dirent_remove(ctx, inoent_to_exist, "..");
+  if (rr < 0)
+  {
+    kafs_journal_abort(ctx, jseq, "dst_remove_dotdot=%d", rr);
+    kafs_rename_lock_list_release(ctx, lock_list, lock_n);
+    return rr;
+  }
+
+  return 0;
+}
+
+static int kafs_rename_move_entries_locked(struct kafs_context *ctx, uint64_t jseq,
+                                           const uint32_t *lock_list, size_t lock_n,
+                                           kafs_sinode_t *inoent_dir_from,
+                                           kafs_sinode_t *inoent_dir_to, kafs_inocnt_t ino_src,
+                                           const char *from_base, const char *to_base,
+                                           kafs_inocnt_t *removed_dst_ino)
+{
+  int rc_locked;
+  kafs_inocnt_t moved_ino = KAFS_INO_NONE;
+
+  *removed_dst_ino = KAFS_INO_NONE;
+  rc_locked = kafs_dirent_remove_nolink(ctx, inoent_dir_to, to_base, removed_dst_ino);
+  if (rc_locked < 0 && rc_locked != -ENOENT)
+  {
+    kafs_journal_abort(ctx, jseq, "dst_remove=%d", rc_locked);
+    kafs_rename_lock_list_release(ctx, lock_list, lock_n);
+    return rc_locked;
+  }
+  if (rc_locked == -ENOENT)
+    *removed_dst_ino = KAFS_INO_NONE;
+
+  rc_locked = kafs_dirent_remove_nolink(ctx, inoent_dir_from, from_base, &moved_ino);
+  if (rc_locked < 0)
+  {
+    kafs_journal_abort(ctx, jseq, "src_remove=%d", rc_locked);
+    kafs_rename_lock_list_release(ctx, lock_list, lock_n);
+    return rc_locked;
+  }
+  if (moved_ino != ino_src)
+  {
+    kafs_journal_abort(ctx, jseq, "ESTALE moved_ino=%u src=%u", (unsigned)moved_ino,
+                       (unsigned)ino_src);
+    kafs_rename_lock_list_release(ctx, lock_list, lock_n);
+    return -ESTALE;
+  }
+
+  rc_locked = kafs_dirent_add_nolink(ctx, inoent_dir_to, ino_src, to_base);
+  if (rc_locked < 0)
+  {
+    kafs_journal_abort(ctx, jseq, "dst_add=%d", rc_locked);
+    kafs_rename_lock_list_release(ctx, lock_list, lock_n);
+    return rc_locked;
+  }
+
+  return 0;
+}
+
+static int kafs_rename_update_dotdot_locked(struct kafs_context *ctx, uint64_t jseq,
+                                            const uint32_t *lock_list, size_t lock_n,
+                                            int src_is_dir, uint32_t ino_from_dir,
+                                            uint32_t ino_to_dir, kafs_sinode_t *inoent_src)
+{
+  if (!src_is_dir || ino_from_dir == ino_to_dir)
+    return 0;
+
+  int rr = kafs_dirent_remove(ctx, inoent_src, "..");
+  if (rr < 0)
+  {
+    kafs_journal_abort(ctx, jseq, "src_remove_dotdot=%d", rr);
+    kafs_rename_lock_list_release(ctx, lock_list, lock_n);
+    return rr;
+  }
+  rr = kafs_dirent_add(ctx, inoent_src, (kafs_inocnt_t)ino_to_dir, "..");
+  if (rr < 0)
+  {
+    kafs_journal_abort(ctx, jseq, "src_add_dotdot=%d", rr);
+    kafs_rename_lock_list_release(ctx, lock_list, lock_n);
+    return rr;
+  }
+
+  return 0;
+}
+
+static void kafs_rename_finalize_replaced_inode(struct kafs_context *ctx,
+                                                kafs_inocnt_t removed_dst_ino)
+{
+  if (removed_dst_ino == KAFS_INO_NONE)
+    return;
+
+  int reclaim_dst_now = kafs_tombstone_pressure(ctx);
+  kafs_inode_lock(ctx, (uint32_t)removed_dst_ino);
+  int reclaimed_dst = 0;
+  (void)kafs_inode_drop_link_locked(ctx, removed_dst_ino, reclaim_dst_now, &reclaimed_dst);
+  kafs_inode_unlock(ctx, (uint32_t)removed_dst_ino);
+
+  if (reclaimed_dst)
+  {
+    kafs_inode_alloc_lock(ctx);
+    (void)kafs_sb_inocnt_free_incr(ctx->c_superblock);
+    kafs_sb_wtime_set(ctx->c_superblock, kafs_now());
+    kafs_inode_alloc_unlock(ctx);
+  }
+}
+
 static int kafs_op_rename(const char *from, const char *to, unsigned int flags)
 {
   // 最小実装: 通常ファイルのみ対応。RENAME_NOREPLACE は尊重。その他のフラグは未対応。
@@ -9104,32 +9288,19 @@ static int kafs_op_rename(const char *from, const char *to, unsigned int flags)
   if (!S_ISREG(src_mode) && !S_ISLNK(src_mode) && !src_is_dir)
     return -EOPNOTSUPP;
 
-  // パス分解
   char from_copy[strlen(from) + 1];
-  strcpy(from_copy, from);
   const char *from_dir = from_copy;
-  char *from_base = strrchr(from_copy, '/');
-  if (from_dir == from_base)
-    from_dir = "/";
-  *from_base = '\0';
-  from_base++;
-  if (from_base[0] == '\0')
-    return -EINVAL;
-  if (strcmp(from_base, ".") == 0 || strcmp(from_base, "..") == 0)
-    return -EINVAL;
+  char *from_base = NULL;
+  rc = kafs_split_parent_basename(from, from_copy, &from_dir, &from_base);
+  if (rc < 0)
+    return rc;
 
   char to_copy[strlen(to) + 1];
-  strcpy(to_copy, to);
   const char *to_dir = to_copy;
-  char *to_base = strrchr(to_copy, '/');
-  if (to_dir == to_base)
-    to_dir = "/";
-  *to_base = '\0';
-  to_base++;
-  if (to_base[0] == '\0')
-    return -EINVAL;
-  if (strcmp(to_base, ".") == 0 || strcmp(to_base, "..") == 0)
-    return -EINVAL;
+  char *to_base = NULL;
+  rc = kafs_split_parent_basename(to, to_copy, &to_dir, &to_base);
+  if (rc < 0)
+    return rc;
 
   uint64_t jseq = kafs_journal_begin(ctx, "RENAME", "from=%s to=%s flags=%u", from, to, flags);
 
@@ -9197,141 +9368,29 @@ static int kafs_op_rename(const char *from, const char *to, unsigned int flags)
     ino_dst_u32 = kafs_ctx_ino_no(ctx, inoent_to_exist);
 
   uint32_t lock_list[4];
-  size_t lock_n = 0;
-  lock_list[lock_n++] = ino_from_dir;
-  if (ino_to_dir != ino_from_dir)
-    lock_list[lock_n++] = ino_to_dir;
-  if (ino_src_u32 != ino_from_dir && ino_src_u32 != ino_to_dir)
-    lock_list[lock_n++] = ino_src_u32;
-  if (ino_dst_u32 != UINT32_MAX && ino_dst_u32 != ino_from_dir && ino_dst_u32 != ino_to_dir &&
-      ino_dst_u32 != ino_src_u32)
-    lock_list[lock_n++] = ino_dst_u32;
+  size_t lock_n =
+      kafs_rename_prepare_lock_list(lock_list, ino_from_dir, ino_to_dir, ino_src_u32, ino_dst_u32);
+  kafs_rename_lock_list_acquire(ctx, lock_list, lock_n);
 
-  for (size_t i = 0; i < lock_n; ++i)
-    for (size_t j = i + 1; j < lock_n; ++j)
-      if (lock_list[j] < lock_list[i])
-      {
-        uint32_t tmp = lock_list[i];
-        lock_list[i] = lock_list[j];
-        lock_list[j] = tmp;
-      }
+  rc = kafs_rename_prepare_existing_destination_locked(ctx, jseq, lock_list, lock_n, src_is_dir,
+                                                       exists_to, inoent_to_exist);
+  if (rc < 0)
+    return rc;
 
-  for (size_t i = 0; i < lock_n; ++i)
-    kafs_inode_lock(ctx, lock_list[i]);
-
-  // ディレクトリ置換の場合は、空 (".." のみ) を確認して ".." を除去する（親リンク数整合）。
-  if (src_is_dir && exists_to == 0 && inoent_to_exist)
-  {
-    int empty_rc = kafs_dir_is_empty_locked(ctx, inoent_to_exist);
-    if (empty_rc < 0)
-    {
-      kafs_journal_abort(ctx, jseq, "dst_dir_empty=%d", empty_rc);
-      for (size_t i = lock_n; i > 0; --i)
-        kafs_inode_unlock(ctx, lock_list[i - 1]);
-      return empty_rc;
-    }
-    if (empty_rc == 0)
-    {
-      kafs_journal_abort(ctx, jseq, "DST_DIR_NOT_EMPTY");
-      for (size_t i = lock_n; i > 0; --i)
-        kafs_inode_unlock(ctx, lock_list[i - 1]);
-      return -ENOTEMPTY;
-    }
-
-    int rr = kafs_dirent_remove(ctx, inoent_to_exist, "..");
-    if (rr < 0)
-    {
-      kafs_journal_abort(ctx, jseq, "dst_remove_dotdot=%d", rr);
-      for (size_t i = lock_n; i > 0; --i)
-        kafs_inode_unlock(ctx, lock_list[i - 1]);
-      return rr;
-    }
-  }
-
-  // 置換先が存在していればエントリを除去（rename では moved inode の linkcount は変えない）
   kafs_inocnt_t removed_dst_ino = KAFS_INO_NONE;
-  if (exists_to == 0)
-  {
-    // Remove dirent only; decrement linkcount later under inode lock.
-    int rc_locked = kafs_dirent_remove_nolink(ctx, inoent_dir_to, to_base, &removed_dst_ino);
-    if (rc_locked < 0)
-    {
-      kafs_journal_abort(ctx, jseq, "dst_remove=%d", rc_locked);
-      for (size_t i = lock_n; i > 0; --i)
-        kafs_inode_unlock(ctx, lock_list[i - 1]);
-      return rc_locked;
-    }
-  }
-  // from から削除（rename ではリンク数を変更しない）
-  kafs_inocnt_t moved_ino = KAFS_INO_NONE;
-  int rc_locked = kafs_dirent_remove_nolink(ctx, inoent_dir_from, from_base, &moved_ino);
-  if (rc_locked < 0)
-  {
-    kafs_journal_abort(ctx, jseq, "src_remove=%d", rc_locked);
-    for (size_t i = lock_n; i > 0; --i)
-      kafs_inode_unlock(ctx, lock_list[i - 1]);
-    return rc_locked;
-  }
-  if (moved_ino != ino_src)
-  {
-    kafs_journal_abort(ctx, jseq, "ESTALE moved_ino=%u src=%u", (unsigned)moved_ino,
-                       (unsigned)ino_src);
-    for (size_t i = lock_n; i > 0; --i)
-      kafs_inode_unlock(ctx, lock_list[i - 1]);
-    return -ESTALE;
-  }
-  // to に追加（rename ではリンク数を変更しない）
-  rc_locked = kafs_dirent_add_nolink(ctx, inoent_dir_to, ino_src, to_base);
-  if (rc_locked < 0)
-  {
-    kafs_journal_abort(ctx, jseq, "dst_add=%d", rc_locked);
-    for (size_t i = lock_n; i > 0; --i)
-      kafs_inode_unlock(ctx, lock_list[i - 1]);
-    return rc_locked;
-  }
+  rc = kafs_rename_move_entries_locked(ctx, jseq, lock_list, lock_n, inoent_dir_from, inoent_dir_to,
+                                       ino_src, from_base, to_base, &removed_dst_ino);
+  if (rc < 0)
+    return rc;
 
-  // ディレクトリを親またぎで移動した場合は、".." を新しい親へ付け替える。
-  if (src_is_dir && ino_from_dir != ino_to_dir)
-  {
-    int rr = kafs_dirent_remove(ctx, inoent_src, "..");
-    if (rr < 0)
-    {
-      kafs_journal_abort(ctx, jseq, "src_remove_dotdot=%d", rr);
-      for (size_t i = lock_n; i > 0; --i)
-        kafs_inode_unlock(ctx, lock_list[i - 1]);
-      return rr;
-    }
-    rr = kafs_dirent_add(ctx, inoent_src, (kafs_inocnt_t)ino_to_dir, "..");
-    if (rr < 0)
-    {
-      kafs_journal_abort(ctx, jseq, "src_add_dotdot=%d", rr);
-      for (size_t i = lock_n; i > 0; --i)
-        kafs_inode_unlock(ctx, lock_list[i - 1]);
-      return rr;
-    }
-  }
+  rc = kafs_rename_update_dotdot_locked(ctx, jseq, lock_list, lock_n, src_is_dir, ino_from_dir,
+                                        ino_to_dir, inoent_src);
+  if (rc < 0)
+    return rc;
 
-  // ロック解除（取得の逆順）
-  for (size_t i = lock_n; i > 0; --i)
-    kafs_inode_unlock(ctx, lock_list[i - 1]);
+  kafs_rename_lock_list_release(ctx, lock_list, lock_n);
 
-  // If we replaced an existing dst, decrement its linkcount under inode lock.
-  if (removed_dst_ino != KAFS_INO_NONE)
-  {
-    int reclaim_dst_now = kafs_tombstone_pressure(ctx);
-    kafs_inode_lock(ctx, (uint32_t)removed_dst_ino);
-    int reclaimed_dst = 0;
-    (void)kafs_inode_drop_link_locked(ctx, removed_dst_ino, reclaim_dst_now, &reclaimed_dst);
-    kafs_inode_unlock(ctx, (uint32_t)removed_dst_ino);
-
-    if (reclaimed_dst)
-    {
-      kafs_inode_alloc_lock(ctx);
-      (void)kafs_sb_inocnt_free_incr(ctx->c_superblock);
-      kafs_sb_wtime_set(ctx->c_superblock, kafs_now());
-      kafs_inode_alloc_unlock(ctx);
-    }
-  }
+  kafs_rename_finalize_replaced_inode(ctx, removed_dst_ino);
 
   kafs_journal_commit(ctx, jseq);
   kafs_dlog(2, "%s: exit rc=0 from=%s to=%s flags=%u\n", __func__, from, to, flags);

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -11628,7 +11628,7 @@ static int kafs_main_handle_pending_token(kafs_main_options_t *opts, const char 
   return 0;
 }
 
-static int kafs_main_handle_bg_dedup_token(kafs_main_options_t *opts, const char *tok)
+static int kafs_main_handle_bg_dedup_scan_token(kafs_main_options_t *opts, const char *tok)
 {
   if (strcmp(tok, "bg_dedup_scan") == 0 || strcmp(tok, "bg_dedup_scan=on") == 0 ||
       strcmp(tok, "dedup_scan") == 0 || strcmp(tok, "dedup_scan=on") == 0)
@@ -11643,13 +11643,14 @@ static int kafs_main_handle_bg_dedup_token(kafs_main_options_t *opts, const char
     return 1;
   }
 
-  int rc = kafs_main_parse_token_onoff_alias2(
+  return kafs_main_parse_token_onoff_alias2(
       tok, "bg_dedup_scan=", "dedup_scan=", &opts->bg_dedup_scan_enabled,
       "dedup_scan/bg_dedup_scan");
-  if (rc != 0)
-    return rc;
+}
 
-  rc = kafs_main_parse_token_u32_alias2(
+static int kafs_main_handle_bg_dedup_interval_token(kafs_main_options_t *opts, const char *tok)
+{
+  int rc = kafs_main_parse_token_u32_alias2(
       tok, "bg_dedup_interval_ms=", "dedup_interval_ms=", KAFS_BG_DEDUP_INTERVAL_MS_MIN,
       KAFS_BG_DEDUP_INTERVAL_MS_MAX, &opts->bg_dedup_interval_ms,
       "dedup_interval_ms/bg_dedup_interval_ms");
@@ -11663,39 +11664,54 @@ static int kafs_main_handle_bg_dedup_token(kafs_main_options_t *opts, const char
   if (rc != 0)
     return rc;
 
-  rc = kafs_main_parse_token_u32_alias2(
+  return kafs_main_parse_token_u32_alias2(
       tok, "bg_dedup_pressure_interval_ms=", "dedup_pressure_interval_ms=",
       KAFS_BG_DEDUP_INTERVAL_MS_MIN, KAFS_BG_DEDUP_INTERVAL_MS_MAX,
       &opts->bg_dedup_pressure_interval_ms,
       "dedup_pressure_interval_ms/bg_dedup_pressure_interval_ms");
+}
+
+static int kafs_main_handle_bg_dedup_threshold_token(kafs_main_options_t *opts, const char *tok)
+{
+  int rc = kafs_main_parse_token_u32_alias2(
+      tok, "bg_dedup_start_used_pct=", "dedup_start_used_pct=", 0, 100u,
+      &opts->bg_dedup_start_used_pct, "dedup_start_used_pct/bg_dedup_start_used_pct");
   if (rc != 0)
     return rc;
 
-  rc = kafs_main_parse_token_u32_alias2(tok, "bg_dedup_start_used_pct=", "dedup_start_used_pct=", 0,
-                                        100u, &opts->bg_dedup_start_used_pct,
-                                        "dedup_start_used_pct/bg_dedup_start_used_pct");
-  if (rc != 0)
-    return rc;
-
-  rc = kafs_main_parse_token_u32_alias2(
+  return kafs_main_parse_token_u32_alias2(
       tok, "bg_dedup_pressure_used_pct=", "dedup_pressure_used_pct=", 0, 100u,
       &opts->bg_dedup_pressure_used_pct, "dedup_pressure_used_pct/bg_dedup_pressure_used_pct");
-  if (rc != 0)
-    return rc;
+}
 
-  rc = kafs_main_parse_token_prio_alias2(
+static int kafs_main_handle_bg_dedup_priority_token(kafs_main_options_t *opts, const char *tok)
+{
+  int rc = kafs_main_parse_token_prio_alias2(
       tok, "bg_dedup_worker_prio=", "dedup_scan_worker_prio=", &opts->bg_dedup_worker_prio_mode,
       "bg_dedup_worker_prio/dedup_scan_worker_prio");
   if (rc != 0)
     return rc;
 
-  rc = kafs_main_parse_token_nice_alias2(
+  return kafs_main_parse_token_nice_alias2(
       tok, "bg_dedup_worker_nice=", "dedup_scan_worker_nice=", &opts->bg_dedup_worker_nice,
       "bg_dedup_worker_nice/dedup_scan_worker_nice");
+}
+
+static int kafs_main_handle_bg_dedup_token(kafs_main_options_t *opts, const char *tok)
+{
+  int rc = kafs_main_handle_bg_dedup_scan_token(opts, tok);
   if (rc != 0)
     return rc;
 
-  return 0;
+  rc = kafs_main_handle_bg_dedup_interval_token(opts, tok);
+  if (rc != 0)
+    return rc;
+
+  rc = kafs_main_handle_bg_dedup_threshold_token(opts, tok);
+  if (rc != 0)
+    return rc;
+
+  return kafs_main_handle_bg_dedup_priority_token(opts, tok);
 }
 
 static void kafs_main_append_filtered_token(char *filtered, size_t *used, const char *tok)

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -2792,268 +2792,269 @@ static void kafs_ino_blocks_adjust(kafs_sinode_t *inoent, int delta)
   }
 }
 
-static int kafs_ino_ibrk_run(struct kafs_context *ctx, kafs_sinode_t *inoent, kafs_iblkcnt_t iblo,
-                             kafs_blkcnt_t *pblo, kafs_iblkref_func_t ifunc)
+static int kafs_ino_ibrk_run_direct(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                    kafs_iblkcnt_t iblo, kafs_iblkcnt_t iblo_orig,
+                                    kafs_blkcnt_t *pblo, kafs_iblkref_func_t ifunc)
 {
-  kafs_iblkcnt_t iblo_orig = iblo;
-  assert(ctx != NULL);
-  assert(pblo != NULL);
-  assert(inoent != NULL);
-  kafs_dlog(3, "ibrk_run: iblo=%" PRIuFAST32 " ifunc=%d (size=%" PRIuFAST64 ")\n", iblo, (int)ifunc,
-            kafs_ino_size_get(inoent));
+  kafs_blkcnt_t blo_data_raw = kafs_blkcnt_stoh(inoent->i_blkreftbl[iblo]);
+  kafs_blkcnt_t blo_data = KAFS_BLO_NONE;
 
-  if (iblo < 12)
+  switch (ifunc)
   {
-    kafs_blkcnt_t blo_data_raw = kafs_blkcnt_stoh(inoent->i_blkreftbl[iblo]);
-    kafs_blkcnt_t blo_data = KAFS_BLO_NONE;
-    switch (ifunc)
+  case KAFS_IBLKREF_FUNC_GET_RAW:
+    *pblo = blo_data_raw;
+    return KAFS_SUCCESS;
+
+  case KAFS_IBLKREF_FUNC_GET:
+    KAFS_CALL(kafs_ref_resolve_data_blo, ctx, blo_data_raw, &blo_data);
+    *pblo = blo_data;
+    return KAFS_SUCCESS;
+
+  case KAFS_IBLKREF_FUNC_PUT:
+    KAFS_CALL(kafs_ref_resolve_data_blo, ctx, blo_data_raw, &blo_data);
+    if (blo_data == KAFS_BLO_NONE)
     {
-    case KAFS_IBLKREF_FUNC_GET_RAW:
-      *pblo = blo_data_raw;
-      return KAFS_SUCCESS;
-
-    case KAFS_IBLKREF_FUNC_GET:
-      KAFS_CALL(kafs_ref_resolve_data_blo, ctx, blo_data_raw, &blo_data);
-      *pblo = blo_data;
-      return KAFS_SUCCESS;
-
-    case KAFS_IBLKREF_FUNC_PUT:
-      KAFS_CALL(kafs_ref_resolve_data_blo, ctx, blo_data_raw, &blo_data);
-      if (blo_data == KAFS_BLO_NONE)
-      {
-        KAFS_CALL(kafs_blk_alloc, ctx, &blo_data);
-        inoent->i_blkreftbl[iblo] = kafs_blkcnt_htos(blo_data);
-      }
-      *pblo = blo_data;
-      return KAFS_SUCCESS;
-
-    case KAFS_IBLKREF_FUNC_SET:
-      // 直接参照に new blo を設定（中間テーブル不要）
-      kafs_diag_log_dir_ref_set("ibrk_set_direct", ctx, inoent, iblo_orig, blo_data_raw, *pblo);
-      if (blo_data_raw == KAFS_BLO_NONE && *pblo != KAFS_BLO_NONE)
-        kafs_ino_blocks_adjust(inoent, +1);
-      else if (blo_data_raw != KAFS_BLO_NONE && *pblo == KAFS_BLO_NONE)
-        kafs_ino_blocks_adjust(inoent, -1);
-      inoent->i_blkreftbl[iblo] = kafs_blkcnt_htos(*pblo);
-      return KAFS_SUCCESS;
+      KAFS_CALL(kafs_blk_alloc, ctx, &blo_data);
+      inoent->i_blkreftbl[iblo] = kafs_blkcnt_htos(blo_data);
     }
+    *pblo = blo_data;
+    return KAFS_SUCCESS;
+
+  case KAFS_IBLKREF_FUNC_SET:
+    kafs_diag_log_dir_ref_set("ibrk_set_direct", ctx, inoent, iblo_orig, blo_data_raw, *pblo);
+    if (blo_data_raw == KAFS_BLO_NONE && *pblo != KAFS_BLO_NONE)
+      kafs_ino_blocks_adjust(inoent, +1);
+    else if (blo_data_raw != KAFS_BLO_NONE && *pblo == KAFS_BLO_NONE)
+      kafs_ino_blocks_adjust(inoent, -1);
+    inoent->i_blkreftbl[iblo] = kafs_blkcnt_htos(*pblo);
+    return KAFS_SUCCESS;
   }
 
-  iblo -= 12;
-  kafs_blksize_t blksize = kafs_sb_blksize_get(ctx->c_superblock);
-  kafs_logblksize_t log_blkrefs_pb = kafs_sb_log_blkref_pb_get(ctx->c_superblock);
-  kafs_blkcnt_t blkrefs_pb = kafs_sb_blkref_pb_get(ctx->c_superblock);
-  if (iblo < blkrefs_pb)
+  return KAFS_SUCCESS;
+}
+
+static int kafs_ino_ibrk_run_single(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                    kafs_iblkcnt_t iblo, kafs_iblkcnt_t iblo_orig,
+                                    kafs_blkcnt_t *pblo, kafs_iblkref_func_t ifunc,
+                                    kafs_blksize_t blksize, kafs_blkcnt_t blkrefs_pb)
+{
+  kafs_sblkcnt_t blkreftbl[blkrefs_pb];
+  kafs_blkcnt_t blo_blkreftbl = kafs_blkcnt_stoh(inoent->i_blkreftbl[12]);
+  kafs_blkcnt_t blo_data;
+
+  kafs_dlog(3,
+            "ibrk_run: single-indirect idx=%" PRIuFAST32 ", blkrefs_pb=%" PRIuFAST32
+            ", tbl_blo=%" PRIuFAST32 "\n",
+            iblo, blkrefs_pb, blo_blkreftbl);
+
+  switch (ifunc)
   {
-    kafs_sblkcnt_t blkreftbl[blkrefs_pb];
-    kafs_blkcnt_t blo_blkreftbl = kafs_blkcnt_stoh(inoent->i_blkreftbl[12]);
-    kafs_blkcnt_t blo_data;
-    kafs_dlog(3,
-              "ibrk_run: single-indirect idx=%" PRIuFAST32 ", blkrefs_pb=%" PRIuFAST32
-              ", tbl_blo=%" PRIuFAST32 "\n",
-              iblo, blkrefs_pb, blo_blkreftbl);
-
-    switch (ifunc)
+  case KAFS_IBLKREF_FUNC_GET_RAW:
+    if (blo_blkreftbl == KAFS_BLO_NONE)
     {
-    case KAFS_IBLKREF_FUNC_GET_RAW:
-      if (blo_blkreftbl == KAFS_BLO_NONE)
-      {
-        *pblo = KAFS_BLO_NONE;
-        return KAFS_SUCCESS;
-      }
+      *pblo = KAFS_BLO_NONE;
+      return KAFS_SUCCESS;
+    }
+    KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl, blkreftbl);
+    *pblo = kafs_blkcnt_stoh(blkreftbl[iblo]);
+    return KAFS_SUCCESS;
+
+  case KAFS_IBLKREF_FUNC_GET:
+    if (blo_blkreftbl == KAFS_BLO_NONE)
+    {
+      *pblo = KAFS_BLO_NONE;
+      return KAFS_SUCCESS;
+    }
+    KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl, blkreftbl);
+    KAFS_CALL(kafs_ref_resolve_data_blo, ctx, kafs_blkcnt_stoh(blkreftbl[iblo]), pblo);
+    return KAFS_SUCCESS;
+
+  case KAFS_IBLKREF_FUNC_PUT:
+    if (blo_blkreftbl == KAFS_BLO_NONE)
+    {
+      KAFS_CALL(kafs_blk_alloc, ctx, &blo_blkreftbl);
+      inoent->i_blkreftbl[12] = kafs_blkcnt_htos(blo_blkreftbl);
+      memset(blkreftbl, 0, blksize);
+      blo_data = KAFS_BLO_NONE;
+    }
+    else
+    {
       KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl, blkreftbl);
-      *pblo = kafs_blkcnt_stoh(blkreftbl[iblo]);
-      return KAFS_SUCCESS;
-
-    case KAFS_IBLKREF_FUNC_GET:
-      if (blo_blkreftbl == KAFS_BLO_NONE)
-      {
-        *pblo = KAFS_BLO_NONE;
-        return KAFS_SUCCESS;
-      }
-      KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl, blkreftbl);
-      KAFS_CALL(kafs_ref_resolve_data_blo, ctx, kafs_blkcnt_stoh(blkreftbl[iblo]), pblo);
-      return KAFS_SUCCESS;
-
-    case KAFS_IBLKREF_FUNC_PUT:
-      if (blo_blkreftbl == KAFS_BLO_NONE)
-      {
-        KAFS_CALL(kafs_blk_alloc, ctx, &blo_blkreftbl);
-        inoent->i_blkreftbl[12] = kafs_blkcnt_htos(blo_blkreftbl);
-        // 新規に間接テーブルを割り当てた場合は全エントリを 0 で初期化する
-        memset(blkreftbl, 0, blksize);
-        blo_data = KAFS_BLO_NONE;
-      }
-      else
-      {
-        KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl, blkreftbl);
-        KAFS_CALL(kafs_ref_resolve_data_blo, ctx, kafs_blkcnt_stoh(blkreftbl[iblo]), &blo_data);
-      }
-      if (blo_data == KAFS_BLO_NONE)
-      {
-        KAFS_CALL(kafs_blk_alloc, ctx, &blo_data);
-        blkreftbl[iblo] = kafs_blkcnt_htos(blo_data);
-        KAFS_CALL(kafs_blk_write, ctx, blo_blkreftbl, blkreftbl);
-      }
-      *pblo = blo_data;
-      return KAFS_SUCCESS;
-
-    case KAFS_IBLKREF_FUNC_SET:
-      if (blo_blkreftbl == KAFS_BLO_NONE)
-      {
-        // 中間テーブルを割り当て
-        KAFS_CALL(kafs_blk_alloc, ctx, &blo_blkreftbl);
-        inoent->i_blkreftbl[12] = kafs_blkcnt_htos(blo_blkreftbl);
-        kafs_ino_blocks_adjust(inoent, +1);
-        memset(blkreftbl, 0, blksize);
-      }
-      else
-      {
-        KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl, blkreftbl);
-      }
-      blo_data = kafs_blkcnt_stoh(blkreftbl[iblo]);
-      kafs_diag_log_dir_ref_set("ibrk_set_single", ctx, inoent, iblo_orig, blo_data, *pblo);
-      if (blo_data == KAFS_BLO_NONE && *pblo != KAFS_BLO_NONE)
-        kafs_ino_blocks_adjust(inoent, +1);
-      else if (blo_data != KAFS_BLO_NONE && *pblo == KAFS_BLO_NONE)
-        kafs_ino_blocks_adjust(inoent, -1);
-      blkreftbl[iblo] = kafs_blkcnt_htos(*pblo);
+      KAFS_CALL(kafs_ref_resolve_data_blo, ctx, kafs_blkcnt_stoh(blkreftbl[iblo]), &blo_data);
+    }
+    if (blo_data == KAFS_BLO_NONE)
+    {
+      KAFS_CALL(kafs_blk_alloc, ctx, &blo_data);
+      blkreftbl[iblo] = kafs_blkcnt_htos(blo_data);
       KAFS_CALL(kafs_blk_write, ctx, blo_blkreftbl, blkreftbl);
-      return KAFS_SUCCESS;
     }
-  }
+    *pblo = blo_data;
+    return KAFS_SUCCESS;
 
-  iblo -= blkrefs_pb;
-  kafs_logblksize_t log_blkrefs_pb_sq = log_blkrefs_pb << 1;
-  kafs_blksize_t blkrefs_pb_sq = 1 << log_blkrefs_pb_sq;
-  if (iblo < blkrefs_pb_sq)
-  {
-    kafs_sblkcnt_t blkreftbl1[blkrefs_pb];
-    kafs_sblkcnt_t blkreftbl2[blkrefs_pb];
-    kafs_blkcnt_t blo_blkreftbl1 = kafs_blkcnt_stoh(inoent->i_blkreftbl[13]);
-    kafs_blkcnt_t blo_blkreftbl2;
-    kafs_blkcnt_t blo_data;
-    kafs_blkcnt_t iblo1 = iblo >> log_blkrefs_pb;
-    kafs_blkcnt_t iblo2 = iblo & (blkrefs_pb - 1);
-
-    switch (ifunc)
+  case KAFS_IBLKREF_FUNC_SET:
+    if (blo_blkreftbl == KAFS_BLO_NONE)
     {
-    case KAFS_IBLKREF_FUNC_GET_RAW:
-      if (blo_blkreftbl1 == KAFS_BLO_NONE)
-      {
-        *pblo = KAFS_BLO_NONE;
-        return KAFS_SUCCESS;
-      }
-      KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl1, blkreftbl1);
-      blo_blkreftbl2 = kafs_blkcnt_stoh(blkreftbl1[iblo1]);
-      if (blo_blkreftbl2 == KAFS_BLO_NONE)
-      {
-        *pblo = KAFS_BLO_NONE;
-        return KAFS_SUCCESS;
-      }
-      KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl2, blkreftbl2);
-      *pblo = kafs_blkcnt_stoh(blkreftbl2[iblo2]);
-      return KAFS_SUCCESS;
-
-    case KAFS_IBLKREF_FUNC_GET:
-      if (blo_blkreftbl1 == KAFS_BLO_NONE)
-      {
-        *pblo = KAFS_BLO_NONE;
-        return KAFS_SUCCESS;
-      }
-      KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl1, blkreftbl1);
-      blo_blkreftbl2 = kafs_blkcnt_stoh(blkreftbl1[iblo1]);
-      if (blo_blkreftbl2 == KAFS_BLO_NONE)
-      {
-        *pblo = KAFS_BLO_NONE;
-        return KAFS_SUCCESS;
-      }
-      KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl2, blkreftbl2);
-      KAFS_CALL(kafs_ref_resolve_data_blo, ctx, kafs_blkcnt_stoh(blkreftbl2[iblo2]), pblo);
-      return KAFS_SUCCESS;
-
-    case KAFS_IBLKREF_FUNC_PUT:
-      if (blo_blkreftbl1 == KAFS_BLO_NONE)
-      {
-        KAFS_CALL(kafs_blk_alloc, ctx, &blo_blkreftbl1);
-        inoent->i_blkreftbl[13] = kafs_blkcnt_htos(blo_blkreftbl1);
-        memset(blkreftbl1, 0, blksize);
-        blo_blkreftbl2 = KAFS_BLO_NONE;
-      }
-      else
-      {
-        KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl1, blkreftbl1);
-        blo_blkreftbl2 = kafs_blkcnt_stoh(blkreftbl1[iblo1]);
-      }
-      if (blo_blkreftbl2 == KAFS_BLO_NONE)
-      {
-        KAFS_CALL(kafs_blk_alloc, ctx, &blo_blkreftbl2);
-        blkreftbl1[iblo1] = kafs_blkcnt_htos(blo_blkreftbl2);
-        KAFS_CALL(kafs_blk_write, ctx, blo_blkreftbl1, blkreftbl1);
-        memset(blkreftbl2, 0, blksize);
-        blo_data = KAFS_BLO_NONE;
-      }
-      else
-      {
-        KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl2, blkreftbl2);
-        KAFS_CALL(kafs_ref_resolve_data_blo, ctx, kafs_blkcnt_stoh(blkreftbl2[iblo2]), &blo_data);
-      }
-      if (blo_data == KAFS_BLO_NONE)
-      {
-        KAFS_CALL(kafs_blk_alloc, ctx, &blo_data);
-        blkreftbl2[iblo2] = kafs_blkcnt_htos(blo_data);
-        KAFS_CALL(kafs_blk_write, ctx, blo_blkreftbl2, blkreftbl2);
-      }
-      *pblo = blo_data;
-      return KAFS_SUCCESS;
-    case KAFS_IBLKREF_FUNC_SET:
-      if (blo_blkreftbl1 == KAFS_BLO_NONE)
-      {
-        KAFS_CALL(kafs_blk_alloc, ctx, &blo_blkreftbl1);
-        inoent->i_blkreftbl[13] = kafs_blkcnt_htos(blo_blkreftbl1);
-        kafs_ino_blocks_adjust(inoent, +1);
-        memset(blkreftbl1, 0, blksize);
-        blo_blkreftbl2 = KAFS_BLO_NONE;
-      }
-      else
-      {
-        KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl1, blkreftbl1);
-        blo_blkreftbl2 = kafs_blkcnt_stoh(blkreftbl1[iblo1]);
-      }
-      if (blo_blkreftbl2 == KAFS_BLO_NONE)
-      {
-        KAFS_CALL(kafs_blk_alloc, ctx, &blo_blkreftbl2);
-        blkreftbl1[iblo1] = kafs_blkcnt_htos(blo_blkreftbl2);
-        KAFS_CALL(kafs_blk_write, ctx, blo_blkreftbl1, blkreftbl1);
-        kafs_ino_blocks_adjust(inoent, +1);
-        memset(blkreftbl2, 0, blksize);
-      }
-      else
-      {
-        KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl2, blkreftbl2);
-      }
-      blo_data = kafs_blkcnt_stoh(blkreftbl2[iblo2]);
-      kafs_diag_log_dir_ref_set("ibrk_set_double", ctx, inoent, iblo_orig, blo_data, *pblo);
-      if (blo_data == KAFS_BLO_NONE && *pblo != KAFS_BLO_NONE)
-        kafs_ino_blocks_adjust(inoent, +1);
-      else if (blo_data != KAFS_BLO_NONE && *pblo == KAFS_BLO_NONE)
-        kafs_ino_blocks_adjust(inoent, -1);
-      blkreftbl2[iblo2] = kafs_blkcnt_htos(*pblo);
-      KAFS_CALL(kafs_blk_write, ctx, blo_blkreftbl2, blkreftbl2);
-      return KAFS_SUCCESS;
+      KAFS_CALL(kafs_blk_alloc, ctx, &blo_blkreftbl);
+      inoent->i_blkreftbl[12] = kafs_blkcnt_htos(blo_blkreftbl);
+      kafs_ino_blocks_adjust(inoent, +1);
+      memset(blkreftbl, 0, blksize);
     }
+    else
+    {
+      KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl, blkreftbl);
+    }
+    blo_data = kafs_blkcnt_stoh(blkreftbl[iblo]);
+    kafs_diag_log_dir_ref_set("ibrk_set_single", ctx, inoent, iblo_orig, blo_data, *pblo);
+    if (blo_data == KAFS_BLO_NONE && *pblo != KAFS_BLO_NONE)
+      kafs_ino_blocks_adjust(inoent, +1);
+    else if (blo_data != KAFS_BLO_NONE && *pblo == KAFS_BLO_NONE)
+      kafs_ino_blocks_adjust(inoent, -1);
+    blkreftbl[iblo] = kafs_blkcnt_htos(*pblo);
+    KAFS_CALL(kafs_blk_write, ctx, blo_blkreftbl, blkreftbl);
+    return KAFS_SUCCESS;
   }
 
-  iblo -= blkrefs_pb_sq;
+  return KAFS_SUCCESS;
+}
+
+static int kafs_ino_ibrk_run_double(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                    kafs_iblkcnt_t iblo, kafs_iblkcnt_t iblo_orig,
+                                    kafs_blkcnt_t *pblo, kafs_iblkref_func_t ifunc,
+                                    kafs_blksize_t blksize, kafs_logblksize_t log_blkrefs_pb,
+                                    kafs_blkcnt_t blkrefs_pb)
+{
+  kafs_sblkcnt_t blkreftbl1[blkrefs_pb];
+  kafs_sblkcnt_t blkreftbl2[blkrefs_pb];
+  kafs_blkcnt_t blo_blkreftbl1 = kafs_blkcnt_stoh(inoent->i_blkreftbl[13]);
+  kafs_blkcnt_t blo_blkreftbl2;
+  kafs_blkcnt_t blo_data;
+  kafs_blkcnt_t iblo1 = iblo >> log_blkrefs_pb;
+  kafs_blkcnt_t iblo2 = iblo & (blkrefs_pb - 1);
+
+  switch (ifunc)
+  {
+  case KAFS_IBLKREF_FUNC_GET_RAW:
+    if (blo_blkreftbl1 == KAFS_BLO_NONE)
+    {
+      *pblo = KAFS_BLO_NONE;
+      return KAFS_SUCCESS;
+    }
+    KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl1, blkreftbl1);
+    blo_blkreftbl2 = kafs_blkcnt_stoh(blkreftbl1[iblo1]);
+    if (blo_blkreftbl2 == KAFS_BLO_NONE)
+    {
+      *pblo = KAFS_BLO_NONE;
+      return KAFS_SUCCESS;
+    }
+    KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl2, blkreftbl2);
+    *pblo = kafs_blkcnt_stoh(blkreftbl2[iblo2]);
+    return KAFS_SUCCESS;
+
+  case KAFS_IBLKREF_FUNC_GET:
+    if (blo_blkreftbl1 == KAFS_BLO_NONE)
+    {
+      *pblo = KAFS_BLO_NONE;
+      return KAFS_SUCCESS;
+    }
+    KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl1, blkreftbl1);
+    blo_blkreftbl2 = kafs_blkcnt_stoh(blkreftbl1[iblo1]);
+    if (blo_blkreftbl2 == KAFS_BLO_NONE)
+    {
+      *pblo = KAFS_BLO_NONE;
+      return KAFS_SUCCESS;
+    }
+    KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl2, blkreftbl2);
+    KAFS_CALL(kafs_ref_resolve_data_blo, ctx, kafs_blkcnt_stoh(blkreftbl2[iblo2]), pblo);
+    return KAFS_SUCCESS;
+
+  case KAFS_IBLKREF_FUNC_PUT:
+    if (blo_blkreftbl1 == KAFS_BLO_NONE)
+    {
+      KAFS_CALL(kafs_blk_alloc, ctx, &blo_blkreftbl1);
+      inoent->i_blkreftbl[13] = kafs_blkcnt_htos(blo_blkreftbl1);
+      memset(blkreftbl1, 0, blksize);
+      blo_blkreftbl2 = KAFS_BLO_NONE;
+    }
+    else
+    {
+      KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl1, blkreftbl1);
+      blo_blkreftbl2 = kafs_blkcnt_stoh(blkreftbl1[iblo1]);
+    }
+    if (blo_blkreftbl2 == KAFS_BLO_NONE)
+    {
+      KAFS_CALL(kafs_blk_alloc, ctx, &blo_blkreftbl2);
+      blkreftbl1[iblo1] = kafs_blkcnt_htos(blo_blkreftbl2);
+      KAFS_CALL(kafs_blk_write, ctx, blo_blkreftbl1, blkreftbl1);
+      memset(blkreftbl2, 0, blksize);
+      blo_data = KAFS_BLO_NONE;
+    }
+    else
+    {
+      KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl2, blkreftbl2);
+      KAFS_CALL(kafs_ref_resolve_data_blo, ctx, kafs_blkcnt_stoh(blkreftbl2[iblo2]), &blo_data);
+    }
+    if (blo_data == KAFS_BLO_NONE)
+    {
+      KAFS_CALL(kafs_blk_alloc, ctx, &blo_data);
+      blkreftbl2[iblo2] = kafs_blkcnt_htos(blo_data);
+      KAFS_CALL(kafs_blk_write, ctx, blo_blkreftbl2, blkreftbl2);
+    }
+    *pblo = blo_data;
+    return KAFS_SUCCESS;
+
+  case KAFS_IBLKREF_FUNC_SET:
+    if (blo_blkreftbl1 == KAFS_BLO_NONE)
+    {
+      KAFS_CALL(kafs_blk_alloc, ctx, &blo_blkreftbl1);
+      inoent->i_blkreftbl[13] = kafs_blkcnt_htos(blo_blkreftbl1);
+      kafs_ino_blocks_adjust(inoent, +1);
+      memset(blkreftbl1, 0, blksize);
+      blo_blkreftbl2 = KAFS_BLO_NONE;
+    }
+    else
+    {
+      KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl1, blkreftbl1);
+      blo_blkreftbl2 = kafs_blkcnt_stoh(blkreftbl1[iblo1]);
+    }
+    if (blo_blkreftbl2 == KAFS_BLO_NONE)
+    {
+      KAFS_CALL(kafs_blk_alloc, ctx, &blo_blkreftbl2);
+      blkreftbl1[iblo1] = kafs_blkcnt_htos(blo_blkreftbl2);
+      KAFS_CALL(kafs_blk_write, ctx, blo_blkreftbl1, blkreftbl1);
+      kafs_ino_blocks_adjust(inoent, +1);
+      memset(blkreftbl2, 0, blksize);
+    }
+    else
+    {
+      KAFS_CALL(kafs_blk_read, ctx, blo_blkreftbl2, blkreftbl2);
+    }
+    blo_data = kafs_blkcnt_stoh(blkreftbl2[iblo2]);
+    kafs_diag_log_dir_ref_set("ibrk_set_double", ctx, inoent, iblo_orig, blo_data, *pblo);
+    if (blo_data == KAFS_BLO_NONE && *pblo != KAFS_BLO_NONE)
+      kafs_ino_blocks_adjust(inoent, +1);
+    else if (blo_data != KAFS_BLO_NONE && *pblo == KAFS_BLO_NONE)
+      kafs_ino_blocks_adjust(inoent, -1);
+    blkreftbl2[iblo2] = kafs_blkcnt_htos(*pblo);
+    KAFS_CALL(kafs_blk_write, ctx, blo_blkreftbl2, blkreftbl2);
+    return KAFS_SUCCESS;
+  }
+
+  return KAFS_SUCCESS;
+}
+
+static int kafs_ino_ibrk_run_triple(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                    kafs_iblkcnt_t iblo, kafs_iblkcnt_t iblo_orig,
+                                    kafs_blkcnt_t *pblo, kafs_iblkref_func_t ifunc,
+                                    kafs_blksize_t blksize, kafs_logblksize_t log_blkrefs_pb,
+                                    kafs_logblksize_t log_blkrefs_pb_sq, kafs_blkcnt_t blkrefs_pb)
+{
   kafs_sblkcnt_t blkreftbl1[blkrefs_pb];
   kafs_sblkcnt_t blkreftbl2[blkrefs_pb];
   kafs_sblkcnt_t blkreftbl3[blkrefs_pb];
-
   kafs_blkcnt_t blo_blkreftbl1 = kafs_blkcnt_stoh(inoent->i_blkreftbl[14]);
   kafs_blkcnt_t blo_blkreftbl2;
   kafs_blkcnt_t blo_blkreftbl3;
   kafs_blkcnt_t blo_data;
-
   kafs_blkcnt_t iblo1 = iblo >> log_blkrefs_pb_sq;
   kafs_blkcnt_t iblo2 = (iblo >> log_blkrefs_pb) & (blkrefs_pb - 1);
   kafs_blkcnt_t iblo3 = iblo & (blkrefs_pb - 1);
@@ -3206,7 +3207,40 @@ static int kafs_ino_ibrk_run(struct kafs_context *ctx, kafs_sinode_t *inoent, ka
     KAFS_CALL(kafs_blk_write, ctx, blo_blkreftbl3, blkreftbl3);
     return KAFS_SUCCESS;
   }
+
   return KAFS_SUCCESS;
+}
+
+static int kafs_ino_ibrk_run(struct kafs_context *ctx, kafs_sinode_t *inoent, kafs_iblkcnt_t iblo,
+                             kafs_blkcnt_t *pblo, kafs_iblkref_func_t ifunc)
+{
+  kafs_iblkcnt_t iblo_orig = iblo;
+  assert(ctx != NULL);
+  assert(pblo != NULL);
+  assert(inoent != NULL);
+  kafs_dlog(3, "ibrk_run: iblo=%" PRIuFAST32 " ifunc=%d (size=%" PRIuFAST64 ")\n", iblo, (int)ifunc,
+            kafs_ino_size_get(inoent));
+
+  if (iblo < 12)
+    return kafs_ino_ibrk_run_direct(ctx, inoent, iblo, iblo_orig, pblo, ifunc);
+
+  iblo -= 12;
+  kafs_blksize_t blksize = kafs_sb_blksize_get(ctx->c_superblock);
+  kafs_logblksize_t log_blkrefs_pb = kafs_sb_log_blkref_pb_get(ctx->c_superblock);
+  kafs_blkcnt_t blkrefs_pb = kafs_sb_blkref_pb_get(ctx->c_superblock);
+  if (iblo < blkrefs_pb)
+    return kafs_ino_ibrk_run_single(ctx, inoent, iblo, iblo_orig, pblo, ifunc, blksize, blkrefs_pb);
+
+  iblo -= blkrefs_pb;
+  kafs_logblksize_t log_blkrefs_pb_sq = log_blkrefs_pb << 1;
+  kafs_blksize_t blkrefs_pb_sq = 1 << log_blkrefs_pb_sq;
+  if (iblo < blkrefs_pb_sq)
+    return kafs_ino_ibrk_run_double(ctx, inoent, iblo, iblo_orig, pblo, ifunc, blksize,
+                                    log_blkrefs_pb, blkrefs_pb);
+
+  iblo -= blkrefs_pb_sq;
+  return kafs_ino_ibrk_run_triple(ctx, inoent, iblo, iblo_orig, pblo, ifunc, blksize,
+                                  log_blkrefs_pb, log_blkrefs_pb_sq, blkrefs_pb);
 }
 
 // SET(NONE) 実施後に、空になった間接テーブルを親から切り離す。

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -7943,6 +7943,110 @@ static int kafs_ctl_handle_request(kafs_context_t *ctx, kafs_ctl_session_t *sess
   return (int)size;
 }
 
+#ifdef __linux__
+static int kafs_ioctl_handle_ficlone(struct fuse_context *fctx, kafs_context_t *ctx,
+                                     const char *path, int cmd, void *arg,
+                                     struct fuse_file_info *fi, void *data)
+{
+  int srcfd = -1;
+  if (data)
+  {
+    if (_IOC_SIZE((unsigned int)cmd) < sizeof(int))
+      return -EINVAL;
+    srcfd = *(int *)data;
+  }
+  else
+  {
+    srcfd = (int)(uintptr_t)arg;
+  }
+
+  char sp[PATH_MAX];
+  int prc = kafs_procfd_to_kafs_path(ctx, fctx->pid, srcfd, sp);
+  if (prc != 0)
+    return prc;
+
+  kafs_sinode_t *ino_src;
+  kafs_sinode_t *ino_dst;
+  KAFS_CALL(kafs_access, fctx, ctx, sp, NULL, R_OK, &ino_src);
+  KAFS_CALL(kafs_access, fctx, ctx, path, fi, W_OK, &ino_dst);
+  return kafs_reflink_clone(ctx, ino_src, ino_dst);
+}
+#endif
+
+static int kafs_ioctl_lookup_copy_dst(struct fuse_context *fctx, kafs_context_t *ctx,
+                                      const char *dst, kafs_sinode_t **ino_dst)
+{
+  int drc = kafs_access(fctx, ctx, dst, NULL, F_OK, ino_dst);
+  if (drc == -ENOENT)
+  {
+    kafs_inocnt_t ino_new;
+    KAFS_CALL(kafs_create, dst, 0644 | S_IFREG, 0, NULL, &ino_new);
+    *ino_dst = kafs_ctx_inode(ctx, ino_new);
+    return 0;
+  }
+  if (drc < 0)
+    return drc;
+
+  KAFS_CALL(kafs_access, fctx, ctx, dst, NULL, W_OK, ino_dst);
+  return 0;
+}
+
+static int kafs_ioctl_handle_copy(struct fuse_context *fctx, kafs_context_t *ctx, void *arg,
+                                  void *data)
+{
+  void *buf = data ? data : arg;
+  if (!buf)
+    return -EINVAL;
+  if (_IOC_SIZE((unsigned int)KAFS_IOCTL_COPY) < sizeof(kafs_ioctl_copy_t))
+    return -EINVAL;
+
+  kafs_ioctl_copy_t req;
+  memcpy(&req, buf, sizeof(req));
+  if (req.struct_size < sizeof(req))
+    return -EINVAL;
+  if (req.src[0] != '/' || req.dst[0] != '/' || req.src[1] == '\0' || req.dst[1] == '\0')
+    return -EINVAL;
+
+  kafs_sinode_t *ino_src;
+  kafs_sinode_t *ino_dst;
+  KAFS_CALL(kafs_access, fctx, ctx, req.src, NULL, R_OK, &ino_src);
+  int rc = kafs_ioctl_lookup_copy_dst(fctx, ctx, req.dst, &ino_dst);
+  if (rc < 0)
+    return rc;
+
+  if ((req.flags & KAFS_IOCTL_COPY_F_REFLINK) != 0)
+    return kafs_reflink_clone(ctx, ino_src, ino_dst);
+
+  uint32_t ino_dst_no = (uint32_t)kafs_ctx_ino_no(ctx, ino_dst);
+  kafs_inode_lock(ctx, ino_dst_no);
+  int trc = kafs_truncate(ctx, ino_dst, 0);
+  kafs_inode_unlock(ctx, ino_dst_no);
+  if (trc < 0)
+    return trc;
+
+  kafs_off_t src_size = kafs_ino_size_get(ino_src);
+  ssize_t copied = kafs_copy_regular_range(ctx, ino_src, ino_dst, 0, 0, (size_t)src_size);
+  return copied < 0 ? (int)copied : 0;
+}
+
+static int kafs_ioctl_handle_get_stats(kafs_context_t *ctx, int cmd, void *arg, void *data)
+{
+  void *buf = data ? data : arg;
+  if (!buf)
+    return -EINVAL;
+  if (_IOC_SIZE((unsigned int)cmd) < sizeof(kafs_stats_t))
+    return -EINVAL;
+
+  kafs_stats_t req;
+  memset(&req, 0, sizeof(req));
+  memcpy(&req, buf, sizeof(req));
+
+  kafs_stats_t out;
+  kafs_stats_snapshot(ctx, &out, req.request_flags);
+  memcpy(buf, &out, sizeof(out));
+  return 0;
+}
+
 static int kafs_op_ioctl(const char *path, int cmd, void *arg, struct fuse_file_info *fi,
                          unsigned int flags, void *data)
 {
@@ -7953,99 +8057,16 @@ static int kafs_op_ioctl(const char *path, int cmd, void *arg, struct fuse_file_
 
 #ifdef __linux__
   if ((unsigned int)cmd == (unsigned int)FICLONE)
-  {
-    int srcfd = -1;
-    if (data)
-    {
-      if (_IOC_SIZE((unsigned int)cmd) < sizeof(int))
-        return -EINVAL;
-      srcfd = *(int *)data;
-    }
-    else
-    {
-      // FICLONE takes an int fd argument (passed as ioctl arg value, not as pointer).
-      srcfd = (int)(uintptr_t)arg;
-    }
-
-    char sp[PATH_MAX];
-    int prc = kafs_procfd_to_kafs_path(ctx, fctx->pid, srcfd, sp);
-    if (prc != 0)
-      return prc;
-
-    kafs_sinode_t *ino_src;
-    kafs_sinode_t *ino_dst;
-    KAFS_CALL(kafs_access, fctx, ctx, sp, NULL, R_OK, &ino_src);
-    KAFS_CALL(kafs_access, fctx, ctx, path, fi, W_OK, &ino_dst);
-    return kafs_reflink_clone(ctx, ino_src, ino_dst);
-  }
+    return kafs_ioctl_handle_ficlone(fctx, ctx, path, cmd, arg, fi, data);
   if ((unsigned int)cmd == (unsigned int)FICLONERANGE)
     return -EOPNOTSUPP;
 #endif
 
   if ((unsigned int)cmd == (unsigned int)KAFS_IOCTL_COPY)
-  {
-    void *buf = data ? data : arg;
-    if (!buf)
-      return -EINVAL;
-    if (_IOC_SIZE((unsigned int)cmd) < sizeof(kafs_ioctl_copy_t))
-      return -EINVAL;
-    kafs_ioctl_copy_t req;
-    memcpy(&req, buf, sizeof(req));
-    if (req.struct_size < sizeof(req))
-      return -EINVAL;
-    if (req.src[0] != '/' || req.dst[0] != '/' || req.src[1] == '\0' || req.dst[1] == '\0')
-      return -EINVAL;
-
-    kafs_sinode_t *ino_src;
-    kafs_sinode_t *ino_dst;
-    KAFS_CALL(kafs_access, fctx, ctx, req.src, NULL, R_OK, &ino_src);
-
-    int drc = kafs_access(fctx, ctx, req.dst, NULL, F_OK, &ino_dst);
-    if (drc == -ENOENT)
-    {
-      kafs_inocnt_t ino_new;
-      KAFS_CALL(kafs_create, req.dst, 0644 | S_IFREG, 0, NULL, &ino_new);
-      ino_dst = kafs_ctx_inode(ctx, ino_new);
-    }
-    else
-    {
-      if (drc < 0)
-        return drc;
-      KAFS_CALL(kafs_access, fctx, ctx, req.dst, NULL, W_OK, &ino_dst);
-    }
-
-    if ((req.flags & KAFS_IOCTL_COPY_F_REFLINK) != 0)
-      return kafs_reflink_clone(ctx, ino_src, ino_dst);
-
-    uint32_t ino_dst_no = (uint32_t)kafs_ctx_ino_no(ctx, ino_dst);
-    kafs_inode_lock(ctx, ino_dst_no);
-    int trc = kafs_truncate(ctx, ino_dst, 0);
-    kafs_inode_unlock(ctx, ino_dst_no);
-    if (trc < 0)
-      return trc;
-
-    kafs_off_t src_size = kafs_ino_size_get(ino_src);
-    ssize_t copied = kafs_copy_regular_range(ctx, ino_src, ino_dst, 0, 0, (size_t)src_size);
-    return copied < 0 ? (int)copied : 0;
-  }
+    return kafs_ioctl_handle_copy(fctx, ctx, arg, data);
 
   if ((unsigned int)cmd == (unsigned int)KAFS_IOCTL_GET_STATS)
-  {
-    void *buf = data ? data : arg;
-    if (!buf)
-      return -EINVAL;
-    if (_IOC_SIZE((unsigned int)cmd) < sizeof(kafs_stats_t))
-      return -EINVAL;
-    kafs_stats_t req;
-    memset(&req, 0, sizeof(req));
-    memcpy(&req, buf, sizeof(req));
-    uint32_t request_flags = req.request_flags;
-
-    kafs_stats_t out;
-    kafs_stats_snapshot(ctx, &out, request_flags);
-    memcpy(buf, &out, sizeof(out));
-    return 0;
-  }
+    return kafs_ioctl_handle_get_stats(ctx, cmd, arg, data);
   return -ENOTTY;
 }
 

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -10404,6 +10404,157 @@ static int kafs_main_apply_env_overrides(kafs_main_options_t *opts)
   return kafs_main_apply_misc_env_overrides(opts);
 }
 
+static int kafs_main_copy_cli_string_option(char *dst, size_t dst_size, const char *value,
+                                            const char *error_message)
+{
+  if (!*value || snprintf(dst, dst_size, "%s", value) >= (int)dst_size)
+  {
+    fprintf(stderr, "%s\n", error_message);
+    return 2;
+  }
+  return 0;
+}
+
+static int kafs_main_handle_flag_arg(kafs_main_options_t *opts, const char *arg)
+{
+  if (kafs_cli_is_help_arg(arg))
+  {
+    opts->show_help = KAFS_TRUE;
+    return 1;
+  }
+  if (strcmp(arg, "--migrate") == 0 || strcmp(arg, "--migrate-v2") == 0)
+  {
+    opts->auto_migrate = KAFS_TRUE;
+    return 1;
+  }
+  if (strcmp(arg, "--yes") == 0)
+  {
+    opts->migrate_yes = KAFS_TRUE;
+    return 1;
+  }
+  if (strcmp(arg, "--no-writeback-cache") == 0)
+  {
+    opts->writeback_cache_enabled = KAFS_FALSE;
+    opts->writeback_cache_explicit = KAFS_TRUE;
+    return 1;
+  }
+  if (strcmp(arg, "--writeback-cache") == 0)
+  {
+    opts->writeback_cache_enabled = KAFS_TRUE;
+    opts->writeback_cache_explicit = KAFS_TRUE;
+    return 1;
+  }
+  if (strcmp(arg, "--trim-on-free") == 0)
+  {
+    opts->trim_on_free_enabled = KAFS_TRUE;
+    opts->trim_on_free_explicit = KAFS_TRUE;
+    return 1;
+  }
+  if (strcmp(arg, "--no-trim-on-free") == 0)
+  {
+    opts->trim_on_free_enabled = KAFS_FALSE;
+    opts->trim_on_free_explicit = KAFS_TRUE;
+    return 1;
+  }
+  if (strcmp(arg, "--hotplug") == 0)
+  {
+    snprintf(opts->hotplug_uds_opt, sizeof(opts->hotplug_uds_opt), "%s", KAFS_HOTPLUG_UDS_DEFAULT);
+    return 1;
+  }
+  return 0;
+}
+
+static int kafs_main_handle_hotplug_arg(int argc, char **argv, const char *prog, int *index,
+                                        kafs_main_options_t *opts, const char *arg)
+{
+  if (strncmp(arg, "--hotplug=", 10) == 0)
+    return kafs_main_copy_cli_string_option(opts->hotplug_uds_opt, sizeof(opts->hotplug_uds_opt),
+                                            arg + 10, "invalid --hotplug value");
+
+  if (strcmp(arg, "--hotplug-uds") == 0)
+  {
+    if (*index + 1 >= argc)
+    {
+      fprintf(stderr, "--hotplug-uds requires a path argument.\n");
+      usage(prog);
+      return 2;
+    }
+    *index += 1;
+    return kafs_main_copy_cli_string_option(opts->hotplug_uds_opt, sizeof(opts->hotplug_uds_opt),
+                                            argv[*index], "invalid --hotplug-uds value");
+  }
+
+  if (strncmp(arg, "--hotplug-uds=", 14) == 0)
+    return kafs_main_copy_cli_string_option(opts->hotplug_uds_opt, sizeof(opts->hotplug_uds_opt),
+                                            arg + 14, "invalid --hotplug-uds value");
+
+  if (strcmp(arg, "--hotplug-back-bin") == 0)
+  {
+    if (*index + 1 >= argc)
+    {
+      fprintf(stderr, "--hotplug-back-bin requires a path argument.\n");
+      usage(prog);
+      return 2;
+    }
+    *index += 1;
+    return kafs_main_copy_cli_string_option(opts->hotplug_back_bin_opt,
+                                            sizeof(opts->hotplug_back_bin_opt), argv[*index],
+                                            "invalid --hotplug-back-bin value");
+  }
+
+  if (strncmp(arg, "--hotplug-back-bin=", 19) == 0)
+    return kafs_main_copy_cli_string_option(opts->hotplug_back_bin_opt,
+                                            sizeof(opts->hotplug_back_bin_opt), arg + 19,
+                                            "invalid --hotplug-back-bin value");
+
+  return 0;
+}
+
+static int kafs_main_handle_passthrough_arg(int argc, char **argv, const char *prog, int *index,
+                                            kafs_main_options_t *opts, char **argv_clean,
+                                            int *argc_clean, const char *arg)
+{
+  if (strcmp(arg, "--option") == 0)
+  {
+    if (*index + 1 >= argc)
+    {
+      fprintf(stderr, "--option requires an argument.\n");
+      usage(prog);
+      return 2;
+    }
+    argv_clean[(*argc_clean)++] = "-o";
+    argv_clean[(*argc_clean)++] = argv[++(*index)];
+    return 1;
+  }
+
+  if (strncmp(arg, "--option=", 9) == 0)
+  {
+    argv_clean[(*argc_clean)++] = "-o";
+    argv_clean[(*argc_clean)++] = (char *)(arg + 9);
+    return 1;
+  }
+
+  if (strcmp(arg, "--image") == 0)
+  {
+    if (*index + 1 >= argc)
+    {
+      fprintf(stderr, "--image requires a path argument.\n");
+      usage(prog);
+      return 2;
+    }
+    opts->image_path = argv[++(*index)];
+    return 1;
+  }
+
+  if (strncmp(arg, "--image=", 8) == 0)
+  {
+    opts->image_path = arg + 8;
+    return 1;
+  }
+
+  return 0;
+}
+
 static int kafs_main_collect_args(int argc, char **argv, const char *prog,
                                   kafs_main_options_t *opts, char **argv_clean, int *argc_clean)
 {
@@ -10411,152 +10562,21 @@ static int kafs_main_collect_args(int argc, char **argv, const char *prog,
   for (int i = 0; i < argc; ++i)
   {
     const char *a = argv[i];
-    if (kafs_cli_is_help_arg(a))
-    {
-      opts->show_help = KAFS_TRUE;
+    if (kafs_main_handle_flag_arg(opts, a) != 0)
       continue;
-    }
-    if (strcmp(a, "--migrate") == 0 || strcmp(a, "--migrate-v2") == 0)
-    {
-      opts->auto_migrate = KAFS_TRUE;
-      continue;
-    }
-    if (strcmp(a, "--yes") == 0)
-    {
-      opts->migrate_yes = KAFS_TRUE;
-      continue;
-    }
-    if (strcmp(a, "--no-writeback-cache") == 0)
-    {
-      opts->writeback_cache_enabled = KAFS_FALSE;
-      opts->writeback_cache_explicit = KAFS_TRUE;
-      continue;
-    }
-    if (strcmp(a, "--writeback-cache") == 0)
-    {
-      opts->writeback_cache_enabled = KAFS_TRUE;
-      opts->writeback_cache_explicit = KAFS_TRUE;
-      continue;
-    }
-    if (strcmp(a, "--trim-on-free") == 0)
-    {
-      opts->trim_on_free_enabled = KAFS_TRUE;
-      opts->trim_on_free_explicit = KAFS_TRUE;
-      continue;
-    }
-    if (strcmp(a, "--no-trim-on-free") == 0)
-    {
-      opts->trim_on_free_enabled = KAFS_FALSE;
-      opts->trim_on_free_explicit = KAFS_TRUE;
-      continue;
-    }
-    if (strcmp(a, "--hotplug") == 0)
-    {
-      snprintf(opts->hotplug_uds_opt, sizeof(opts->hotplug_uds_opt), "%s",
-               KAFS_HOTPLUG_UDS_DEFAULT);
-      continue;
-    }
-    if (strncmp(a, "--hotplug=", 10) == 0)
-    {
-      const char *v = a + 10;
-      if (!*v || snprintf(opts->hotplug_uds_opt, sizeof(opts->hotplug_uds_opt), "%s", v) >=
-                     (int)sizeof(opts->hotplug_uds_opt))
-      {
-        fprintf(stderr, "invalid --hotplug value\n");
-        return 2;
-      }
-      continue;
-    }
-    if (strcmp(a, "--hotplug-uds") == 0)
-    {
-      if (i + 1 < argc)
-      {
-        const char *v = argv[++i];
-        if (!*v || snprintf(opts->hotplug_uds_opt, sizeof(opts->hotplug_uds_opt), "%s", v) >=
-                       (int)sizeof(opts->hotplug_uds_opt))
-        {
-          fprintf(stderr, "invalid --hotplug-uds value\n");
-          return 2;
-        }
-        continue;
-      }
-      fprintf(stderr, "--hotplug-uds requires a path argument.\n");
-      usage(prog);
+
+    int rc = kafs_main_handle_hotplug_arg(argc, argv, prog, &i, opts, a);
+    if (rc == 2)
       return 2;
-    }
-    if (strncmp(a, "--hotplug-uds=", 14) == 0)
-    {
-      const char *v = a + 14;
-      if (!*v || snprintf(opts->hotplug_uds_opt, sizeof(opts->hotplug_uds_opt), "%s", v) >=
-                     (int)sizeof(opts->hotplug_uds_opt))
-      {
-        fprintf(stderr, "invalid --hotplug-uds value\n");
-        return 2;
-      }
+    if (rc == 1)
       continue;
-    }
-    if (strcmp(a, "--hotplug-back-bin") == 0)
-    {
-      if (i + 1 < argc)
-      {
-        const char *v = argv[++i];
-        if (!*v || snprintf(opts->hotplug_back_bin_opt, sizeof(opts->hotplug_back_bin_opt), "%s",
-                            v) >= (int)sizeof(opts->hotplug_back_bin_opt))
-        {
-          fprintf(stderr, "invalid --hotplug-back-bin value\n");
-          return 2;
-        }
-        continue;
-      }
-      fprintf(stderr, "--hotplug-back-bin requires a path argument.\n");
-      usage(prog);
+
+    rc = kafs_main_handle_passthrough_arg(argc, argv, prog, &i, opts, argv_clean, argc_clean, a);
+    if (rc == 2)
       return 2;
-    }
-    if (strncmp(a, "--hotplug-back-bin=", 19) == 0)
-    {
-      const char *v = a + 19;
-      if (!*v || snprintf(opts->hotplug_back_bin_opt, sizeof(opts->hotplug_back_bin_opt), "%s",
-                          v) >= (int)sizeof(opts->hotplug_back_bin_opt))
-      {
-        fprintf(stderr, "invalid --hotplug-back-bin value\n");
-        return 2;
-      }
+    if (rc == 1)
       continue;
-    }
-    if (strcmp(a, "--option") == 0)
-    {
-      if (i + 1 < argc)
-      {
-        argv_clean[(*argc_clean)++] = "-o";
-        argv_clean[(*argc_clean)++] = argv[++i];
-        continue;
-      }
-      fprintf(stderr, "--option requires an argument.\n");
-      usage(prog);
-      return 2;
-    }
-    if (strncmp(a, "--option=", 9) == 0)
-    {
-      argv_clean[(*argc_clean)++] = "-o";
-      argv_clean[(*argc_clean)++] = (char *)(a + 9);
-      continue;
-    }
-    if (strcmp(a, "--image") == 0)
-    {
-      if (i + 1 < argc)
-      {
-        opts->image_path = argv[++i];
-        continue;
-      }
-      fprintf(stderr, "--image requires a path argument.\n");
-      usage(prog);
-      return 2;
-    }
-    if (strncmp(a, "--image=", 8) == 0)
-    {
-      opts->image_path = a + 8;
-      continue;
-    }
+
     argv_clean[(*argc_clean)++] = argv[i];
   }
   return 0;

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -3475,112 +3475,93 @@ static int kafs_ino_iblk_write_legacy(struct kafs_context *ctx, kafs_sinode_t *i
   return KAFS_SUCCESS;
 }
 
-/// @brief inode毎のデータを書き込む（ブロック単位）
-/// @param ctx コンテキスト
-/// @param inoent inode テーブルエントリ
-/// @param iblo ブロック番号
-/// @param buf バッファ
-/// @return 0: 成功, < 0: 失敗 (-errno)
-static int kafs_ino_iblk_write(struct kafs_context *ctx, kafs_sinode_t *inoent, kafs_iblkcnt_t iblo,
-                               const void *buf)
+static int kafs_ino_iblk_write_pending(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                       kafs_iblkcnt_t iblo, const void *buf, uint32_t *warned_state)
 {
-  static uint32_t s_pendinglog_full_warned = 0;
-#define KAFS_IBWRITE_TRY(_expr)                                                                    \
-  do                                                                                               \
-  {                                                                                                \
-    int _rc = (_expr);                                                                             \
-    if (_rc < 0)                                                                                   \
-      return _rc;                                                                                  \
-  } while (0)
-  kafs_dlog(3, "%s(ino = %d, iblo = %" PRIuFAST32 ")\n", __func__, kafs_ctx_ino_no(ctx, inoent),
-            iblo);
-  assert(ctx != NULL);
-  assert(buf != NULL);
-  assert(inoent != NULL);
-  assert(kafs_ino_get_usage(inoent));
-  // Directory metadata is frequently rewritten and can cross the inline/block-backed boundary.
-  // Keep that path synchronous so shrink-to-inline and unlink do not race with pendinglog writes.
-  if (ctx->c_pendinglog_enabled && ctx->c_pending_worker_running &&
-      !S_ISDIR(kafs_ino_mode_get(inoent)))
+  kafs_blkcnt_t temp_blo = KAFS_BLO_NONE;
+  int rc = kafs_blk_alloc(ctx, &temp_blo);
+  if (rc < 0)
+    return rc;
+
+  uint64_t t_lw0 = kafs_now_ns();
+  rc = kafs_blk_write(ctx, temp_blo, buf);
+  uint64_t t_lw1 = kafs_now_ns();
+  __atomic_add_fetch(&ctx->c_stat_iblk_write_ns_legacy_blk_write, t_lw1 - t_lw0, __ATOMIC_RELAXED);
+  if (rc < 0)
+    return rc;
+
+  uint32_t ino_idx = (uint32_t)kafs_ctx_ino_no(ctx, inoent);
+  kafs_blkcnt_t old_raw = KAFS_BLO_NONE;
+  kafs_blkcnt_t old_blo = KAFS_BLO_NONE;
+  uint32_t ino_epoch = kafs_inode_epoch_get(ctx, ino_idx);
+  rc = kafs_ino_ibrk_run(ctx, inoent, iblo, &old_raw, KAFS_IBLKREF_FUNC_GET_RAW);
+  if (rc < 0)
+    return rc;
+  if (!kafs_ref_is_pending(old_raw))
   {
-    kafs_blkcnt_t temp_blo = KAFS_BLO_NONE;
-    KAFS_IBWRITE_TRY(kafs_blk_alloc(ctx, &temp_blo));
-    uint64_t t_lw0 = kafs_now_ns();
-    KAFS_IBWRITE_TRY(kafs_blk_write(ctx, temp_blo, buf));
-    uint64_t t_lw1 = kafs_now_ns();
-    __atomic_add_fetch(&ctx->c_stat_iblk_write_ns_legacy_blk_write, t_lw1 - t_lw0,
-                       __ATOMIC_RELAXED);
-
-    uint32_t ino_idx = (uint32_t)kafs_ctx_ino_no(ctx, inoent);
-    kafs_blkcnt_t old_raw = KAFS_BLO_NONE;
-    kafs_blkcnt_t old_blo = KAFS_BLO_NONE;
-    uint32_t ino_epoch = kafs_inode_epoch_get(ctx, ino_idx);
-    KAFS_IBWRITE_TRY(kafs_ino_ibrk_run(ctx, inoent, iblo, &old_raw, KAFS_IBLKREF_FUNC_GET_RAW));
-    if (!kafs_ref_is_pending(old_raw))
-      KAFS_IBWRITE_TRY(kafs_ref_resolve_data_blo(ctx, old_raw, &old_blo));
-
-    kafs_pendinglog_entry_t ent = {0};
-    ent.ino = ino_idx;
-    ent.iblk = (uint32_t)iblo;
-    ent.ino_epoch = ino_epoch;
-    ent.temp_blo = (uint32_t)temp_blo;
-    ent.state = KAFS_PENDING_QUEUED;
-    ent.target_hrid = (uint32_t)old_blo;
-    ent.seq = kafs_now_realtime_ns();
-
-    uint64_t pending_id = 0;
-    if (ctx->c_pending_worker_lock_init)
-      pthread_mutex_lock(&ctx->c_pending_worker_lock);
-    int qrc = kafs_pendinglog_enqueue(ctx, &ent, &pending_id);
-    if (ctx->c_pending_worker_lock_init)
-    {
-      kafs_pending_worker_adjust_priority_locked(ctx);
-      pthread_mutex_unlock(&ctx->c_pending_worker_lock);
-    }
-    if (qrc < 0)
-    {
-      (void)kafs_inode_release_hrl_ref(ctx, temp_blo);
-      if (qrc != -ENOSPC)
-        return qrc;
-
-      uint32_t c = __atomic_fetch_add(&s_pendinglog_full_warned, 1u, __ATOMIC_RELAXED);
-      if (c < 8u)
-      {
-        kafs_log(KAFS_LOG_WARNING,
-                 "%s: pendinglog full (ino=%" PRIu32 ", iblk=%" PRIu32
-                 "), fallback to sync write\n",
-                 __func__, ino_idx, (uint32_t)iblo);
-      }
-
-      return kafs_ino_iblk_write_legacy(ctx, inoent, iblo, buf, 1);
-    }
-
-    if (qrc == 0)
-    {
-      kafs_blkcnt_t pref = KAFS_BLO_NONE;
-      KAFS_IBWRITE_TRY(kafs_ref_pending_encode(pending_id, &pref));
-      kafs_diag_log_dir_iblk_write("iblk_write_pending", ctx, inoent, iblo, old_raw, pref, buf,
-                                   kafs_sb_blksize_get(ctx->c_superblock));
-      KAFS_IBWRITE_TRY(kafs_ino_ibrk_run(ctx, inoent, iblo, &pref, KAFS_IBLKREF_FUNC_SET));
-
-      kafs_pending_worker_notify(ctx);
-      return KAFS_SUCCESS;
-    }
+    rc = kafs_ref_resolve_data_blo(ctx, old_raw, &old_blo);
+    if (rc < 0)
+      return rc;
   }
 
-  if (S_ISDIR(kafs_ino_mode_get(inoent)))
-    return kafs_ino_iblk_write_legacy(ctx, inoent, iblo, buf, 0);
+  kafs_pendinglog_entry_t ent = {0};
+  ent.ino = ino_idx;
+  ent.iblk = (uint32_t)iblo;
+  ent.ino_epoch = ino_epoch;
+  ent.temp_blo = (uint32_t)temp_blo;
+  ent.state = KAFS_PENDING_QUEUED;
+  ent.target_hrid = (uint32_t)old_blo;
+  ent.seq = kafs_now_realtime_ns();
 
-  // ゼロ/非ゼロを区別せず、常に通常のデータ書き込み経路を使う。
-  // Lock order policy requires hrl_global before inode. To avoid taking a lower-rank
-  // HRL lock while holding the inode lock, acquire the HRL ref outside the inode lock,
-  // then revalidate the target block mapping before committing the new reference.
+  uint64_t pending_id = 0;
+  if (ctx->c_pending_worker_lock_init)
+    pthread_mutex_lock(&ctx->c_pending_worker_lock);
+  int qrc = kafs_pendinglog_enqueue(ctx, &ent, &pending_id);
+  if (ctx->c_pending_worker_lock_init)
+  {
+    kafs_pending_worker_adjust_priority_locked(ctx);
+    pthread_mutex_unlock(&ctx->c_pending_worker_lock);
+  }
+  if (qrc < 0)
+  {
+    (void)kafs_inode_release_hrl_ref(ctx, temp_blo);
+    if (qrc != -ENOSPC)
+      return qrc;
+
+    uint32_t c = __atomic_fetch_add(warned_state, 1u, __ATOMIC_RELAXED);
+    if (c < 8u)
+    {
+      kafs_log(KAFS_LOG_WARNING,
+               "%s: pendinglog full (ino=%" PRIu32 ", iblk=%" PRIu32 "), fallback to sync write\n",
+               __func__, ino_idx, (uint32_t)iblo);
+    }
+    return 1;
+  }
+
+  kafs_blkcnt_t pref = KAFS_BLO_NONE;
+  rc = kafs_ref_pending_encode(pending_id, &pref);
+  if (rc < 0)
+    return rc;
+  kafs_diag_log_dir_iblk_write("iblk_write_pending", ctx, inoent, iblo, old_raw, pref, buf,
+                               kafs_sb_blksize_get(ctx->c_superblock));
+  rc = kafs_ino_ibrk_run(ctx, inoent, iblo, &pref, KAFS_IBLKREF_FUNC_SET);
+  if (rc < 0)
+    return rc;
+
+  kafs_pending_worker_notify(ctx);
+  return 0;
+}
+
+static int kafs_ino_iblk_write_hrl_retry(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                         kafs_iblkcnt_t iblo, const void *buf)
+{
   uint32_t ino_idx = (uint32_t)kafs_ctx_ino_no(ctx, inoent);
   for (unsigned retry = 0; retry < 8; ++retry)
   {
     kafs_blkcnt_t expected_old_blo = KAFS_BLO_NONE;
-    KAFS_IBWRITE_TRY(
-        kafs_ino_ibrk_run(ctx, inoent, iblo, &expected_old_blo, KAFS_IBLKREF_FUNC_GET));
+    int rc = kafs_ino_ibrk_run(ctx, inoent, iblo, &expected_old_blo, KAFS_IBLKREF_FUNC_GET);
+    if (rc < 0)
+      return rc;
 
     kafs_inode_unlock(ctx, ino_idx);
 
@@ -3591,7 +3572,7 @@ static int kafs_ino_iblk_write(struct kafs_context *ctx, kafs_sinode_t *inoent, 
 
     ctx->c_stat_hrl_put_calls++;
     uint64_t t_hrl0 = kafs_now_ns();
-    int rc = kafs_hrl_put(ctx, buf, &hrid, &is_new, &candidate_blo);
+    rc = kafs_hrl_put(ctx, buf, &hrid, &is_new, &candidate_blo);
     uint64_t t_hrl1 = kafs_now_ns();
     __atomic_add_fetch(&ctx->c_stat_iblk_write_ns_hrl_put, t_hrl1 - t_hrl0, __ATOMIC_RELAXED);
     if (rc == 0)
@@ -3613,7 +3594,9 @@ static int kafs_ino_iblk_write(struct kafs_context *ctx, kafs_sinode_t *inoent, 
     kafs_inode_lock(ctx, ino_idx);
 
     kafs_blkcnt_t current_old_blo = KAFS_BLO_NONE;
-    KAFS_IBWRITE_TRY(kafs_ino_ibrk_run(ctx, inoent, iblo, &current_old_blo, KAFS_IBLKREF_FUNC_GET));
+    rc = kafs_ino_ibrk_run(ctx, inoent, iblo, &current_old_blo, KAFS_IBLKREF_FUNC_GET);
+    if (rc < 0)
+      return rc;
     if (current_old_blo != expected_old_blo)
     {
       if (rc == 0 && candidate_blo != KAFS_BLO_NONE)
@@ -3634,7 +3617,9 @@ static int kafs_ino_iblk_write(struct kafs_context *ctx, kafs_sinode_t *inoent, 
       kafs_diag_log_dir_iblk_write(candidate_kind == 2 ? "iblk_write_rescue" : "iblk_write_hrl",
                                    ctx, inoent, iblo, current_old_blo, candidate_blo, buf,
                                    kafs_sb_blksize_get(ctx->c_superblock));
-      KAFS_IBWRITE_TRY(kafs_ino_ibrk_run(ctx, inoent, iblo, &candidate_blo, KAFS_IBLKREF_FUNC_SET));
+      rc = kafs_ino_ibrk_run(ctx, inoent, iblo, &candidate_blo, KAFS_IBLKREF_FUNC_SET);
+      if (rc < 0)
+        return rc;
       if (current_old_blo != KAFS_BLO_NONE && current_old_blo != candidate_blo)
       {
         kafs_inode_unlock(ctx, ino_idx);
@@ -3644,16 +3629,58 @@ static int kafs_ino_iblk_write(struct kafs_context *ctx, kafs_sinode_t *inoent, 
         __atomic_add_fetch(&ctx->c_stat_iblk_write_ns_dec_ref, t_dec1 - t_dec0, __ATOMIC_RELAXED);
         kafs_inode_lock(ctx, ino_idx);
       }
-      return KAFS_SUCCESS;
+      return 0;
     }
 
     break;
   }
 
-  // HRL 失敗時: レガシー経路
   ctx->c_stat_hrl_put_fallback_legacy++;
+  return 1;
+}
+
+/// @brief inode毎のデータを書き込む（ブロック単位）
+/// @param ctx コンテキスト
+/// @param inoent inode テーブルエントリ
+/// @param iblo ブロック番号
+/// @param buf バッファ
+/// @return 0: 成功, < 0: 失敗 (-errno)
+static int kafs_ino_iblk_write(struct kafs_context *ctx, kafs_sinode_t *inoent, kafs_iblkcnt_t iblo,
+                               const void *buf)
+{
+  static uint32_t s_pendinglog_full_warned = 0;
+  kafs_dlog(3, "%s(ino = %d, iblo = %" PRIuFAST32 ")\n", __func__, kafs_ctx_ino_no(ctx, inoent),
+            iblo);
+  assert(ctx != NULL);
+  assert(buf != NULL);
+  assert(inoent != NULL);
+  assert(kafs_ino_get_usage(inoent));
+  // Directory metadata is frequently rewritten and can cross the inline/block-backed boundary.
+  // Keep that path synchronous so shrink-to-inline and unlink do not race with pendinglog writes.
+  if (ctx->c_pendinglog_enabled && ctx->c_pending_worker_running &&
+      !S_ISDIR(kafs_ino_mode_get(inoent)))
+  {
+    int prc = kafs_ino_iblk_write_pending(ctx, inoent, iblo, buf, &s_pendinglog_full_warned);
+    if (prc < 0)
+      return prc;
+    if (prc == 0)
+      return KAFS_SUCCESS;
+    return kafs_ino_iblk_write_legacy(ctx, inoent, iblo, buf, 1);
+  }
+
+  if (S_ISDIR(kafs_ino_mode_get(inoent)))
+    return kafs_ino_iblk_write_legacy(ctx, inoent, iblo, buf, 0);
+
+  // ゼロ/非ゼロを区別せず、常に通常のデータ書き込み経路を使う。
+  // Lock order policy requires hrl_global before inode. To avoid taking a lower-rank
+  // HRL lock while holding the inode lock, acquire the HRL ref outside the inode lock,
+  // then revalidate the target block mapping before committing the new reference.
+  int hrc = kafs_ino_iblk_write_hrl_retry(ctx, inoent, iblo, buf);
+  if (hrc < 0)
+    return hrc;
+  if (hrc == 0)
+    return KAFS_SUCCESS;
   return kafs_ino_iblk_write_legacy(ctx, inoent, iblo, buf, 1);
-#undef KAFS_IBWRITE_TRY
 }
 
 __attribute_maybe_unused__ static int

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -4614,6 +4614,181 @@ out_success:
   return size;
 }
 
+static int kafs_truncate_push_free_ref(kafs_blkcnt_t **deferred_free, size_t *deferred_free_cnt,
+                                       size_t *deferred_free_cap, kafs_blkcnt_t blo)
+{
+  if (blo == KAFS_BLO_NONE)
+    return 0;
+  if (*deferred_free_cnt == *deferred_free_cap)
+  {
+    size_t new_cap = *deferred_free_cap ? (*deferred_free_cap << 1) : 256u;
+    kafs_blkcnt_t *nw = realloc(*deferred_free, new_cap * sizeof(*nw));
+    if (!nw)
+      return -ENOMEM;
+    *deferred_free = nw;
+    *deferred_free_cap = new_cap;
+  }
+  (*deferred_free)[(*deferred_free_cnt)++] = blo;
+  return 0;
+}
+
+static int kafs_truncate_collect_free_range(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                            kafs_iblkcnt_t start, kafs_iblkcnt_t end,
+                                            kafs_blkcnt_t **deferred_free,
+                                            size_t *deferred_free_cnt, size_t *deferred_free_cap)
+{
+  for (kafs_iblkcnt_t iblo = start; iblo < end; iblo++)
+  {
+    kafs_blkcnt_t old;
+    int rc = kafs_ino_ibrk_run(ctx, inoent, iblo, &old, KAFS_IBLKREF_FUNC_GET);
+    if (rc != 0)
+      return rc;
+    if (old == KAFS_BLO_NONE)
+      continue;
+
+    kafs_blkcnt_t none = KAFS_BLO_NONE;
+    rc = kafs_ino_ibrk_run(ctx, inoent, iblo, &none, KAFS_IBLKREF_FUNC_SET);
+    if (rc != 0)
+      return rc;
+
+    kafs_blkcnt_t f1, f2, f3;
+    rc = kafs_ino_prune_empty_indirects(ctx, inoent, iblo, &f1, &f2, &f3);
+    if (rc != 0)
+      return rc;
+
+    rc = kafs_truncate_push_free_ref(deferred_free, deferred_free_cnt, deferred_free_cap, old);
+    if (rc != 0)
+      return rc;
+    rc = kafs_truncate_push_free_ref(deferred_free, deferred_free_cnt, deferred_free_cap, f1);
+    if (rc != 0)
+      return rc;
+    rc = kafs_truncate_push_free_ref(deferred_free, deferred_free_cnt, deferred_free_cap, f2);
+    if (rc != 0)
+      return rc;
+    rc = kafs_truncate_push_free_ref(deferred_free, deferred_free_cnt, deferred_free_cap, f3);
+    if (rc != 0)
+      return rc;
+  }
+  return 0;
+}
+
+static void kafs_truncate_release_deferred_refs(struct kafs_context *ctx, uint32_t ino_idx,
+                                                kafs_blkcnt_t *deferred_free,
+                                                size_t deferred_free_cnt)
+{
+  if (deferred_free_cnt == 0)
+    return;
+  kafs_inode_unlock(ctx, ino_idx);
+  for (size_t i = 0; i < deferred_free_cnt; ++i)
+    (void)kafs_inode_release_hrl_ref(ctx, deferred_free[i]);
+  kafs_inode_lock(ctx, ino_idx);
+}
+
+static int kafs_truncate_handle_tail_only(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                          const kafs_sinode_taildesc_v5_t *taildesc,
+                                          kafs_off_t filesize_new, kafs_blksize_t blksize)
+{
+  if (filesize_new == 0)
+  {
+    struct kafs_tailmeta_region_view view;
+    uint32_t container_index;
+    uint16_t class_bytes;
+    uint16_t slot_index;
+    int rc = kafs_tailmeta_region_view_get(ctx, &view);
+    if (rc != 0)
+      return rc;
+    rc = kafs_tailmeta_find_container_index_by_blo(
+        &view, kafs_ino_taildesc_v5_container_blo_get(taildesc), &container_index);
+    if (rc != 0)
+      return rc;
+    class_bytes = kafs_tailmeta_container_hdr_class_bytes_get(&view.containers[container_index]);
+    if (class_bytes == 0u || kafs_ino_taildesc_v5_fragment_off_get(taildesc) % class_bytes != 0u)
+      return -EPROTO;
+    slot_index = (uint16_t)(kafs_ino_taildesc_v5_fragment_off_get(taildesc) / class_bytes);
+    KAFS_CALL(kafs_tailmeta_release_slot, &view, container_index, slot_index);
+    memset(inoent->i_blkreftbl, 0, sizeof(inoent->i_blkreftbl));
+    kafs_ino_blocks_set(inoent, 0);
+    kafs_ino_size_set(inoent, 0);
+    kafs_tailmeta_inode_taildesc_set_inline(ctx, inoent);
+    return KAFS_SUCCESS;
+  }
+
+  if (filesize_new <= (kafs_off_t)KAFS_INODE_DIRECT_BYTES)
+  {
+    struct kafs_tailmeta_region_view view;
+    uint32_t container_index;
+    uint16_t class_bytes;
+    uint16_t slot_index;
+    char inline_buf[KAFS_INODE_DIRECT_BYTES];
+    int rc = kafs_tailmeta_tail_only_load(ctx, inoent, inline_buf, filesize_new, 0);
+    if (rc != 0)
+      return rc;
+    rc = kafs_tailmeta_region_view_get(ctx, &view);
+    if (rc != 0)
+      return rc;
+    rc = kafs_tailmeta_find_container_index_by_blo(
+        &view, kafs_ino_taildesc_v5_container_blo_get(taildesc), &container_index);
+    if (rc != 0)
+      return rc;
+    class_bytes = kafs_tailmeta_container_hdr_class_bytes_get(&view.containers[container_index]);
+    if (class_bytes == 0u || kafs_ino_taildesc_v5_fragment_off_get(taildesc) % class_bytes != 0u)
+      return -EPROTO;
+    slot_index = (uint16_t)(kafs_ino_taildesc_v5_fragment_off_get(taildesc) / class_bytes);
+    KAFS_CALL(kafs_tailmeta_release_slot, &view, container_index, slot_index);
+    memset(inoent->i_blkreftbl, 0, sizeof(inoent->i_blkreftbl));
+    memcpy(inoent->i_blkreftbl, inline_buf, (size_t)filesize_new);
+    if (filesize_new < (kafs_off_t)KAFS_INODE_DIRECT_BYTES)
+      memset((char *)inoent->i_blkreftbl + filesize_new, 0,
+             KAFS_INODE_DIRECT_BYTES - (size_t)filesize_new);
+    kafs_ino_blocks_set(inoent, 0);
+    kafs_ino_size_set(inoent, filesize_new);
+    kafs_tailmeta_inode_taildesc_set_inline(ctx, inoent);
+    return KAFS_SUCCESS;
+  }
+
+  if (filesize_new < (kafs_off_t)blksize)
+  {
+    char smallbuf[blksize];
+    KAFS_CALL(kafs_tailmeta_load_small_file_bytes, ctx, inoent, smallbuf, filesize_new);
+    KAFS_CALL(kafs_tailmeta_store_tail_only, ctx, inoent, smallbuf, filesize_new);
+    return KAFS_SUCCESS;
+  }
+
+  KAFS_CALL(kafs_tailmeta_promote_tail_only_to_full_block, ctx, inoent);
+  kafs_ino_size_set(inoent, filesize_new);
+  kafs_tailmeta_inode_taildesc_set_full_block(ctx, inoent);
+  return KAFS_SUCCESS;
+}
+
+static int kafs_truncate_handle_growth(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                       kafs_off_t filesize_orig, kafs_off_t filesize_new,
+                                       kafs_blksize_t blksize)
+{
+  if (kafs_tailmeta_inode_is_regular_v5(ctx, inoent) &&
+      filesize_orig <= (kafs_off_t)KAFS_INODE_DIRECT_BYTES &&
+      filesize_new > (kafs_off_t)KAFS_INODE_DIRECT_BYTES && filesize_new < (kafs_off_t)blksize)
+  {
+    char smallbuf[blksize];
+    memset(smallbuf, 0, sizeof(smallbuf));
+    memcpy(smallbuf, inoent->i_blkreftbl, (size_t)filesize_orig);
+    KAFS_CALL(kafs_tailmeta_store_tail_only, ctx, inoent, smallbuf, filesize_new);
+    return KAFS_SUCCESS;
+  }
+
+  if (filesize_orig <= KAFS_INODE_DIRECT_BYTES && filesize_new > KAFS_INODE_DIRECT_BYTES)
+  {
+    char buf[blksize];
+    memcpy(buf, inoent->i_blkreftbl, filesize_orig);
+    memset(buf + filesize_orig, 0, blksize - filesize_orig);
+    KAFS_CALL(kafs_ino_iblk_write, ctx, inoent, 0, buf);
+  }
+
+  kafs_ino_size_set(inoent, filesize_new);
+  if (kafs_tailmeta_inode_is_regular_v5(ctx, inoent))
+    kafs_tailmeta_inode_taildesc_set_full_block(ctx, inoent);
+  return KAFS_SUCCESS;
+}
+
 static int kafs_truncate(struct kafs_context *ctx, kafs_sinode_t *inoent, kafs_off_t filesize_new)
 {
   uint32_t ino_idx = kafs_ctx_ino_no(ctx, inoent);
@@ -4629,28 +4804,6 @@ static int kafs_truncate(struct kafs_context *ctx, kafs_sinode_t *inoent, kafs_o
   kafs_blkcnt_t *deferred_free = NULL;
   size_t deferred_free_cnt = 0;
   size_t deferred_free_cap = 0;
-#define KAFS_TRUNC_PUSH_FREE(_blo)                                                                 \
-  do                                                                                               \
-  {                                                                                                \
-    kafs_blkcnt_t __b = (_blo);                                                                    \
-    if (__b != KAFS_BLO_NONE)                                                                      \
-    {                                                                                              \
-      kafs_dlog(2, "%s: ino=%u queue free blo=%" PRIuFAST32 "\n", __func__, ino_idx, __b);         \
-      if (deferred_free_cnt == deferred_free_cap)                                                  \
-      {                                                                                            \
-        size_t new_cap = deferred_free_cap ? (deferred_free_cap << 1) : 256u;                      \
-        kafs_blkcnt_t *nw = realloc(deferred_free, new_cap * sizeof(*nw));                         \
-        if (!nw)                                                                                   \
-        {                                                                                          \
-          free(deferred_free);                                                                     \
-          return -ENOMEM;                                                                          \
-        }                                                                                          \
-        deferred_free = nw;                                                                        \
-        deferred_free_cap = new_cap;                                                               \
-      }                                                                                            \
-      deferred_free[deferred_free_cnt++] = __b;                                                    \
-    }                                                                                              \
-  } while (0)
   (void)kafs_inode_epoch_bump(ctx, ino_idx);
   const kafs_sinode_taildesc_v5_t *taildesc = kafs_ctx_inode_taildesc_v5_const(ctx, inoent);
   if (taildesc &&
@@ -4663,102 +4816,15 @@ static int kafs_truncate(struct kafs_context *ctx, kafs_sinode_t *inoent, kafs_o
   }
   if (taildesc && kafs_ino_taildesc_v5_layout_kind_get(taildesc) == KAFS_TAIL_LAYOUT_TAIL_ONLY)
   {
-    if (filesize_new == 0)
-    {
-      struct kafs_tailmeta_region_view view;
-      uint32_t container_index;
-      uint16_t class_bytes;
-      uint16_t slot_index;
-      int rc = kafs_tailmeta_region_view_get(ctx, &view);
-      if (rc != 0)
-        return rc;
-      rc = kafs_tailmeta_find_container_index_by_blo(
-          &view, kafs_ino_taildesc_v5_container_blo_get(taildesc), &container_index);
-      if (rc != 0)
-        return rc;
-      class_bytes = kafs_tailmeta_container_hdr_class_bytes_get(&view.containers[container_index]);
-      if (class_bytes == 0u || kafs_ino_taildesc_v5_fragment_off_get(taildesc) % class_bytes != 0u)
-        return -EPROTO;
-      slot_index = (uint16_t)(kafs_ino_taildesc_v5_fragment_off_get(taildesc) / class_bytes);
-      KAFS_CALL(kafs_tailmeta_release_slot, &view, container_index, slot_index);
-      memset(inoent->i_blkreftbl, 0, sizeof(inoent->i_blkreftbl));
-      kafs_ino_blocks_set(inoent, 0);
-      kafs_ino_size_set(inoent, 0);
-      kafs_tailmeta_inode_taildesc_set_inline(ctx, inoent);
-      free(deferred_free);
-      return KAFS_SUCCESS;
-    }
-    if (filesize_new <= (kafs_off_t)KAFS_INODE_DIRECT_BYTES)
-    {
-      struct kafs_tailmeta_region_view view;
-      uint32_t container_index;
-      uint16_t class_bytes;
-      uint16_t slot_index;
-      char inline_buf[KAFS_INODE_DIRECT_BYTES];
-      int rc = kafs_tailmeta_tail_only_load(ctx, inoent, inline_buf, filesize_new, 0);
-      if (rc != 0)
-        return rc;
-      rc = kafs_tailmeta_region_view_get(ctx, &view);
-      if (rc != 0)
-        return rc;
-      rc = kafs_tailmeta_find_container_index_by_blo(
-          &view, kafs_ino_taildesc_v5_container_blo_get(taildesc), &container_index);
-      if (rc != 0)
-        return rc;
-      class_bytes = kafs_tailmeta_container_hdr_class_bytes_get(&view.containers[container_index]);
-      if (class_bytes == 0u || kafs_ino_taildesc_v5_fragment_off_get(taildesc) % class_bytes != 0u)
-        return -EPROTO;
-      slot_index = (uint16_t)(kafs_ino_taildesc_v5_fragment_off_get(taildesc) / class_bytes);
-      KAFS_CALL(kafs_tailmeta_release_slot, &view, container_index, slot_index);
-      memset(inoent->i_blkreftbl, 0, sizeof(inoent->i_blkreftbl));
-      memcpy(inoent->i_blkreftbl, inline_buf, (size_t)filesize_new);
-      if (filesize_new < (kafs_off_t)KAFS_INODE_DIRECT_BYTES)
-        memset((char *)inoent->i_blkreftbl + filesize_new, 0,
-               KAFS_INODE_DIRECT_BYTES - (size_t)filesize_new);
-      kafs_ino_blocks_set(inoent, 0);
-      kafs_ino_size_set(inoent, filesize_new);
-      kafs_tailmeta_inode_taildesc_set_inline(ctx, inoent);
-      free(deferred_free);
-      return KAFS_SUCCESS;
-    }
-    if (filesize_new < (kafs_off_t)blksize)
-    {
-      char smallbuf[blksize];
-      KAFS_CALL(kafs_tailmeta_load_small_file_bytes, ctx, inoent, smallbuf, filesize_new);
-      KAFS_CALL(kafs_tailmeta_store_tail_only, ctx, inoent, smallbuf, filesize_new);
-      free(deferred_free);
-      return KAFS_SUCCESS;
-    }
-    KAFS_CALL(kafs_tailmeta_promote_tail_only_to_full_block, ctx, inoent);
-    kafs_ino_size_set(inoent, filesize_new);
-    kafs_tailmeta_inode_taildesc_set_full_block(ctx, inoent);
+    int rc = kafs_truncate_handle_tail_only(ctx, inoent, taildesc, filesize_new, blksize);
     free(deferred_free);
-    return KAFS_SUCCESS;
+    return rc;
   }
   if (filesize_new > filesize_orig)
   {
-    if (kafs_tailmeta_inode_is_regular_v5(ctx, inoent) &&
-        filesize_orig <= (kafs_off_t)KAFS_INODE_DIRECT_BYTES &&
-        filesize_new > (kafs_off_t)KAFS_INODE_DIRECT_BYTES && filesize_new < (kafs_off_t)blksize)
-    {
-      char smallbuf[blksize];
-      memset(smallbuf, 0, sizeof(smallbuf));
-      memcpy(smallbuf, inoent->i_blkreftbl, (size_t)filesize_orig);
-      KAFS_CALL(kafs_tailmeta_store_tail_only, ctx, inoent, smallbuf, filesize_new);
-      free(deferred_free);
-      return KAFS_SUCCESS;
-    }
-    if (filesize_orig <= KAFS_INODE_DIRECT_BYTES && filesize_new > KAFS_INODE_DIRECT_BYTES)
-    {
-      char buf[blksize];
-      memcpy(buf, inoent->i_blkreftbl, filesize_orig);
-      memset(buf + filesize_orig, 0, blksize - filesize_orig);
-      KAFS_CALL(kafs_ino_iblk_write, ctx, inoent, 0, buf);
-    }
-    kafs_ino_size_set(inoent, filesize_new);
-    if (kafs_tailmeta_inode_is_regular_v5(ctx, inoent))
-      kafs_tailmeta_inode_taildesc_set_full_block(ctx, inoent);
-    return KAFS_SUCCESS;
+    int rc = kafs_truncate_handle_growth(ctx, inoent, filesize_orig, filesize_new, blksize);
+    free(deferred_free);
+    return rc;
   }
   assert(filesize_new < filesize_orig);
   kafs_iblkcnt_t iblooff = filesize_new >> log_blksize;
@@ -4792,31 +4858,12 @@ static int kafs_truncate(struct kafs_context *ctx, kafs_sinode_t *inoent, kafs_o
       if (end > iblocnt)
         end = iblocnt;
 
-      kafs_blkcnt_t to_free[TRUNC_BATCH * 4];
-      size_t to_free_cnt = 0;
-      for (kafs_iblkcnt_t iblo = cur; iblo < end; iblo++)
+      int rc = kafs_truncate_collect_free_range(ctx, inoent, cur, end, &deferred_free,
+                                                &deferred_free_cnt, &deferred_free_cap);
+      if (rc != 0)
       {
-        kafs_blkcnt_t old;
-        KAFS_CALL(kafs_ino_ibrk_run, ctx, inoent, iblo, &old, KAFS_IBLKREF_FUNC_GET);
-        if (old == KAFS_BLO_NONE)
-          continue;
-        kafs_blkcnt_t none = KAFS_BLO_NONE;
-        KAFS_CALL(kafs_ino_ibrk_run, ctx, inoent, iblo, &none, KAFS_IBLKREF_FUNC_SET);
-        kafs_blkcnt_t f1, f2, f3;
-        KAFS_CALL(kafs_ino_prune_empty_indirects, ctx, inoent, iblo, &f1, &f2, &f3);
-        to_free[to_free_cnt++] = old;
-        if (f1 != KAFS_BLO_NONE)
-          to_free[to_free_cnt++] = f1;
-        if (f2 != KAFS_BLO_NONE)
-          to_free[to_free_cnt++] = f2;
-        if (f3 != KAFS_BLO_NONE)
-          to_free[to_free_cnt++] = f3;
-      }
-
-      if (to_free_cnt)
-      {
-        for (size_t i = 0; i < to_free_cnt; i++)
-          KAFS_TRUNC_PUSH_FREE(to_free[i]);
+        free(deferred_free);
+        return rc;
       }
       cur = end;
     }
@@ -4826,13 +4873,7 @@ static int kafs_truncate(struct kafs_context *ctx, kafs_sinode_t *inoent, kafs_o
       memset((void *)inoent->i_blkreftbl + filesize_new, 0, KAFS_INODE_DIRECT_BYTES - filesize_new);
     if (kafs_tailmeta_inode_is_regular_v5(ctx, inoent))
       kafs_tailmeta_inode_taildesc_set_inline(ctx, inoent);
-    if (deferred_free_cnt)
-    {
-      kafs_inode_unlock(ctx, ino_idx);
-      for (size_t i = 0; i < deferred_free_cnt; ++i)
-        (void)kafs_inode_release_hrl_ref(ctx, deferred_free[i]);
-      kafs_inode_lock(ctx, ino_idx);
-    }
+    kafs_truncate_release_deferred_refs(ctx, ino_idx, deferred_free, deferred_free_cnt);
     free(deferred_free);
     return KAFS_SUCCESS;
   }
@@ -4868,44 +4909,18 @@ static int kafs_truncate(struct kafs_context *ctx, kafs_sinode_t *inoent, kafs_o
     if (end > iblocnt)
       end = iblocnt;
 
-    kafs_blkcnt_t to_free[TRUNC_BATCH * 4];
-    size_t to_free_cnt = 0;
-    for (kafs_iblkcnt_t iblo = iblooff; iblo < end; iblo++)
+    int rc = kafs_truncate_collect_free_range(ctx, inoent, iblooff, end, &deferred_free,
+                                              &deferred_free_cnt, &deferred_free_cap);
+    if (rc != 0)
     {
-      kafs_blkcnt_t old;
-      KAFS_CALL(kafs_ino_ibrk_run, ctx, inoent, iblo, &old, KAFS_IBLKREF_FUNC_GET);
-      if (old == KAFS_BLO_NONE)
-        continue;
-      kafs_blkcnt_t none = KAFS_BLO_NONE;
-      KAFS_CALL(kafs_ino_ibrk_run, ctx, inoent, iblo, &none, KAFS_IBLKREF_FUNC_SET);
-      kafs_blkcnt_t f1, f2, f3;
-      KAFS_CALL(kafs_ino_prune_empty_indirects, ctx, inoent, iblo, &f1, &f2, &f3);
-      to_free[to_free_cnt++] = old;
-      if (f1 != KAFS_BLO_NONE)
-        to_free[to_free_cnt++] = f1;
-      if (f2 != KAFS_BLO_NONE)
-        to_free[to_free_cnt++] = f2;
-      if (f3 != KAFS_BLO_NONE)
-        to_free[to_free_cnt++] = f3;
-    }
-
-    if (to_free_cnt)
-    {
-      for (size_t i = 0; i < to_free_cnt; i++)
-        KAFS_TRUNC_PUSH_FREE(to_free[i]);
+      free(deferred_free);
+      return rc;
     }
     iblooff = end;
   }
 
-  if (deferred_free_cnt)
-  {
-    kafs_inode_unlock(ctx, ino_idx);
-    for (size_t i = 0; i < deferred_free_cnt; ++i)
-      (void)kafs_inode_release_hrl_ref(ctx, deferred_free[i]);
-    kafs_inode_lock(ctx, ino_idx);
-  }
+  kafs_truncate_release_deferred_refs(ctx, ino_idx, deferred_free, deferred_free_cnt);
   free(deferred_free);
-#undef KAFS_TRUNC_PUSH_FREE
   {
     int rc = kafs_tailmeta_normalize_block_layout(ctx, inoent);
     if (rc != 0)

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -8021,6 +8021,43 @@ static ssize_t kafs_copy_regular_range(kafs_context_t *ctx, kafs_sinode_t *ino_i
 
 // Copy one full block by sharing HRL reference instead of read+hash+write.
 // Caller must hold src/dst inode locks.
+static void kafs_copy_share_append_release(kafs_blkcnt_t *release_list, size_t *release_cnt,
+                                           kafs_blkcnt_t blo)
+{
+  if (blo != KAFS_BLO_NONE)
+    release_list[(*release_cnt)++] = blo;
+}
+
+static int kafs_copy_share_collect_pruned_refs(kafs_context_t *ctx, kafs_sinode_t *dst,
+                                               kafs_iblkcnt_t dst_iblo, kafs_blkcnt_t *release_list,
+                                               size_t *release_cnt)
+{
+  kafs_blkcnt_t f1 = KAFS_BLO_NONE;
+  kafs_blkcnt_t f2 = KAFS_BLO_NONE;
+  kafs_blkcnt_t f3 = KAFS_BLO_NONE;
+  int rc = kafs_ino_prune_empty_indirects(ctx, dst, dst_iblo, &f1, &f2, &f3);
+  if (rc < 0)
+    return rc;
+
+  kafs_copy_share_append_release(release_list, release_cnt, f1);
+  kafs_copy_share_append_release(release_list, release_cnt, f2);
+  kafs_copy_share_append_release(release_list, release_cnt, f3);
+  return 0;
+}
+
+static void kafs_copy_share_release_refs(kafs_context_t *ctx, uint32_t ino_dst,
+                                         const kafs_blkcnt_t *release_list, size_t release_cnt)
+{
+  if (release_cnt == 0)
+    return;
+
+  // Keep existing lock ordering: dec_ref runs outside inode lock.
+  kafs_inode_unlock(ctx, ino_dst);
+  for (size_t i = 0; i < release_cnt; ++i)
+    (void)kafs_inode_release_hrl_ref(ctx, release_list[i]);
+  kafs_inode_lock(ctx, ino_dst);
+}
+
 static int kafs_copy_share_one_iblk_locked(kafs_context_t *ctx, kafs_sinode_t *src,
                                            kafs_sinode_t *dst, kafs_iblkcnt_t src_iblo,
                                            kafs_iblkcnt_t dst_iblo, uint32_t ino_dst)
@@ -8066,31 +8103,13 @@ static int kafs_copy_share_one_iblk_locked(kafs_context_t *ctx, kafs_sinode_t *s
 
   if (src_blo == KAFS_BLO_NONE)
   {
-    kafs_blkcnt_t f1 = KAFS_BLO_NONE;
-    kafs_blkcnt_t f2 = KAFS_BLO_NONE;
-    kafs_blkcnt_t f3 = KAFS_BLO_NONE;
-    rc = kafs_ino_prune_empty_indirects(ctx, dst, dst_iblo, &f1, &f2, &f3);
+    rc = kafs_copy_share_collect_pruned_refs(ctx, dst, dst_iblo, release_list, &release_cnt);
     if (rc < 0)
       return rc;
-    if (f1 != KAFS_BLO_NONE)
-      release_list[release_cnt++] = f1;
-    if (f2 != KAFS_BLO_NONE)
-      release_list[release_cnt++] = f2;
-    if (f3 != KAFS_BLO_NONE)
-      release_list[release_cnt++] = f3;
   }
 
-  if (old_blo != KAFS_BLO_NONE)
-    release_list[release_cnt++] = old_blo;
-
-  if (release_cnt != 0)
-  {
-    // Keep existing lock ordering: dec_ref runs outside inode lock.
-    kafs_inode_unlock(ctx, ino_dst);
-    for (size_t i = 0; i < release_cnt; ++i)
-      (void)kafs_inode_release_hrl_ref(ctx, release_list[i]);
-    kafs_inode_lock(ctx, ino_dst);
-  }
+  kafs_copy_share_append_release(release_list, &release_cnt, old_blo);
+  kafs_copy_share_release_refs(ctx, ino_dst, release_list, release_cnt);
   __atomic_add_fetch(&ctx->c_stat_copy_share_done_blocks, 1u, __ATOMIC_RELAXED);
   return 0;
 }

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -2809,6 +2809,8 @@ static void kafs_diag_log_live_dir_block0_write(struct kafs_context *ctx, kafs_b
                       g_diag_write_path ? g_diag_write_path : "(null)",
                       hex_sample[0] ? hex_sample : "-", ascii_sample[0] ? ascii_sample : "-");
   }
+}
+
 #else
   (void)ctx;
   (void)blo;

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -6014,6 +6014,87 @@ static int kafs_resolve_fh_inode(struct kafs_context *ctx, const struct fuse_fil
   return KAFS_SUCCESS;
 }
 
+static size_t kafs_access_load_groups(gid_t groups[])
+{
+  ssize_t ng0 = fuse_getgroups(0, NULL);
+  size_t ngroups = (ng0 > 0) ? (size_t)ng0 : 0;
+
+  if (ngroups > 0)
+    (void)fuse_getgroups(ngroups, groups);
+  return ngroups;
+}
+
+static int kafs_access_resolve_start(struct kafs_context *ctx, const char *path,
+                                     struct fuse_file_info *fi, kafs_sinode_t **inoent,
+                                     const char **p)
+{
+  int fh_rc = -EBADF;
+
+  if (fi != NULL)
+    fh_rc = kafs_resolve_fh_inode(ctx, fi, inoent);
+
+  if (path == NULL || path[0] == '\0')
+  {
+    assert(fi != NULL);
+    if (fh_rc < 0)
+      return fh_rc;
+    *p = "";
+    return KAFS_SUCCESS;
+  }
+
+  if (fh_rc == 0)
+  {
+    __atomic_add_fetch(&ctx->c_stat_access_fh_fastpath_hits, 1u, __ATOMIC_RELAXED);
+    *p = "";
+    return KAFS_SUCCESS;
+  }
+
+  __atomic_add_fetch(&ctx->c_stat_access_path_walk_calls, 1u, __ATOMIC_RELAXED);
+  *inoent = kafs_ctx_inode(ctx, KAFS_INO_ROOTDIR);
+  *p = path + 1;
+  return KAFS_SUCCESS;
+}
+
+static int kafs_access_walk_path(struct fuse_context *fctx, kafs_context_t *ctx,
+                                 kafs_sinode_t **inoent, const char *p, gid_t groups[],
+                                 size_t ngroups)
+{
+  while (*p != '\0')
+  {
+    const char *n = strchrnul(p, '/');
+    __atomic_add_fetch(&ctx->c_stat_access_path_components, 1u, __ATOMIC_RELAXED);
+    kafs_mode_t cur_mode = kafs_ino_mode_get(*inoent);
+    kafs_dlog(2, "%s: component='%.*s' checking dir ino=%u mode=%o\n", __func__, (int)(n - p), p,
+              (unsigned)kafs_ctx_ino_no(ctx, *inoent), (unsigned)cur_mode);
+
+    int rc = kafs_access_check(X_OK, *inoent, KAFS_TRUE, fctx->uid, fctx->gid, ngroups, groups);
+    if (rc < 0)
+      return rc;
+
+    uint32_t ino_dir = (uint32_t)kafs_ctx_ino_no(ctx, *inoent);
+    char *snap = NULL;
+    size_t snap_len = 0;
+    kafs_inode_lock(ctx, ino_dir);
+    rc = kafs_dir_snapshot(ctx, *inoent, &snap, &snap_len);
+    kafs_inode_unlock(ctx, ino_dir);
+    if (rc < 0)
+      return rc;
+
+    rc = kafs_dirent_search_snapshot(ctx, snap, snap_len, p, n - p, ino_dir, inoent);
+    free(snap);
+    if (rc < 0)
+    {
+      kafs_dlog(2, "%s: dirent_search('%.*s') rc=%d\n", __func__, (int)(n - p), p, rc);
+      return rc;
+    }
+    if (*n == '\0')
+      break;
+    p = n + 1;
+  }
+
+  return KAFS_SUCCESS;
+}
+
 // cppcheck-suppress constParameterCallback
 static int kafs_access(struct fuse_context *fctx, kafs_context_t *ctx, const char *path,
                        struct fuse_file_info *fi, int ok, kafs_sinode_t **pinoent)
@@ -6028,74 +6109,18 @@ static int kafs_access(struct fuse_context *fctx, kafs_context_t *ctx, const cha
   uid_t uid = fctx->uid;
   gid_t gid = fctx->gid;
   ssize_t ng0 = fuse_getgroups(0, NULL);
-  size_t ngroups = (ng0 > 0) ? (size_t)ng0 : 0;
-  gid_t groups[(ngroups > 0) ? ngroups : 1];
-  if (ngroups > 0)
-    (void)fuse_getgroups(ngroups, groups);
+  gid_t groups[(ng0 > 0) ? (size_t)ng0 : 1];
+  size_t ngroups = kafs_access_load_groups(groups);
 
   kafs_sinode_t *inoent = NULL;
   const char *p = NULL;
-  int fh_rc = -EBADF;
-  if (fi != NULL)
-    fh_rc = kafs_resolve_fh_inode(ctx, fi, &inoent);
-
-  if (path == NULL || path[0] == '\0')
-  {
-    assert(fi != NULL);
-    if (fh_rc < 0)
-      return fh_rc;
-    p = "";
-  }
-  else if (fh_rc == 0)
-  {
-    __atomic_add_fetch(&ctx->c_stat_access_fh_fastpath_hits, 1u, __ATOMIC_RELAXED);
-    p = "";
-  }
-  else
-  {
-    __atomic_add_fetch(&ctx->c_stat_access_path_walk_calls, 1u, __ATOMIC_RELAXED);
-    inoent = kafs_ctx_inode(ctx, KAFS_INO_ROOTDIR);
-    p = path + 1;
-  }
-
-  int ok_final = ok;
-  while (*p != '\0')
-  {
-    const char *n = strchrnul(p, '/');
-    __atomic_add_fetch(&ctx->c_stat_access_path_components, 1u, __ATOMIC_RELAXED);
-    kafs_mode_t cur_mode = kafs_ino_mode_get(inoent);
-    kafs_dlog(2, "%s: component='%.*s' checking dir ino=%u mode=%o\n", __func__, (int)(n - p), p,
-              (unsigned)kafs_ctx_ino_no(ctx, inoent), (unsigned)cur_mode);
-    int ok_dirs = X_OK;
-    int rc_ac = kafs_access_check(ok_dirs, inoent, KAFS_TRUE, uid, gid, ngroups, groups);
-    if (rc_ac < 0)
-      return rc_ac;
-
-    uint32_t ino_dir = (uint32_t)kafs_ctx_ino_no(ctx, inoent);
-    char *snap = NULL;
-    size_t snap_len = 0;
-    kafs_inode_lock(ctx, ino_dir);
-    int rc = kafs_dir_snapshot(ctx, inoent, &snap, &snap_len);
-    kafs_inode_unlock(ctx, ino_dir);
-    if (rc < 0)
-      return rc;
-
-    rc = kafs_dirent_search_snapshot(ctx, snap, snap_len, p, n - p, ino_dir, &inoent);
-    free(snap);
-    if (rc < 0)
-    {
-      kafs_dlog(2, "%s: dirent_search('%.*s') rc=%d\n", __func__, (int)(n - p), p, rc);
-      return rc;
-    }
-    if (*n == '\0')
-      break;
-    p = n + 1;
-  }
+  KAFS_CALL(kafs_access_resolve_start, ctx, path, fi, &inoent, &p);
+  KAFS_CALL(kafs_access_walk_path, fctx, ctx, &inoent, p, groups, ngroups);
 
   kafs_mode_t final_mode = kafs_ino_mode_get(inoent);
   kafs_dlog(2, "%s: final node ino=%u mode=%o ok=%d\n", __func__,
-            (unsigned)kafs_ctx_ino_no(ctx, inoent), (unsigned)final_mode, ok_final);
-  KAFS_CALL(kafs_access_check, ok_final, inoent, KAFS_FALSE, uid, gid, ngroups, groups);
+            (unsigned)kafs_ctx_ino_no(ctx, inoent), (unsigned)final_mode, ok);
+  KAFS_CALL(kafs_access_check, ok, inoent, KAFS_FALSE, uid, gid, ngroups, groups);
   if (pinoent != NULL)
     *pinoent = inoent;
   return KAFS_SUCCESS;

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -1675,6 +1675,140 @@ static int kafs_bg_dedup_try_install(struct kafs_context *ctx, uint32_t ino, kaf
   return installed;
 }
 
+typedef struct kafs_bg_dedup_sweep_state
+{
+  uint32_t bucket_heads[KAFS_BG_DEDUP_SWEEP_BUCKETS];
+  uint64_t entry_fast[KAFS_BG_DEDUP_SWEEP_IDX_CAP_PRESSURE];
+  uint32_t entry_blo[KAFS_BG_DEDUP_SWEEP_IDX_CAP_PRESSURE];
+  uint32_t entry_next[KAFS_BG_DEDUP_SWEEP_IDX_CAP_PRESSURE];
+  uint32_t entry_count;
+} kafs_bg_dedup_sweep_state_t;
+
+static void kafs_bg_dedup_advance_or_cooldown(struct kafs_context *ctx, kafs_inocnt_t inocnt,
+                                              uint32_t next_iblk, int pressure_mode)
+{
+  if (kafs_bg_advance_cursor(ctx, inocnt, next_iblk))
+    kafs_bg_enter_cooldown(ctx, pressure_mode);
+}
+
+static void kafs_bg_dedup_sweep_state_init(kafs_bg_dedup_sweep_state_t *state)
+{
+  state->entry_count = 0;
+  for (uint32_t i = 0; i < KAFS_BG_DEDUP_SWEEP_BUCKETS; ++i)
+    state->bucket_heads[i] = UINT32_MAX;
+}
+
+static int kafs_bg_dedup_prepare_inode_scan(struct kafs_context *ctx, kafs_sinode_t *inoent,
+                                            kafs_inocnt_t scanned, kafs_inocnt_t inocnt,
+                                            int pressure_mode, kafs_blksize_t bs,
+                                            uint32_t scan_window, kafs_iblkcnt_t *iblocnt_out,
+                                            uint32_t *direct_cnt_out)
+{
+  if (!kafs_ino_get_usage(inoent) || S_ISDIR(kafs_ino_mode_get(inoent)))
+  {
+    kafs_inode_unlock(ctx, kafs_ctx_ino_no(ctx, inoent));
+    if (scanned == 0)
+      kafs_bg_dedup_advance_or_cooldown(ctx, inocnt, 0, pressure_mode);
+    return 0;
+  }
+
+  kafs_off_t size = kafs_ino_size_get(inoent);
+  if (size <= KAFS_INODE_DIRECT_BYTES)
+  {
+    kafs_inode_unlock(ctx, kafs_ctx_ino_no(ctx, inoent));
+    if (scanned == 0)
+      kafs_bg_dedup_advance_or_cooldown(ctx, inocnt, 0, pressure_mode);
+    return 0;
+  }
+
+  *iblocnt_out = (kafs_iblkcnt_t)((size + bs - 1) / bs);
+  *direct_cnt_out = (*iblocnt_out < scan_window) ? (uint32_t)*iblocnt_out : scan_window;
+  if (*direct_cnt_out == 0)
+  {
+    kafs_inode_unlock(ctx, kafs_ctx_ino_no(ctx, inoent));
+    if (scanned == 0)
+      kafs_bg_dedup_advance_or_cooldown(ctx, inocnt, 0, pressure_mode);
+    return 0;
+  }
+
+  return 1;
+}
+
+static int kafs_bg_dedup_handle_scanned_block(struct kafs_context *ctx, uint32_t ino,
+                                              kafs_iblkcnt_t iblk, kafs_blkcnt_t snapshot_raw,
+                                              kafs_blkcnt_t old_blo, const void *buf,
+                                              kafs_blksize_t bs, uint32_t sweep_cap,
+                                              uint32_t block_budget,
+                                              uint32_t *scanned_blocks_this_step,
+                                              kafs_bg_dedup_sweep_state_t *sweep_state)
+{
+  kafs_blkcnt_t match_blo = KAFS_BLO_NONE;
+  int mrc = kafs_hrl_match_inc_by_block_excluding_blo(ctx, buf, old_blo, &match_blo);
+  if (mrc == 0 && match_blo != KAFS_BLO_NONE)
+  {
+    if (kafs_bg_dedup_try_install(ctx, ino, iblk, snapshot_raw, match_blo))
+    {
+      __atomic_add_fetch(&ctx->c_stat_bg_dedup_replacements, 1u, __ATOMIC_RELAXED);
+      (void)kafs_inode_release_hrl_ref(ctx, old_blo);
+      __atomic_add_fetch(&ctx->c_stat_pending_old_block_freed, 1u, __ATOMIC_RELAXED);
+      return 2;
+    }
+    (void)kafs_inode_release_hrl_ref(ctx, match_blo);
+  }
+
+  uint64_t fast = kafs_bg_hash64(buf, bs);
+  kafs_blkcnt_t dup_direct = kafs_bg_sweep_find_dup_blo(
+      ctx, fast, old_blo, buf, sweep_state->bucket_heads, sweep_state->entry_fast,
+      sweep_state->entry_blo, sweep_state->entry_next);
+  if (dup_direct == KAFS_BLO_NONE)
+    dup_direct = kafs_bg_recent_find_dup_blo(ctx, fast, old_blo, buf);
+  if (dup_direct == KAFS_BLO_NONE)
+    dup_direct = kafs_bg_index_find_dup_blo(ctx, fast, old_blo, buf);
+  kafs_bg_sweep_note(fast, old_blo, sweep_cap, &sweep_state->entry_count, sweep_state->bucket_heads,
+                     sweep_state->entry_fast, sweep_state->entry_blo, sweep_state->entry_next);
+  kafs_bg_recent_note(ctx, fast, old_blo);
+  kafs_bg_index_note(ctx, fast, old_blo);
+  if (dup_direct == KAFS_BLO_NONE)
+  {
+    if (*scanned_blocks_this_step >= block_budget)
+      return 2;
+    return 1;
+  }
+
+  __atomic_add_fetch(&ctx->c_stat_bg_dedup_direct_hits, 1u, __ATOMIC_RELAXED);
+
+  kafs_hrid_t hrid = 0;
+  int is_new = 0;
+  kafs_blkcnt_t final_blo = KAFS_BLO_NONE;
+  int prc = kafs_hrl_put(ctx, buf, &hrid, &is_new, &final_blo);
+  if (prc == -ENOSPC)
+  {
+    kafs_blkcnt_t evicted_blo = KAFS_BLO_NONE;
+    if (kafs_hrl_evict_ref1_to_direct(ctx, &evicted_blo) == 0)
+    {
+      __atomic_add_fetch(&ctx->c_stat_bg_dedup_evicts, 1u, __ATOMIC_RELAXED);
+      __atomic_add_fetch(&ctx->c_stat_bg_dedup_retries, 1u, __ATOMIC_RELAXED);
+      prc = kafs_hrl_put(ctx, buf, &hrid, &is_new, &final_blo);
+    }
+  }
+
+  if (prc == 0 && final_blo != KAFS_BLO_NONE && final_blo != old_blo)
+  {
+    if (kafs_bg_dedup_try_install(ctx, ino, iblk, snapshot_raw, final_blo))
+    {
+      __atomic_add_fetch(&ctx->c_stat_bg_dedup_replacements, 1u, __ATOMIC_RELAXED);
+      (void)kafs_inode_release_hrl_ref(ctx, old_blo);
+      __atomic_add_fetch(&ctx->c_stat_pending_old_block_freed, 1u, __ATOMIC_RELAXED);
+      return 2;
+    }
+    (void)kafs_inode_release_hrl_ref(ctx, final_blo);
+  }
+
+  if (*scanned_blocks_this_step >= block_budget)
+    return 2;
+  return 1;
+}
+
 static void kafs_bg_dedup_step(struct kafs_context *ctx, int pressure_mode)
 {
   if (!ctx || !ctx->c_superblock)
@@ -1701,13 +1835,8 @@ static void kafs_bg_dedup_step(struct kafs_context *ctx, int pressure_mode)
   uint32_t sweep_cap =
       pressure_mode ? KAFS_BG_DEDUP_SWEEP_IDX_CAP_PRESSURE : KAFS_BG_DEDUP_SWEEP_IDX_CAP_DEFAULT;
   uint32_t scanned_blocks_this_step = 0;
-  uint32_t sweep_bucket_heads[KAFS_BG_DEDUP_SWEEP_BUCKETS];
-  uint64_t sweep_entry_fast[KAFS_BG_DEDUP_SWEEP_IDX_CAP_PRESSURE];
-  uint32_t sweep_entry_blo[KAFS_BG_DEDUP_SWEEP_IDX_CAP_PRESSURE];
-  uint32_t sweep_entry_next[KAFS_BG_DEDUP_SWEEP_IDX_CAP_PRESSURE];
-  uint32_t sweep_entry_count = 0;
-  for (uint32_t i = 0; i < KAFS_BG_DEDUP_SWEEP_BUCKETS; ++i)
-    sweep_bucket_heads[i] = UINT32_MAX;
+  kafs_bg_dedup_sweep_state_t sweep_state;
+  kafs_bg_dedup_sweep_state_init(&sweep_state);
 
   for (kafs_inocnt_t scanned = 0; scanned < inocnt; ++scanned)
   {
@@ -1716,54 +1845,12 @@ static void kafs_bg_dedup_step(struct kafs_context *ctx, int pressure_mode)
     kafs_inode_lock(ctx, ino);
     inode_locked = 1;
     kafs_sinode_t *inoent = kafs_ctx_inode(ctx, ino);
-    if (!kafs_ino_get_usage(inoent))
+    kafs_iblkcnt_t iblocnt = 0;
+    uint32_t direct_cnt = 0;
+    if (!kafs_bg_dedup_prepare_inode_scan(ctx, inoent, scanned, inocnt, pressure_mode, bs,
+                                          scan_window, &iblocnt, &direct_cnt))
     {
-      kafs_inode_unlock(ctx, ino);
       inode_locked = 0;
-      if (scanned == 0)
-      {
-        if (kafs_bg_advance_cursor(ctx, inocnt, 0))
-          kafs_bg_enter_cooldown(ctx, pressure_mode);
-      }
-      continue;
-    }
-
-    if (S_ISDIR(kafs_ino_mode_get(inoent)))
-    {
-      kafs_inode_unlock(ctx, ino);
-      inode_locked = 0;
-      if (scanned == 0)
-      {
-        if (kafs_bg_advance_cursor(ctx, inocnt, 0))
-          kafs_bg_enter_cooldown(ctx, pressure_mode);
-      }
-      continue;
-    }
-
-    kafs_off_t size = kafs_ino_size_get(inoent);
-    if (size <= KAFS_INODE_DIRECT_BYTES)
-    {
-      kafs_inode_unlock(ctx, ino);
-      inode_locked = 0;
-      if (scanned == 0)
-      {
-        if (kafs_bg_advance_cursor(ctx, inocnt, 0))
-          kafs_bg_enter_cooldown(ctx, pressure_mode);
-      }
-      continue;
-    }
-
-    kafs_iblkcnt_t iblocnt = (kafs_iblkcnt_t)((size + bs - 1) / bs);
-    uint32_t direct_cnt = (iblocnt < scan_window) ? (uint32_t)iblocnt : scan_window;
-    if (direct_cnt == 0)
-    {
-      kafs_inode_unlock(ctx, ino);
-      inode_locked = 0;
-      if (scanned == 0)
-      {
-        if (kafs_bg_advance_cursor(ctx, inocnt, 0))
-          kafs_bg_enter_cooldown(ctx, pressure_mode);
-      }
       continue;
     }
 
@@ -1789,87 +1876,25 @@ static void kafs_bg_dedup_step(struct kafs_context *ctx, int pressure_mode)
       __atomic_add_fetch(&ctx->c_stat_bg_dedup_scanned_blocks, 1u, __ATOMIC_RELAXED);
       scanned_blocks_this_step++;
 
-      if (kafs_bg_advance_cursor(ctx, inocnt, next_iblk))
-        kafs_bg_enter_cooldown(ctx, pressure_mode);
+      kafs_bg_dedup_advance_or_cooldown(ctx, inocnt, next_iblk, pressure_mode);
 
       kafs_blkcnt_t snapshot_raw = raw;
       kafs_inode_unlock(ctx, ino);
       inode_locked = 0;
 
-      kafs_blkcnt_t match_blo = KAFS_BLO_NONE;
-      int mrc = kafs_hrl_match_inc_by_block_excluding_blo(ctx, buf, old_blo, &match_blo);
-      if (mrc == 0 && match_blo != KAFS_BLO_NONE)
-      {
-        if (kafs_bg_dedup_try_install(ctx, ino, (kafs_iblkcnt_t)iblk, snapshot_raw, match_blo))
-        {
-          __atomic_add_fetch(&ctx->c_stat_bg_dedup_replacements, 1u, __ATOMIC_RELAXED);
-          (void)kafs_inode_release_hrl_ref(ctx, old_blo);
-          __atomic_add_fetch(&ctx->c_stat_pending_old_block_freed, 1u, __ATOMIC_RELAXED);
-          return;
-        }
-        (void)kafs_inode_release_hrl_ref(ctx, match_blo);
-      }
-
-      uint64_t fast = kafs_bg_hash64(buf, bs);
-      kafs_blkcnt_t dup_direct =
-          kafs_bg_sweep_find_dup_blo(ctx, fast, old_blo, buf, sweep_bucket_heads, sweep_entry_fast,
-                                     sweep_entry_blo, sweep_entry_next);
-      if (dup_direct == KAFS_BLO_NONE)
-        dup_direct = kafs_bg_recent_find_dup_blo(ctx, fast, old_blo, buf);
-      if (dup_direct == KAFS_BLO_NONE)
-        dup_direct = kafs_bg_index_find_dup_blo(ctx, fast, old_blo, buf);
-      kafs_bg_sweep_note(fast, old_blo, sweep_cap, &sweep_entry_count, sweep_bucket_heads,
-                         sweep_entry_fast, sweep_entry_blo, sweep_entry_next);
-      kafs_bg_recent_note(ctx, fast, old_blo);
-      kafs_bg_index_note(ctx, fast, old_blo);
-      if (dup_direct == KAFS_BLO_NONE)
-      {
-        if (scanned_blocks_this_step >= block_budget)
-          return;
-        break;
-      }
-
-      __atomic_add_fetch(&ctx->c_stat_bg_dedup_direct_hits, 1u, __ATOMIC_RELAXED);
-
-      kafs_hrid_t hrid = 0;
-      int is_new = 0;
-      kafs_blkcnt_t final_blo = KAFS_BLO_NONE;
-      int prc = kafs_hrl_put(ctx, buf, &hrid, &is_new, &final_blo);
-      if (prc == -ENOSPC)
-      {
-        kafs_blkcnt_t evicted_blo = KAFS_BLO_NONE;
-        if (kafs_hrl_evict_ref1_to_direct(ctx, &evicted_blo) == 0)
-        {
-          __atomic_add_fetch(&ctx->c_stat_bg_dedup_evicts, 1u, __ATOMIC_RELAXED);
-          __atomic_add_fetch(&ctx->c_stat_bg_dedup_retries, 1u, __ATOMIC_RELAXED);
-          prc = kafs_hrl_put(ctx, buf, &hrid, &is_new, &final_blo);
-        }
-      }
-
-      if (prc == 0 && final_blo != KAFS_BLO_NONE && final_blo != old_blo)
-      {
-        if (kafs_bg_dedup_try_install(ctx, ino, (kafs_iblkcnt_t)iblk, snapshot_raw, final_blo))
-        {
-          __atomic_add_fetch(&ctx->c_stat_bg_dedup_replacements, 1u, __ATOMIC_RELAXED);
-          (void)kafs_inode_release_hrl_ref(ctx, old_blo);
-          __atomic_add_fetch(&ctx->c_stat_pending_old_block_freed, 1u, __ATOMIC_RELAXED);
-          return;
-        }
-        (void)kafs_inode_release_hrl_ref(ctx, final_blo);
-      }
-
-      if (scanned_blocks_this_step >= block_budget)
+      int action = kafs_bg_dedup_handle_scanned_block(ctx, ino, (kafs_iblkcnt_t)iblk, snapshot_raw,
+                                                      old_blo, buf, bs, sweep_cap, block_budget,
+                                                      &scanned_blocks_this_step, &sweep_state);
+      if (action == 2)
         return;
-      break;
+      if (action == 1)
+        break;
     }
 
     if (inode_locked)
       kafs_inode_unlock(ctx, ino);
     if (scanned == 0)
-    {
-      if (kafs_bg_advance_cursor(ctx, inocnt, 0))
-        kafs_bg_enter_cooldown(ctx, pressure_mode);
-    }
+      kafs_bg_dedup_advance_or_cooldown(ctx, inocnt, 0, pressure_mode);
   }
 }
 

--- a/src/kafs.h
+++ b/src/kafs.h
@@ -6,7 +6,23 @@
 #include <time.h>
 #include <endian.h>
 #include <fuse.h>
+#if defined(__has_include)
+#if __has_include(<fuse_log.h>)
+#include <fuse_log.h>
+#endif
+#endif
 #include <stdlib.h>
+
+#ifndef FUSE_LOG_EMERG
+#define FUSE_LOG_EMERG 0
+#define FUSE_LOG_ALERT 1
+#define FUSE_LOG_CRIT 2
+#define FUSE_LOG_ERR 3
+#define FUSE_LOG_WARNING 4
+#define FUSE_LOG_NOTICE 5
+#define FUSE_LOG_INFO 6
+#define FUSE_LOG_DEBUG 7
+#endif
 
 #ifndef KAFS_ENABLE_EXTRA_DIAG
 #define KAFS_ENABLE_EXTRA_DIAG 0

--- a/src/kafs_hrl.c
+++ b/src/kafs_hrl.c
@@ -720,9 +720,10 @@ static int hrl_try_dec_ref_in_bucket(kafs_context_t *ctx, uint32_t bucket, uint6
   uint32_t *index = hrl_index_tbl(ctx);
   kafs_hrl_entry_t *ents = hrl_entries_tbl(ctx);
   uint32_t cap = hrl_capacity(ctx);
-  uint32_t head = index[bucket];
+  uint32_t head = 0;
 
   kafs_hrl_bucket_lock(ctx, bucket);
+  head = index[bucket];
   for (uint32_t steps = 0; head != 0 && steps < cap; ++steps)
   {
     uint32_t idx = head - 1u;

--- a/src/kafs_hrl.c
+++ b/src/kafs_hrl.c
@@ -4,7 +4,6 @@
 #include <inttypes.h>
 #include <string.h>
 #include <unistd.h>
-#include <errno.h>
 #include <time.h>
 
 #if KAFS_ENABLE_EXTRA_DIAG
@@ -125,73 +124,104 @@ static int hrl_read_blo(kafs_context_t *ctx, kafs_blkcnt_t blo, void *out)
   return (r == (ssize_t)bs) ? 0 : -EIO;
 }
 
+#if KAFS_ENABLE_EXTRA_DIAG
+static void hrl_build_sample_strings(const unsigned char *buf, size_t len, char *hex,
+                                     size_t hex_size, char *ascii, size_t ascii_size)
+{
+  size_t hex_off = 0;
+  size_t ascii_off = 0;
+
+  if (hex_size == 0 || ascii_size == 0)
+    return;
+
+  hex[0] = '\0';
+  ascii[0] = '\0';
+  for (size_t i = 0; i < 16u && i < len; ++i)
+  {
+    int whex = snprintf(hex + hex_off, hex_size - hex_off, "%s%02x", (i == 0) ? "" : " ",
+                        (unsigned)buf[i]);
+    if (whex < 0 || (size_t)whex >= hex_size - hex_off)
+      break;
+    hex_off += (size_t)whex;
+    if (ascii_off + 1u >= ascii_size)
+      break;
+    ascii[ascii_off++] = (buf[i] >= 32 && buf[i] <= 126) ? (char)buf[i] : '.';
+  }
+  ascii[ascii_off] = '\0';
+}
+
+static void hrl_write_diag_line(int fd, const char *line, size_t len)
+{
+  size_t off = 0;
+
+  while (off < len)
+  {
+    ssize_t wr = write(fd, line + off, len - off);
+    if (wr <= 0)
+      return;
+    off += (size_t)wr;
+  }
+}
+
+static void hrl_log_dir_block0_match(kafs_context_t *ctx, kafs_blkcnt_t blo, const void *buf,
+                                     kafs_inocnt_t ino)
+{
+  kafs_sinode_t *inoent = kafs_ctx_inode(ctx, ino);
+  kafs_mode_t mode = kafs_ino_mode_get(inoent);
+  const unsigned char *p = (const unsigned char *)buf;
+  char hex[3 * 16 + 1];
+  char ascii[16 + 1];
+  char line[1024];
+
+  hrl_build_sample_strings(p, (size_t)hrl_blksize(ctx), hex, sizeof(hex), ascii, sizeof(ascii));
+
+  int n = snprintf(
+      line, sizeof(line),
+      "hrl_write_blo: blk=%" PRIuFAST32 " matches live dir block0 ino=%" PRIuFAST32
+      " mode=%o size=%" PRIuFAST64 " src_ino=%" PRIuFAST32
+      " src_path=%s sample_hex=%s sample_ascii='%s'\n",
+      (uint_fast32_t)blo, (uint_fast32_t)ino, (unsigned)mode,
+      (uint_fast64_t)kafs_ino_size_get(inoent),
+      (uint_fast32_t)(kafs_diag_current_write_ino ? kafs_diag_current_write_ino() : KAFS_INO_NONE),
+      (kafs_diag_current_write_path && kafs_diag_current_write_path())
+          ? kafs_diag_current_write_path()
+          : "(null)",
+      hex[0] ? hex : "-", ascii[0] ? ascii : "-");
+  if (n > 0)
+  {
+    size_t len = (size_t)n < sizeof(line) ? (size_t)n : sizeof(line) - 1u;
+    hrl_write_diag_line(ctx->c_diag_log_fd, line, len);
+  }
+}
+
+static void hrl_maybe_log_write_diag(kafs_context_t *ctx, kafs_blkcnt_t blo, const void *buf)
+{
+  if (!ctx || !buf || blo == KAFS_BLO_NONE || ctx->c_diag_log_fd < 0)
+    return;
+
+  kafs_inocnt_t inocnt = kafs_sb_inocnt_get(ctx->c_superblock);
+  for (kafs_inocnt_t ino = KAFS_INO_ROOTDIR; ino < inocnt; ++ino)
+  {
+    kafs_sinode_t *inoent = kafs_ctx_inode(ctx, ino);
+    if (!kafs_ino_get_usage(inoent))
+      continue;
+    if (!S_ISDIR(kafs_ino_mode_get(inoent)))
+      continue;
+    if (kafs_inode_size_is_inline(kafs_ino_size_get(inoent)))
+      continue;
+    if (kafs_blkcnt_stoh(inoent->i_blkreftbl[0]) != blo)
+      continue;
+    hrl_log_dir_block0_match(ctx, blo, buf, ino);
+  }
+}
+#endif
+
 static int hrl_write_blo(kafs_context_t *ctx, kafs_blkcnt_t blo, const void *buf)
 {
   kafs_blksize_t bs = hrl_blksize(ctx);
   kafs_logblksize_t l2 = hrl_log_blksize(ctx);
 #if KAFS_ENABLE_EXTRA_DIAG
-  if (ctx && buf && blo != KAFS_BLO_NONE && ctx->c_diag_log_fd >= 0)
-  {
-    kafs_inocnt_t inocnt = kafs_sb_inocnt_get(ctx->c_superblock);
-    for (kafs_inocnt_t ino = KAFS_INO_ROOTDIR; ino < inocnt; ++ino)
-    {
-      kafs_sinode_t *inoent = kafs_ctx_inode(ctx, ino);
-      if (!kafs_ino_get_usage(inoent))
-        continue;
-      kafs_mode_t mode = kafs_ino_mode_get(inoent);
-      if (!S_ISDIR(mode))
-        continue;
-      if (kafs_inode_size_is_inline(kafs_ino_size_get(inoent)))
-        continue;
-      kafs_blkcnt_t cur_ref = kafs_blkcnt_stoh(inoent->i_blkreftbl[0]);
-      if (cur_ref != blo)
-        continue;
-
-      const unsigned char *p = (const unsigned char *)buf;
-      char hex[3 * 16 + 1];
-      char ascii[16 + 1];
-      size_t hex_off = 0;
-      size_t ascii_off = 0;
-      hex[0] = '\0';
-      ascii[0] = '\0';
-      for (size_t i = 0; i < 16u && i < (size_t)bs; ++i)
-      {
-        int whex = snprintf(hex + hex_off, sizeof(hex) - hex_off, "%s%02x", (i == 0) ? "" : " ",
-                            (unsigned)p[i]);
-        if (whex < 0 || (size_t)whex >= sizeof(hex) - hex_off)
-          break;
-        hex_off += (size_t)whex;
-        ascii[ascii_off++] = (p[i] >= 32 && p[i] <= 126) ? (char)p[i] : '.';
-      }
-      ascii[ascii_off] = '\0';
-
-      char line[1024];
-      int n = snprintf(line, sizeof(line),
-                       "hrl_write_blo: blk=%" PRIuFAST32 " matches live dir block0 ino=%" PRIuFAST32
-                       " mode=%o size=%" PRIuFAST64 " src_ino=%" PRIuFAST32
-                       " src_path=%s sample_hex=%s sample_ascii='%s'\n",
-                       (uint_fast32_t)blo, (uint_fast32_t)ino, (unsigned)mode,
-                       (uint_fast64_t)kafs_ino_size_get(inoent),
-                       (uint_fast32_t)(kafs_diag_current_write_ino ? kafs_diag_current_write_ino()
-                                                                   : KAFS_INO_NONE),
-                       (kafs_diag_current_write_path && kafs_diag_current_write_path())
-                           ? kafs_diag_current_write_path()
-                           : "(null)",
-                       hex[0] ? hex : "-", ascii[0] ? ascii : "-");
-      if (n > 0)
-      {
-        size_t len = (size_t)n < sizeof(line) ? (size_t)n : sizeof(line) - 1u;
-        size_t off = 0;
-        while (off < len)
-        {
-          ssize_t wr = write(ctx->c_diag_log_fd, line + off, len - off);
-          if (wr <= 0)
-            break;
-          off += (size_t)wr;
-        }
-      }
-    }
-  }
+  hrl_maybe_log_write_diag(ctx, blo, buf);
 #endif
   ssize_t w = pwrite(ctx->c_fd, buf, bs, (off_t)blo << l2);
   return (w == (ssize_t)bs) ? 0 : -EIO;
@@ -443,6 +473,67 @@ int kafs_hrl_format(kafs_context_t *ctx)
   return 0;
 }
 
+static int hrl_publish_existing_hit(kafs_hrl_entry_t *e, uint32_t idx, kafs_hrid_t *out_hrid,
+                                    int *out_is_new, kafs_blkcnt_t *out_blo)
+{
+  if (e->refcnt == 0xFFFFFFFFu)
+    return -EOVERFLOW;
+
+  e->refcnt += 1u;
+  *out_hrid = idx;
+  *out_is_new = 0;
+  *out_blo = e->blo;
+  return 0;
+}
+
+static int hrl_find_existing_locked(kafs_context_t *ctx, uint64_t fast, const void *block_data,
+                                    kafs_hrid_t *out_hrid, int *out_is_new, kafs_blkcnt_t *out_blo)
+{
+  uint32_t idx = 0;
+  uint64_t t_find0 = hrl_now_ns();
+  int find_rc = hrl_find_by_hash(ctx, fast, block_data, &idx);
+  uint64_t t_find1 = hrl_now_ns();
+
+  __atomic_add_fetch(&ctx->c_stat_hrl_put_ns_find, t_find1 - t_find0, __ATOMIC_RELAXED);
+  if (find_rc != 0)
+    return find_rc;
+
+  return hrl_publish_existing_hit(hrl_entries_tbl(ctx) + idx, idx, out_hrid, out_is_new, out_blo);
+}
+
+static int hrl_populate_new_entry_locked(kafs_context_t *ctx, uint32_t idx, uint64_t fast,
+                                         const void *block_data, kafs_blkcnt_t *out_blo)
+{
+  kafs_hrl_entry_t *e = hrl_entries_tbl(ctx) + idx;
+  kafs_blkcnt_t blo = KAFS_BLO_NONE;
+  uint64_t t_blk_alloc0 = hrl_now_ns();
+  int rc = kafs_blk_alloc(ctx, &blo);
+  uint64_t t_blk_alloc1 = hrl_now_ns();
+
+  __atomic_add_fetch(&ctx->c_stat_hrl_put_ns_blk_alloc, t_blk_alloc1 - t_blk_alloc0,
+                     __ATOMIC_RELAXED);
+  if (rc != 0)
+    return rc;
+
+  uint64_t t_blk_write0 = hrl_now_ns();
+  rc = hrl_write_blo(ctx, blo, block_data);
+  uint64_t t_blk_write1 = hrl_now_ns();
+  __atomic_add_fetch(&ctx->c_stat_hrl_put_ns_blk_write, t_blk_write1 - t_blk_write0,
+                     __ATOMIC_RELAXED);
+  if (rc != 0)
+  {
+    (void)hrl_release_blo(ctx, &blo);
+    return rc;
+  }
+
+  e->blo = blo;
+  e->fast = fast;
+  e->next_plus1 = 0;
+  hrl_chain_insert_head(ctx, idx, fast);
+  *out_blo = blo;
+  return 0;
+}
+
 int kafs_hrl_put(kafs_context_t *ctx, const void *block_data, kafs_hrid_t *out_hrid,
                  int *out_is_new, kafs_blkcnt_t *out_blo)
 {
@@ -455,29 +546,10 @@ int kafs_hrl_put(kafs_context_t *ctx, const void *block_data, kafs_hrid_t *out_h
   uint64_t fast = hrl_hash64(block_data, hrl_blksize(ctx));
   uint64_t t_hash1 = hrl_now_ns();
   __atomic_add_fetch(&ctx->c_stat_hrl_put_ns_hash, t_hash1 - t_hash0, __ATOMIC_RELAXED);
-  uint32_t idx;
   int b = hrl_bucket_index(ctx, fast);
 
   kafs_hrl_bucket_lock(ctx, (uint32_t)b);
-  uint64_t t_find0 = hrl_now_ns();
-  int find_rc = hrl_find_by_hash(ctx, fast, block_data, &idx);
-  uint64_t t_find1 = hrl_now_ns();
-  __atomic_add_fetch(&ctx->c_stat_hrl_put_ns_find, t_find1 - t_find0, __ATOMIC_RELAXED);
-  if (find_rc == 0)
-  {
-    kafs_hrl_entry_t *e = hrl_entries_tbl(ctx) + idx;
-    if (e->refcnt == 0xFFFFFFFFu)
-    {
-      kafs_hrl_bucket_unlock(ctx, (uint32_t)b);
-      return -EOVERFLOW;
-    }
-    e->refcnt += 1u;
-    *out_hrid = idx;
-    *out_is_new = 0;
-    *out_blo = e->blo;
-    kafs_hrl_bucket_unlock(ctx, (uint32_t)b);
-    return 0;
-  }
+  int find_rc = hrl_find_existing_locked(ctx, fast, block_data, out_hrid, out_is_new, out_blo);
   if (find_rc != -ENOENT)
   {
     kafs_hrl_bucket_unlock(ctx, (uint32_t)b);
@@ -496,24 +568,9 @@ int kafs_hrl_put(kafs_context_t *ctx, const void *block_data, kafs_hrid_t *out_h
     return slot_rc;
 
   kafs_hrl_bucket_lock(ctx, (uint32_t)b);
-  uint32_t found_idx = 0;
-  t_find0 = hrl_now_ns();
-  find_rc = hrl_find_by_hash(ctx, fast, block_data, &found_idx);
-  t_find1 = hrl_now_ns();
-  __atomic_add_fetch(&ctx->c_stat_hrl_put_ns_find, t_find1 - t_find0, __ATOMIC_RELAXED);
+  find_rc = hrl_find_existing_locked(ctx, fast, block_data, out_hrid, out_is_new, out_blo);
   if (find_rc == 0)
   {
-    kafs_hrl_entry_t *existing = hrl_entries_tbl(ctx) + found_idx;
-    if (existing->refcnt == 0xFFFFFFFFu)
-    {
-      kafs_hrl_bucket_unlock(ctx, (uint32_t)b);
-      hrl_release_reserved_slot(ctx, reserved_idx);
-      return -EOVERFLOW;
-    }
-    existing->refcnt += 1u;
-    *out_hrid = found_idx;
-    *out_is_new = 0;
-    *out_blo = existing->blo;
     kafs_hrl_bucket_unlock(ctx, (uint32_t)b);
     hrl_release_reserved_slot(ctx, reserved_idx);
     return 0;
@@ -525,45 +582,20 @@ int kafs_hrl_put(kafs_context_t *ctx, const void *block_data, kafs_hrid_t *out_h
     return find_rc;
   }
 
-  idx = reserved_idx;
-  kafs_hrl_entry_t *e = hrl_entries_tbl(ctx) + idx;
+  kafs_hrl_entry_t *e = hrl_entries_tbl(ctx) + reserved_idx;
   e->next_plus1 = 0;
 
-  // allocate physical block and write
-  kafs_blkcnt_t blo = KAFS_BLO_NONE;
-  uint64_t t_blk_alloc0 = hrl_now_ns();
-  int rc = kafs_blk_alloc(ctx, &blo);
-  uint64_t t_blk_alloc1 = hrl_now_ns();
-  __atomic_add_fetch(&ctx->c_stat_hrl_put_ns_blk_alloc, t_blk_alloc1 - t_blk_alloc0,
-                     __ATOMIC_RELAXED);
+  int rc = hrl_populate_new_entry_locked(ctx, reserved_idx, fast, block_data, out_blo);
   if (rc != 0)
   {
     kafs_hrl_bucket_unlock(ctx, (uint32_t)b);
-    hrl_release_reserved_slot(ctx, idx);
+    hrl_release_reserved_slot(ctx, reserved_idx);
     return rc;
   }
-  uint64_t t_blk_write0 = hrl_now_ns();
-  rc = hrl_write_blo(ctx, blo, block_data);
-  uint64_t t_blk_write1 = hrl_now_ns();
-  __atomic_add_fetch(&ctx->c_stat_hrl_put_ns_blk_write, t_blk_write1 - t_blk_write0,
-                     __ATOMIC_RELAXED);
-  if (rc != 0)
-  {
-    (void)hrl_release_blo(ctx, &blo);
-    kafs_hrl_bucket_unlock(ctx, (uint32_t)b);
-    hrl_release_reserved_slot(ctx, idx);
-    return rc;
-  }
-
-  e->blo = blo;
-  e->fast = fast;
-  e->next_plus1 = 0;
-  hrl_chain_insert_head(ctx, idx, fast);
   kafs_hrl_bucket_unlock(ctx, (uint32_t)b);
 
-  *out_hrid = idx;
+  *out_hrid = reserved_idx;
   *out_is_new = 1;
-  *out_blo = blo;
   return 0;
 }
 
@@ -657,6 +689,66 @@ int kafs_hrl_inc_ref_by_blo(kafs_context_t *ctx, kafs_blkcnt_t blo)
   return 0;
 }
 
+static int hrl_dec_ref_matched_locked(kafs_context_t *ctx, uint32_t bucket, uint32_t idx,
+                                      kafs_hrl_entry_t *e)
+{
+  e->refcnt -= 1u;
+  if (e->refcnt != 0)
+  {
+    kafs_hrl_bucket_unlock(ctx, bucket);
+    return 0;
+  }
+
+  kafs_blkcnt_t pblo = e->blo;
+  int rc = hrl_release_blo(ctx, &pblo);
+  if (rc != 0)
+  {
+    kafs_hrl_bucket_unlock(ctx, bucket);
+    return rc;
+  }
+
+  (void)hrl_chain_remove(ctx, idx, e->fast);
+  hrl_slot_reset(e);
+  kafs_hrl_bucket_unlock(ctx, bucket);
+  hrl_publish_free_slot(ctx, idx);
+  return 0;
+}
+
+static int hrl_try_dec_ref_in_bucket(kafs_context_t *ctx, uint32_t bucket, uint64_t fast,
+                                     kafs_blkcnt_t blo)
+{
+  uint32_t *index = hrl_index_tbl(ctx);
+  kafs_hrl_entry_t *ents = hrl_entries_tbl(ctx);
+  uint32_t cap = hrl_capacity(ctx);
+  uint32_t head = index[bucket];
+
+  kafs_hrl_bucket_lock(ctx, bucket);
+  for (uint32_t steps = 0; head != 0 && steps < cap; ++steps)
+  {
+    uint32_t idx = head - 1u;
+    if (idx >= cap)
+    {
+      kafs_hrl_bucket_unlock(ctx, bucket);
+      return -EIO;
+    }
+
+    kafs_hrl_entry_t *e = &ents[idx];
+    if (e->refcnt != 0 && e->fast == fast && e->blo == blo)
+      return hrl_dec_ref_matched_locked(ctx, bucket, idx, e);
+
+    head = e->next_plus1;
+  }
+  kafs_hrl_bucket_unlock(ctx, bucket);
+  return (head == 0) ? -ENOENT : -EIO;
+}
+
+static int hrl_release_legacy_blo(kafs_context_t *ctx, kafs_blkcnt_t blo)
+{
+  if (kafs_blk_get_usage_locked(ctx, blo) == 0)
+    return 0;
+  return hrl_release_blo(ctx, &blo);
+}
+
 int kafs_hrl_dec_ref_by_blo(kafs_context_t *ctx, kafs_blkcnt_t blo)
 {
   if (!ctx || ctx->c_hrl_bucket_cnt == 0 || hrl_capacity(ctx) == 0)
@@ -672,56 +764,13 @@ int kafs_hrl_dec_ref_by_blo(kafs_context_t *ctx, kafs_blkcnt_t blo)
     return rc;
 
   uint64_t fast = hrl_hash64(buf, bs);
-  int b = hrl_bucket_index(ctx, fast);
-  uint32_t *index = hrl_index_tbl(ctx);
-  kafs_hrl_entry_t *ents = hrl_entries_tbl(ctx);
-  uint32_t cap = hrl_capacity(ctx);
-
-  kafs_hrl_bucket_lock(ctx, (uint32_t)b);
-  uint32_t head = index[b];
-  for (uint32_t steps = 0; head != 0 && steps < cap; ++steps)
-  {
-    uint32_t i = head - 1u;
-    if (i >= cap)
-    {
-      kafs_hrl_bucket_unlock(ctx, (uint32_t)b);
-      return -EIO;
-    }
-    kafs_hrl_entry_t *e = &ents[i];
-    if (e->refcnt != 0 && e->fast == fast && e->blo == blo)
-    {
-      e->refcnt -= 1u;
-      if (e->refcnt == 0)
-      {
-        kafs_blkcnt_t pblo = e->blo;
-        uint32_t free_idx = i;
-        int rc2 = hrl_release_blo(ctx, &pblo);
-        if (rc2 != 0)
-        {
-          kafs_hrl_bucket_unlock(ctx, (uint32_t)b);
-          return rc2;
-        }
-        (void)hrl_chain_remove(ctx, i, e->fast);
-        hrl_slot_reset(e);
-        kafs_hrl_bucket_unlock(ctx, (uint32_t)b);
-        hrl_publish_free_slot(ctx, free_idx);
-        return 0;
-      }
-      kafs_hrl_bucket_unlock(ctx, (uint32_t)b);
-      return 0;
-    }
-    head = e->next_plus1;
-  }
-  kafs_hrl_bucket_unlock(ctx, (uint32_t)b);
-
-  if (head != 0)
-    return -EIO;
+  rc = hrl_try_dec_ref_in_bucket(ctx, (uint32_t)hrl_bucket_index(ctx, fast), fast, blo);
+  if (rc != -ENOENT)
+    return rc;
 
   // not managed by HRL => legacy, free directly.
   // If it's already free (e.g. another thread just dropped the last HRL ref), treat as success.
-  if (kafs_blk_get_usage_locked(ctx, blo) == 0)
-    return 0;
-  return hrl_release_blo(ctx, &blo);
+  return hrl_release_legacy_blo(ctx, blo);
 }
 
 int kafs_hrl_match_inc_by_block_excluding_blo(kafs_context_t *ctx, const void *block_data,

--- a/src/kafs_info.c
+++ b/src/kafs_info.c
@@ -42,34 +42,25 @@ static void fmt_time(char out[64], const kafs_time_t *ts)
 
 static void usage(const char *prog) { fprintf(stderr, "Usage: %s <image>\n", prog); }
 
-int main(int argc, char **argv)
+static int load_image_superblock(const char *img, int *fd_out, kafs_ssuperblock_t *sb_out,
+                                 uint64_t *file_size_out)
 {
-  if (kafs_cli_exit_if_help(argc, argv, usage, argv[0]) == 0)
-    return 0;
-
-  if (argc < 2)
-  {
-    usage(argv[0]);
-    return 2;
-  }
-  const char *img = argv[1];
   int fd = open(img, O_RDONLY);
   if (fd < 0)
   {
     perror("open");
     return 1;
   }
-  kafs_ssuperblock_t sb;
-  ssize_t r = pread(fd, &sb, sizeof(sb), 0);
-  if (r != (ssize_t)sizeof(sb))
+
+  ssize_t r = pread(fd, sb_out, sizeof(*sb_out), 0);
+  if (r != (ssize_t)sizeof(*sb_out))
   {
     perror("pread superblock");
     close(fd);
     return 1;
   }
 
-  uint64_t file_size = 0;
-  int rc = kafs_offline_detect_file_size(fd, &file_size);
+  int rc = kafs_offline_detect_file_size(fd, file_size_out);
   if (rc != 0)
   {
     fprintf(stderr, "failed to detect image size: %s\n", strerror(-rc));
@@ -77,36 +68,45 @@ int main(int argc, char **argv)
     return 1;
   }
 
+  *fd_out = fd;
+  return 0;
+}
+
+static void print_superblock_summary(const kafs_ssuperblock_t *sb)
+{
   printf("magic=0x%08" PRIx32 " version=%" PRIu32 " log_blksize=%" PRIuFAST16 " (bytes=%u)\n",
-         kafs_sb_magic_get(&sb), kafs_sb_format_version_get(&sb), kafs_sb_log_blksize_get(&sb),
-         1u << kafs_sb_log_blksize_get(&sb));
-  printf("inodes total=%" PRIuFAST32 " free=%" PRIuFAST32 "\n", kafs_sb_inocnt_get(&sb),
-         (uint_fast32_t)kafs_sb_inocnt_free_get(&sb));
+         kafs_sb_magic_get(sb), kafs_sb_format_version_get(sb), kafs_sb_log_blksize_get(sb),
+         1u << kafs_sb_log_blksize_get(sb));
+  printf("inodes total=%" PRIuFAST32 " free=%" PRIuFAST32 "\n", kafs_sb_inocnt_get(sb),
+         (uint_fast32_t)kafs_sb_inocnt_free_get(sb));
   printf("blocks user=%" PRIuFAST32 " root=%" PRIuFAST32 " free=%" PRIuFAST32
          " first_data=%" PRIuFAST32 "\n",
-         kafs_sb_blkcnt_get(&sb), kafs_sb_r_blkcnt_get(&sb), kafs_sb_blkcnt_free_get(&sb),
-         kafs_blkcnt_stoh(sb.s_first_data_block));
-  printf("hash fast=%" PRIu32 " strong=%" PRIu32 "\n", kafs_sb_hash_fast_get(&sb),
-         kafs_sb_hash_strong_get(&sb));
+         kafs_sb_blkcnt_get(sb), kafs_sb_r_blkcnt_get(sb), kafs_sb_blkcnt_free_get(sb),
+         kafs_blkcnt_stoh(sb->s_first_data_block));
+  printf("hash fast=%" PRIu32 " strong=%" PRIu32 "\n", kafs_sb_hash_fast_get(sb),
+         kafs_sb_hash_strong_get(sb));
   printf("hrl index: off=%" PRIu64 " size=%" PRIu64 "; entries: off=%" PRIu64 " cnt=%" PRIu32 "\n",
-         (uint64_t)kafs_sb_hrl_index_offset_get(&sb), (uint64_t)kafs_sb_hrl_index_size_get(&sb),
-         (uint64_t)kafs_sb_hrl_entry_offset_get(&sb), (uint32_t)kafs_sb_hrl_entry_cnt_get(&sb));
+         (uint64_t)kafs_sb_hrl_index_offset_get(sb), (uint64_t)kafs_sb_hrl_index_size_get(sb),
+         (uint64_t)kafs_sb_hrl_entry_offset_get(sb), (uint32_t)kafs_sb_hrl_entry_cnt_get(sb));
   printf("tail metadata: enabled=%s off=%" PRIu64 " size=%" PRIu64 "\n",
-         (kafs_sb_feature_flags_get(&sb) & KAFS_FEATURE_TAIL_META_REGION) ? "true" : "false",
-         (uint64_t)kafs_sb_tailmeta_offset_get(&sb), (uint64_t)kafs_sb_tailmeta_size_get(&sb));
+         (kafs_sb_feature_flags_get(sb) & KAFS_FEATURE_TAIL_META_REGION) ? "true" : "false",
+         (uint64_t)kafs_sb_tailmeta_offset_get(sb), (uint64_t)kafs_sb_tailmeta_size_get(sb));
+}
 
+static void print_tombstone_summary(int fd, const kafs_ssuperblock_t *sb, uint64_t file_size)
+{
   uint64_t tombstone_count = 0;
   kafs_time_t oldest_tombstone = {0};
   int have_oldest_tombstone = 0;
   void *inotbl = NULL;
   uint64_t inocnt = 0;
-  int rc_inode = kafs_offline_load_inode_table(fd, &sb, file_size, &inotbl, &inocnt);
+  int rc_inode = kafs_offline_load_inode_table(fd, sb, file_size, &inotbl, &inocnt);
   if (rc_inode == 0)
   {
     for (kafs_inocnt_t ino = KAFS_INO_ROOTDIR; ino < inocnt; ++ino)
     {
       const kafs_sinode_t *inoent = (const kafs_sinode_t *)kafs_inode_ptr_const_in_table(
-          inotbl, kafs_sb_format_version_get(&sb), ino);
+          inotbl, kafs_sb_format_version_get(sb), ino);
       if (!kafs_ino_get_usage(inoent))
         continue;
       if (kafs_ino_linkcnt_get(inoent) != 0)
@@ -137,10 +137,15 @@ int main(int argc, char **argv)
     printf("tombstones count=0 oldest_dtime=none\n");
   }
 
+  free(inotbl);
+}
+
+static void print_tail_summary(int fd, const kafs_ssuperblock_t *sb, uint64_t file_size)
+{
   struct inode_summary ino = {0};
   struct tailmeta_summary tm = {0};
-  rc_inode = collect_inode_summary(fd, &sb, file_size, &ino);
-  int rc_tailmeta = collect_tailmeta_summary(fd, &sb, file_size, &tm);
+  int rc_inode = collect_inode_summary(fd, sb, file_size, &ino);
+  int rc_tailmeta = collect_tailmeta_summary(fd, sb, file_size, &tm);
   if (rc_inode == 0)
   {
     printf("tail layouts: regular=%" PRIu64 " tail_only=%" PRIu64 " mixed_full_tail=%" PRIu64 "\n",
@@ -166,43 +171,73 @@ int main(int argc, char **argv)
              class_summary->invalid_containers);
     }
   }
-  else if (kafs_tailmeta_region_present(&sb))
+  else if (kafs_tailmeta_region_present(sb))
   {
     printf("tail usage: unavailable (%s)\n", (rc_tailmeta < 0) ? strerror(-rc_tailmeta) : "error");
   }
+}
 
-  uint64_t index_size = kafs_sb_hrl_index_size_get(&sb);
-  uint64_t entry_off = kafs_sb_hrl_entry_offset_get(&sb);
-  uint32_t entry_cnt = kafs_sb_hrl_entry_cnt_get(&sb);
-  if (index_size && entry_off && entry_cnt)
+static int print_hrl_summary(int fd, const kafs_ssuperblock_t *sb)
+{
+  uint64_t index_size = kafs_sb_hrl_index_size_get(sb);
+  uint64_t entry_off = kafs_sb_hrl_entry_offset_get(sb);
+  uint32_t entry_cnt = kafs_sb_hrl_entry_cnt_get(sb);
+  if (!(index_size && entry_off && entry_cnt))
+    return 0;
+
+  uint32_t buckets = (uint32_t)(index_size / sizeof(uint32_t));
+  printf("hrl buckets=%u\n", buckets);
+  size_t ents_bytes = (size_t)entry_cnt * sizeof(kafs_hrl_entry_t);
+  kafs_hrl_entry_t *ents = malloc(ents_bytes);
+  if (!ents)
   {
-    uint32_t buckets = (uint32_t)(index_size / sizeof(uint32_t));
-    printf("hrl buckets=%u\n", buckets);
-    size_t ents_bytes = (size_t)entry_cnt * sizeof(kafs_hrl_entry_t);
-    kafs_hrl_entry_t *ents = malloc(ents_bytes);
-    if (!ents)
-    {
-      perror("malloc");
-      close(fd);
-      return 1;
-    }
-    ssize_t er = pread(fd, ents, ents_bytes, (off_t)entry_off);
-    if (er != (ssize_t)ents_bytes)
-    {
-      perror("pread hrl entries");
-      free(ents);
-      close(fd);
-      return 1;
-    }
-    uint32_t used = 0;
-    for (uint32_t i = 0; i < entry_cnt; ++i)
-      if (ents[i].refcnt)
-        ++used;
-    printf("hrl entries used=%u / %u\n", used, entry_cnt);
-    free(ents);
+    perror("malloc");
+    return 1;
   }
 
-  free(inotbl);
+  ssize_t er = pread(fd, ents, ents_bytes, (off_t)entry_off);
+  if (er != (ssize_t)ents_bytes)
+  {
+    perror("pread hrl entries");
+    free(ents);
+    return 1;
+  }
+
+  uint32_t used = 0;
+  for (uint32_t i = 0; i < entry_cnt; ++i)
+    if (ents[i].refcnt)
+      ++used;
+  printf("hrl entries used=%u / %u\n", used, entry_cnt);
+  free(ents);
+  return 0;
+}
+
+int main(int argc, char **argv)
+{
+  if (kafs_cli_exit_if_help(argc, argv, usage, argv[0]) == 0)
+    return 0;
+
+  if (argc < 2)
+  {
+    usage(argv[0]);
+    return 2;
+  }
+  const char *img = argv[1];
+  int fd = -1;
+  kafs_ssuperblock_t sb;
+  uint64_t file_size = 0;
+  if (load_image_superblock(img, &fd, &sb, &file_size) != 0)
+    return 1;
+
+  print_superblock_summary(&sb);
+  print_tombstone_summary(fd, &sb, file_size);
+  print_tail_summary(fd, &sb, file_size);
+  if (print_hrl_summary(fd, &sb) != 0)
+  {
+    close(fd);
+    return 1;
+  }
+
   close(fd);
   return 0;
 }

--- a/src/kafsctl.c
+++ b/src/kafsctl.c
@@ -2014,7 +2014,7 @@ static void kafsctl_stats_report_init(kafs_stats_report_t *report, const kafs_st
   snprintf(report->tombstone_oldest_buf, sizeof(report->tombstone_oldest_buf), "%s", "none");
 }
 
-static void kafsctl_stats_compute_report(kafs_stats_report_t *report)
+static void kafsctl_stats_compute_capacity(kafs_stats_report_t *report)
 {
   report->have_verbose_scan = ((report->st.result_flags & KAFS_STATS_R_VERBOSE_SCAN) != 0);
   report->logical_bytes = report->st.hrl_refcnt_sum * (uint64_t)report->st.blksize;
@@ -2028,21 +2028,29 @@ static void kafsctl_stats_compute_report(kafs_stats_report_t *report)
 
   if (report->st.hrl_put_calls > 0)
     report->hit_rate = (double)report->st.hrl_put_hits / (double)report->st.hrl_put_calls;
-  report->hrl_put_hash_ms = (double)report->st.hrl_put_ns_hash / 1000000.0;
-  report->hrl_put_find_ms = (double)report->st.hrl_put_ns_find / 1000000.0;
-  report->hrl_put_cmp_ms = (double)report->st.hrl_put_ns_cmp_content / 1000000.0;
-  report->hrl_put_slot_alloc_ms = (double)report->st.hrl_put_ns_slot_alloc / 1000000.0;
-  report->hrl_put_blk_alloc_ms = (double)report->st.hrl_put_ns_blk_alloc / 1000000.0;
-  report->hrl_put_blk_write_ms = (double)report->st.hrl_put_ns_blk_write / 1000000.0;
-  report->hrl_put_avg_chain_steps =
+  report->fs_blocks_used = (report->st.fs_blocks_total >= report->st.fs_blocks_free)
+                               ? (report->st.fs_blocks_total - report->st.fs_blocks_free)
+                               : 0;
+  report->fs_inodes_used = (report->st.fs_inodes_total >= report->st.fs_inodes_free)
+                               ? (report->st.fs_inodes_total - report->st.fs_inodes_free)
+                               : 0;
+  report->fs_blocks_used_pct = pct_u64(report->fs_blocks_used, report->st.fs_blocks_total);
+  report->fs_inodes_used_pct = pct_u64(report->fs_inodes_used, report->st.fs_inodes_total);
+  report->hrl_entries_used_pct = pct_u64(report->st.hrl_entries_used, report->st.hrl_entries_total);
+  report->hrl_or_legacy_total = report->st.hrl_put_calls + report->st.hrl_put_fallback_legacy;
+  report->hrl_path_rate = pct_u64(report->st.hrl_put_calls, report->hrl_or_legacy_total);
+  report->legacy_path_rate =
+      pct_u64(report->st.hrl_put_fallback_legacy, report->hrl_or_legacy_total);
+  report->direct_to_hrl_ratio =
       (report->st.hrl_put_calls > 0)
-          ? (double)report->st.hrl_put_chain_steps / (double)report->st.hrl_put_calls
+          ? (double)report->st.hrl_put_fallback_legacy / (double)report->st.hrl_put_calls
           : 0.0;
-  report->hrl_put_avg_cmp_calls =
-      (report->st.hrl_put_calls > 0)
-          ? (double)report->st.hrl_put_cmp_calls / (double)report->st.hrl_put_calls
-          : 0.0;
+  report->hrl_hit_rate_pct = pct_u64(report->st.hrl_put_hits, report->st.hrl_put_calls);
+  report->hrl_miss_rate_pct = pct_u64(report->st.hrl_put_misses, report->st.hrl_put_calls);
+}
 
+static void kafsctl_stats_compute_lock_metrics(kafs_stats_report_t *report)
+{
   report->lock_inode_cont_rate =
       (report->st.lock_inode_acquire > 0)
           ? (double)report->st.lock_inode_contended / (double)report->st.lock_inode_acquire
@@ -2068,6 +2076,24 @@ static void kafsctl_stats_compute_report(kafs_stats_report_t *report)
                                                 (double)report->st.lock_hrl_global_acquire
                                           : 0.0;
   report->lock_hrl_global_wait_ms = (double)report->st.lock_hrl_global_wait_ns / 1000000.0;
+}
+
+static void kafsctl_stats_compute_io_metrics(kafs_stats_report_t *report)
+{
+  report->hrl_put_hash_ms = (double)report->st.hrl_put_ns_hash / 1000000.0;
+  report->hrl_put_find_ms = (double)report->st.hrl_put_ns_find / 1000000.0;
+  report->hrl_put_cmp_ms = (double)report->st.hrl_put_ns_cmp_content / 1000000.0;
+  report->hrl_put_slot_alloc_ms = (double)report->st.hrl_put_ns_slot_alloc / 1000000.0;
+  report->hrl_put_blk_alloc_ms = (double)report->st.hrl_put_ns_blk_alloc / 1000000.0;
+  report->hrl_put_blk_write_ms = (double)report->st.hrl_put_ns_blk_write / 1000000.0;
+  report->hrl_put_avg_chain_steps =
+      (report->st.hrl_put_calls > 0)
+          ? (double)report->st.hrl_put_chain_steps / (double)report->st.hrl_put_calls
+          : 0.0;
+  report->hrl_put_avg_cmp_calls =
+      (report->st.hrl_put_calls > 0)
+          ? (double)report->st.hrl_put_cmp_calls / (double)report->st.hrl_put_calls
+          : 0.0;
   report->access_fh_fastpath_rate =
       (report->st.access_calls > 0)
           ? (double)report->st.access_fh_fastpath_hits / (double)report->st.access_calls
@@ -2099,6 +2125,10 @@ static void kafsctl_stats_compute_report(kafs_stats_report_t *report)
   report->blk_set_usage_bit_ms = (double)report->st.blk_set_usage_ns_bit_update / 1000000.0;
   report->blk_set_usage_freecnt_ms = (double)report->st.blk_set_usage_ns_freecnt_update / 1000000.0;
   report->blk_set_usage_wtime_ms = (double)report->st.blk_set_usage_ns_wtime_update / 1000000.0;
+}
+
+static void kafsctl_stats_compute_bg_metrics(kafs_stats_report_t *report)
+{
   report->copy_share_hit_rate =
       (report->st.copy_share_attempt_blocks > 0)
           ? (double)report->st.copy_share_done_blocks / (double)report->st.copy_share_attempt_blocks
@@ -2111,34 +2141,22 @@ static void kafsctl_stats_compute_report(kafs_stats_report_t *report)
       (report->st.bg_dedup_direct_candidates > 0)
           ? (double)report->st.bg_dedup_direct_hits / (double)report->st.bg_dedup_direct_candidates
           : 0.0;
-  report->pending_worker_start_fail_rate = (report->st.pending_worker_start_calls > 0)
-                                               ? (double)report->st.pending_worker_start_failures /
-                                                     (double)report->st.pending_worker_start_calls
-                                               : 0.0;
-  report->fs_blocks_used = (report->st.fs_blocks_total >= report->st.fs_blocks_free)
-                               ? (report->st.fs_blocks_total - report->st.fs_blocks_free)
-                               : 0;
-  report->fs_inodes_used = (report->st.fs_inodes_total >= report->st.fs_inodes_free)
-                               ? (report->st.fs_inodes_total - report->st.fs_inodes_free)
-                               : 0;
-
-  report->fs_blocks_used_pct = pct_u64(report->fs_blocks_used, report->st.fs_blocks_total);
-  report->fs_inodes_used_pct = pct_u64(report->fs_inodes_used, report->st.fs_inodes_total);
-  report->hrl_entries_used_pct = pct_u64(report->st.hrl_entries_used, report->st.hrl_entries_total);
-  report->hrl_or_legacy_total = report->st.hrl_put_calls + report->st.hrl_put_fallback_legacy;
-  report->hrl_path_rate = pct_u64(report->st.hrl_put_calls, report->hrl_or_legacy_total);
-  report->legacy_path_rate =
-      pct_u64(report->st.hrl_put_fallback_legacy, report->hrl_or_legacy_total);
-  report->direct_to_hrl_ratio =
-      (report->st.hrl_put_calls > 0)
-          ? (double)report->st.hrl_put_fallback_legacy / (double)report->st.hrl_put_calls
-          : 0.0;
-  report->hrl_hit_rate_pct = pct_u64(report->st.hrl_put_hits, report->st.hrl_put_calls);
-  report->hrl_miss_rate_pct = pct_u64(report->st.hrl_put_misses, report->st.hrl_put_calls);
   report->hrl_rescue_hit_rate =
       (report->st.hrl_rescue_attempts > 0)
           ? (double)report->st.hrl_rescue_hits / (double)report->st.hrl_rescue_attempts
           : 0.0;
+  report->pending_worker_start_fail_rate = (report->st.pending_worker_start_calls > 0)
+                                               ? (double)report->st.pending_worker_start_failures /
+                                                     (double)report->st.pending_worker_start_calls
+                                               : 0.0;
+}
+
+static void kafsctl_stats_compute_report(kafs_stats_report_t *report)
+{
+  kafsctl_stats_compute_capacity(report);
+  kafsctl_stats_compute_lock_metrics(report);
+  kafsctl_stats_compute_io_metrics(report);
+  kafsctl_stats_compute_bg_metrics(report);
 
   if (report->st.tombstone_inodes > 0 &&
       (report->st.tombstone_oldest_dtime_sec != 0 || report->st.tombstone_oldest_dtime_nsec != 0))

--- a/src/kafsctl.c
+++ b/src/kafsctl.c
@@ -3344,6 +3344,72 @@ static int cmd_symlink_auto_with_opts(const char *target, const char *linkpath,
   return rc;
 }
 
+static int parse_ln_target_directory_option(int argc, char **argv, int *index, const char *arg,
+                                            kafs_ln_opts_t *opts)
+{
+  if (strcmp(arg, "-t") == 0 || strcmp(arg, "--target-directory") == 0)
+  {
+    if (*index + 1 >= argc)
+    {
+      fprintf(stderr, "missing argument for %s\n", arg);
+      return 2;
+    }
+    opts->target_dir = argv[++(*index)];
+    return 0;
+  }
+
+  if (strncmp(arg, "--target-directory=", 19) == 0)
+  {
+    opts->target_dir = arg + 19;
+    return 0;
+  }
+
+  return -1;
+}
+
+static int parse_ln_flag_option(const char *arg, kafs_ln_opts_t *opts)
+{
+  if (is_ln_symbolic_option(arg))
+    opts->symbolic = 1;
+  else if (strcmp(arg, "-f") == 0 || strcmp(arg, "--force") == 0)
+    opts->force = 1;
+  else if (strcmp(arg, "-n") == 0 || strcmp(arg, "--no-dereference") == 0)
+    opts->no_deref = 1;
+  else if (strcmp(arg, "-T") == 0 || strcmp(arg, "--no-target-directory") == 0)
+    opts->no_target_directory = 1;
+  else if (strcmp(arg, "-v") == 0 || strcmp(arg, "--verbose") == 0)
+    opts->verbose = 1;
+  else
+    return -1;
+
+  return 0;
+}
+
+static int parse_ln_option_arg(int argc, char **argv, int *index, kafs_ln_opts_t *opts)
+{
+  const char *arg = argv[*index];
+  if (strcmp(arg, "--") == 0)
+  {
+    ++(*index);
+    return 3;
+  }
+  if (kafs_cli_is_help_arg(arg))
+    return 1;
+  if (arg[0] != '-' || strcmp(arg, "-") == 0)
+    return 4;
+
+  int rc = parse_ln_flag_option(arg, opts);
+  if (rc == 0)
+    return 0;
+
+  rc = parse_ln_target_directory_option(argc, argv, index, arg, opts);
+  if (rc >= 0)
+    return rc;
+
+  fprintf(stderr, "unknown option: %s\n", arg);
+  return 2;
+}
+
 static int parse_ln_options(int argc, char **argv, kafs_ln_opts_t *opts, int *operand_index)
 {
   if (!opts || !operand_index)
@@ -3353,43 +3419,13 @@ static int parse_ln_options(int argc, char **argv, kafs_ln_opts_t *opts, int *op
   int i = 2;
   while (i < argc)
   {
-    const char *arg = argv[i];
-    if (strcmp(arg, "--") == 0)
-    {
-      ++i;
+    int rc = parse_ln_option_arg(argc, argv, &i, opts);
+    if (rc == 3)
       break;
-    }
-    if (kafs_cli_is_help_arg(arg))
-      return 1;
-    if (arg[0] != '-' || strcmp(arg, "-") == 0)
+    if (rc == 4)
       break;
-
-    if (is_ln_symbolic_option(arg))
-      opts->symbolic = 1;
-    else if (strcmp(arg, "-f") == 0 || strcmp(arg, "--force") == 0)
-      opts->force = 1;
-    else if (strcmp(arg, "-n") == 0 || strcmp(arg, "--no-dereference") == 0)
-      opts->no_deref = 1;
-    else if (strcmp(arg, "-T") == 0 || strcmp(arg, "--no-target-directory") == 0)
-      opts->no_target_directory = 1;
-    else if (strcmp(arg, "-v") == 0 || strcmp(arg, "--verbose") == 0)
-      opts->verbose = 1;
-    else if (strcmp(arg, "-t") == 0 || strcmp(arg, "--target-directory") == 0)
-    {
-      if (i + 1 >= argc)
-      {
-        fprintf(stderr, "missing argument for %s\n", arg);
-        return 2;
-      }
-      opts->target_dir = argv[++i];
-    }
-    else if (strncmp(arg, "--target-directory=", 19) == 0)
-      opts->target_dir = arg + 19;
-    else
-    {
-      fprintf(stderr, "unknown option: %s\n", arg);
-      return 2;
-    }
+    if (rc != 0)
+      return rc;
     ++i;
   }
 

--- a/src/kafsctl.c
+++ b/src/kafsctl.c
@@ -1941,6 +1941,556 @@ static const char *to_mount_rel_path(const char *mnt_abs, const char *p,
   return out;
 }
 
+typedef struct kafs_stats_report
+{
+  kafs_stats_t st;
+  int have_verbose_scan;
+  uint64_t logical_bytes;
+  uint64_t unique_bytes;
+  uint64_t saved_bytes;
+  uint64_t fs_blocks_used;
+  uint64_t fs_inodes_used;
+  uint64_t bg_dedup_ops;
+  uint64_t hrl_or_legacy_total;
+  double dedup_ratio;
+  double hit_rate;
+  double hrl_put_hash_ms;
+  double hrl_put_find_ms;
+  double hrl_put_cmp_ms;
+  double hrl_put_slot_alloc_ms;
+  double hrl_put_blk_alloc_ms;
+  double hrl_put_blk_write_ms;
+  double hrl_put_avg_chain_steps;
+  double hrl_put_avg_cmp_calls;
+  double lock_inode_cont_rate;
+  double lock_inode_wait_ms;
+  double lock_inode_alloc_cont_rate;
+  double lock_inode_alloc_wait_ms;
+  double lock_bitmap_cont_rate;
+  double lock_bitmap_wait_ms;
+  double lock_hrl_bucket_cont_rate;
+  double lock_hrl_bucket_wait_ms;
+  double lock_hrl_global_cont_rate;
+  double lock_hrl_global_wait_ms;
+  double access_fh_fastpath_rate;
+  double access_avg_components;
+  double dir_snapshot_avg_bytes;
+  double pwrite_iblk_read_ms;
+  double pwrite_iblk_write_ms;
+  double pwrite_iblk_write_p50_ms;
+  double pwrite_iblk_write_p95_ms;
+  double pwrite_iblk_write_p99_ms;
+  double iblk_write_hrl_put_ms;
+  double iblk_write_legacy_blk_write_ms;
+  double iblk_write_dec_ref_ms;
+  double blk_alloc_scan_ms;
+  double blk_alloc_claim_ms;
+  double blk_alloc_set_usage_ms;
+  double blk_alloc_retry_rate;
+  double blk_set_usage_bit_ms;
+  double blk_set_usage_freecnt_ms;
+  double blk_set_usage_wtime_ms;
+  double copy_share_hit_rate;
+  double bg_dedup_retry_rate;
+  double bg_dedup_direct_hit_rate;
+  double pending_worker_start_fail_rate;
+  double fs_blocks_used_pct;
+  double fs_inodes_used_pct;
+  double hrl_entries_used_pct;
+  double hrl_path_rate;
+  double legacy_path_rate;
+  double direct_to_hrl_ratio;
+  double hrl_hit_rate_pct;
+  double hrl_miss_rate_pct;
+  double hrl_rescue_hit_rate;
+  char tombstone_oldest_buf[64];
+} kafs_stats_report_t;
+
+static void kafsctl_stats_report_init(kafs_stats_report_t *report, const kafs_stats_t *st)
+{
+  memset(report, 0, sizeof(*report));
+  report->st = *st;
+  report->dedup_ratio = 1.0;
+  snprintf(report->tombstone_oldest_buf, sizeof(report->tombstone_oldest_buf), "%s", "none");
+}
+
+static void kafsctl_stats_compute_report(kafs_stats_report_t *report)
+{
+  report->have_verbose_scan = ((report->st.result_flags & KAFS_STATS_R_VERBOSE_SCAN) != 0);
+  report->logical_bytes = report->st.hrl_refcnt_sum * (uint64_t)report->st.blksize;
+  report->unique_bytes = report->st.hrl_entries_used * (uint64_t)report->st.blksize;
+  report->saved_bytes =
+      (report->st.hrl_refcnt_sum > report->st.hrl_entries_used)
+          ? (report->st.hrl_refcnt_sum - report->st.hrl_entries_used) * (uint64_t)report->st.blksize
+          : 0;
+  if (report->unique_bytes > 0)
+    report->dedup_ratio = (double)report->logical_bytes / (double)report->unique_bytes;
+
+  if (report->st.hrl_put_calls > 0)
+    report->hit_rate = (double)report->st.hrl_put_hits / (double)report->st.hrl_put_calls;
+  report->hrl_put_hash_ms = (double)report->st.hrl_put_ns_hash / 1000000.0;
+  report->hrl_put_find_ms = (double)report->st.hrl_put_ns_find / 1000000.0;
+  report->hrl_put_cmp_ms = (double)report->st.hrl_put_ns_cmp_content / 1000000.0;
+  report->hrl_put_slot_alloc_ms = (double)report->st.hrl_put_ns_slot_alloc / 1000000.0;
+  report->hrl_put_blk_alloc_ms = (double)report->st.hrl_put_ns_blk_alloc / 1000000.0;
+  report->hrl_put_blk_write_ms = (double)report->st.hrl_put_ns_blk_write / 1000000.0;
+  report->hrl_put_avg_chain_steps =
+      (report->st.hrl_put_calls > 0)
+          ? (double)report->st.hrl_put_chain_steps / (double)report->st.hrl_put_calls
+          : 0.0;
+  report->hrl_put_avg_cmp_calls =
+      (report->st.hrl_put_calls > 0)
+          ? (double)report->st.hrl_put_cmp_calls / (double)report->st.hrl_put_calls
+          : 0.0;
+
+  report->lock_inode_cont_rate =
+      (report->st.lock_inode_acquire > 0)
+          ? (double)report->st.lock_inode_contended / (double)report->st.lock_inode_acquire
+          : 0.0;
+  report->lock_inode_wait_ms = (double)report->st.lock_inode_wait_ns / 1000000.0;
+  report->lock_inode_alloc_cont_rate = (report->st.lock_inode_alloc_acquire > 0)
+                                           ? (double)report->st.lock_inode_alloc_contended /
+                                                 (double)report->st.lock_inode_alloc_acquire
+                                           : 0.0;
+  report->lock_inode_alloc_wait_ms = (double)report->st.lock_inode_alloc_wait_ns / 1000000.0;
+  report->lock_bitmap_cont_rate =
+      (report->st.lock_bitmap_acquire > 0)
+          ? (double)report->st.lock_bitmap_contended / (double)report->st.lock_bitmap_acquire
+          : 0.0;
+  report->lock_bitmap_wait_ms = (double)report->st.lock_bitmap_wait_ns / 1000000.0;
+  report->lock_hrl_bucket_cont_rate = (report->st.lock_hrl_bucket_acquire > 0)
+                                          ? (double)report->st.lock_hrl_bucket_contended /
+                                                (double)report->st.lock_hrl_bucket_acquire
+                                          : 0.0;
+  report->lock_hrl_bucket_wait_ms = (double)report->st.lock_hrl_bucket_wait_ns / 1000000.0;
+  report->lock_hrl_global_cont_rate = (report->st.lock_hrl_global_acquire > 0)
+                                          ? (double)report->st.lock_hrl_global_contended /
+                                                (double)report->st.lock_hrl_global_acquire
+                                          : 0.0;
+  report->lock_hrl_global_wait_ms = (double)report->st.lock_hrl_global_wait_ns / 1000000.0;
+  report->access_fh_fastpath_rate =
+      (report->st.access_calls > 0)
+          ? (double)report->st.access_fh_fastpath_hits / (double)report->st.access_calls
+          : 0.0;
+  report->access_avg_components =
+      (report->st.access_path_walk_calls > 0)
+          ? (double)report->st.access_path_components / (double)report->st.access_path_walk_calls
+          : 0.0;
+  report->dir_snapshot_avg_bytes =
+      (report->st.dir_snapshot_calls > 0)
+          ? (double)report->st.dir_snapshot_bytes / (double)report->st.dir_snapshot_calls
+          : 0.0;
+  report->pwrite_iblk_read_ms = (double)report->st.pwrite_ns_iblk_read / 1000000.0;
+  report->pwrite_iblk_write_ms = (double)report->st.pwrite_ns_iblk_write / 1000000.0;
+  report->pwrite_iblk_write_p50_ms = (double)report->st.pwrite_iblk_write_p50_ns / 1000000.0;
+  report->pwrite_iblk_write_p95_ms = (double)report->st.pwrite_iblk_write_p95_ns / 1000000.0;
+  report->pwrite_iblk_write_p99_ms = (double)report->st.pwrite_iblk_write_p99_ns / 1000000.0;
+  report->iblk_write_hrl_put_ms = (double)report->st.iblk_write_ns_hrl_put / 1000000.0;
+  report->iblk_write_legacy_blk_write_ms =
+      (double)report->st.iblk_write_ns_legacy_blk_write / 1000000.0;
+  report->iblk_write_dec_ref_ms = (double)report->st.iblk_write_ns_dec_ref / 1000000.0;
+  report->blk_alloc_scan_ms = (double)report->st.blk_alloc_ns_scan / 1000000.0;
+  report->blk_alloc_claim_ms = (double)report->st.blk_alloc_ns_claim / 1000000.0;
+  report->blk_alloc_set_usage_ms = (double)report->st.blk_alloc_ns_set_usage / 1000000.0;
+  report->blk_alloc_retry_rate =
+      (report->st.blk_alloc_calls > 0)
+          ? (double)report->st.blk_alloc_claim_retries / (double)report->st.blk_alloc_calls
+          : 0.0;
+  report->blk_set_usage_bit_ms = (double)report->st.blk_set_usage_ns_bit_update / 1000000.0;
+  report->blk_set_usage_freecnt_ms = (double)report->st.blk_set_usage_ns_freecnt_update / 1000000.0;
+  report->blk_set_usage_wtime_ms = (double)report->st.blk_set_usage_ns_wtime_update / 1000000.0;
+  report->copy_share_hit_rate =
+      (report->st.copy_share_attempt_blocks > 0)
+          ? (double)report->st.copy_share_done_blocks / (double)report->st.copy_share_attempt_blocks
+          : 0.0;
+  report->bg_dedup_ops = report->st.bg_dedup_replacements + report->st.bg_dedup_retries;
+  report->bg_dedup_retry_rate = (report->bg_dedup_ops > 0) ? (double)report->st.bg_dedup_retries /
+                                                                 (double)report->bg_dedup_ops
+                                                           : 0.0;
+  report->bg_dedup_direct_hit_rate =
+      (report->st.bg_dedup_direct_candidates > 0)
+          ? (double)report->st.bg_dedup_direct_hits / (double)report->st.bg_dedup_direct_candidates
+          : 0.0;
+  report->pending_worker_start_fail_rate = (report->st.pending_worker_start_calls > 0)
+                                               ? (double)report->st.pending_worker_start_failures /
+                                                     (double)report->st.pending_worker_start_calls
+                                               : 0.0;
+  report->fs_blocks_used = (report->st.fs_blocks_total >= report->st.fs_blocks_free)
+                               ? (report->st.fs_blocks_total - report->st.fs_blocks_free)
+                               : 0;
+  report->fs_inodes_used = (report->st.fs_inodes_total >= report->st.fs_inodes_free)
+                               ? (report->st.fs_inodes_total - report->st.fs_inodes_free)
+                               : 0;
+
+  report->fs_blocks_used_pct = pct_u64(report->fs_blocks_used, report->st.fs_blocks_total);
+  report->fs_inodes_used_pct = pct_u64(report->fs_inodes_used, report->st.fs_inodes_total);
+  report->hrl_entries_used_pct = pct_u64(report->st.hrl_entries_used, report->st.hrl_entries_total);
+  report->hrl_or_legacy_total = report->st.hrl_put_calls + report->st.hrl_put_fallback_legacy;
+  report->hrl_path_rate = pct_u64(report->st.hrl_put_calls, report->hrl_or_legacy_total);
+  report->legacy_path_rate =
+      pct_u64(report->st.hrl_put_fallback_legacy, report->hrl_or_legacy_total);
+  report->direct_to_hrl_ratio =
+      (report->st.hrl_put_calls > 0)
+          ? (double)report->st.hrl_put_fallback_legacy / (double)report->st.hrl_put_calls
+          : 0.0;
+  report->hrl_hit_rate_pct = pct_u64(report->st.hrl_put_hits, report->st.hrl_put_calls);
+  report->hrl_miss_rate_pct = pct_u64(report->st.hrl_put_misses, report->st.hrl_put_calls);
+  report->hrl_rescue_hit_rate =
+      (report->st.hrl_rescue_attempts > 0)
+          ? (double)report->st.hrl_rescue_hits / (double)report->st.hrl_rescue_attempts
+          : 0.0;
+
+  if (report->st.tombstone_inodes > 0 &&
+      (report->st.tombstone_oldest_dtime_sec != 0 || report->st.tombstone_oldest_dtime_nsec != 0))
+  {
+    struct timespec tombstone_oldest = {
+        .tv_sec = (time_t)report->st.tombstone_oldest_dtime_sec,
+        .tv_nsec = (long)report->st.tombstone_oldest_dtime_nsec,
+    };
+    fmt_time(report->tombstone_oldest_buf, &tombstone_oldest);
+  }
+}
+
+static int kafsctl_stats_print_json(const kafs_stats_report_t *report)
+{
+  const kafs_stats_t *st = &report->st;
+  printf("{\n");
+  printf("  \"version\": %" PRIu32 ",\n", st->version);
+  printf("  \"request_flags\": %" PRIu32 ",\n", st->request_flags);
+  printf("  \"result_flags\": %" PRIu32 ",\n", st->result_flags);
+  printf("  \"verbose_scan\": %s,\n", report->have_verbose_scan ? "true" : "false");
+  printf("  \"blksize\": %" PRIu32 ",\n", st->blksize);
+  printf("  \"fs_blocks_total\": %" PRIu64 ",\n", st->fs_blocks_total);
+  printf("  \"fs_blocks_free\": %" PRIu64 ",\n", st->fs_blocks_free);
+  printf("  \"fs_inodes_total\": %" PRIu64 ",\n", st->fs_inodes_total);
+  printf("  \"fs_inodes_free\": %" PRIu64 ",\n", st->fs_inodes_free);
+  printf("  \"tombstone_inodes\": %" PRIu64 ",\n", st->tombstone_inodes);
+  printf("  \"tombstone_oldest_dtime_sec\": %" PRIu64 ",\n", st->tombstone_oldest_dtime_sec);
+  printf("  \"tombstone_oldest_dtime_nsec\": %" PRIu64 ",\n", st->tombstone_oldest_dtime_nsec);
+  printf("  \"hrl_entries_total\": %" PRIu64 ",\n", st->hrl_entries_total);
+  printf("  \"hrl_entries_used\": %" PRIu64 ",\n", st->hrl_entries_used);
+  printf("  \"hrl_entries_duplicated\": %" PRIu64 ",\n", st->hrl_entries_duplicated);
+  printf("  \"hrl_refcnt_sum\": %" PRIu64 ",\n", st->hrl_refcnt_sum);
+  printf("  \"logical_bytes\": %" PRIu64 ",\n", report->logical_bytes);
+  printf("  \"unique_bytes\": %" PRIu64 ",\n", report->unique_bytes);
+  printf("  \"saved_bytes\": %" PRIu64 ",\n", report->saved_bytes);
+  printf("  \"dedup_ratio\": %.6f,\n", report->dedup_ratio);
+  printf("  \"hrl_put_calls\": %" PRIu64 ",\n", st->hrl_put_calls);
+  printf("  \"hrl_put_hits\": %" PRIu64 ",\n", st->hrl_put_hits);
+  printf("  \"hrl_put_misses\": %" PRIu64 ",\n", st->hrl_put_misses);
+  printf("  \"hrl_put_fallback_legacy\": %" PRIu64 ",\n", st->hrl_put_fallback_legacy);
+  printf("  \"hrl_put_ns_hash\": %" PRIu64 ",\n", st->hrl_put_ns_hash);
+  printf("  \"hrl_put_ns_find\": %" PRIu64 ",\n", st->hrl_put_ns_find);
+  printf("  \"hrl_put_ns_cmp_content\": %" PRIu64 ",\n", st->hrl_put_ns_cmp_content);
+  printf("  \"hrl_put_ns_slot_alloc\": %" PRIu64 ",\n", st->hrl_put_ns_slot_alloc);
+  printf("  \"hrl_put_ns_blk_alloc\": %" PRIu64 ",\n", st->hrl_put_ns_blk_alloc);
+  printf("  \"hrl_put_ns_blk_write\": %" PRIu64 ",\n", st->hrl_put_ns_blk_write);
+  printf("  \"hrl_put_chain_steps\": %" PRIu64 ",\n", st->hrl_put_chain_steps);
+  printf("  \"hrl_put_cmp_calls\": %" PRIu64 ",\n", st->hrl_put_cmp_calls);
+  printf("  \"hrl_put_hash_ms\": %.3f,\n", report->hrl_put_hash_ms);
+  printf("  \"hrl_put_find_ms\": %.3f,\n", report->hrl_put_find_ms);
+  printf("  \"hrl_put_cmp_ms\": %.3f,\n", report->hrl_put_cmp_ms);
+  printf("  \"hrl_put_slot_alloc_ms\": %.3f,\n", report->hrl_put_slot_alloc_ms);
+  printf("  \"hrl_put_blk_alloc_ms\": %.3f,\n", report->hrl_put_blk_alloc_ms);
+  printf("  \"hrl_put_blk_write_ms\": %.3f,\n", report->hrl_put_blk_write_ms);
+  printf("  \"hrl_put_avg_chain_steps\": %.3f,\n", report->hrl_put_avg_chain_steps);
+  printf("  \"hrl_put_avg_cmp_calls\": %.3f,\n", report->hrl_put_avg_cmp_calls);
+  printf("  \"hrl_put_hit_rate\": %.6f,\n", report->hit_rate);
+  printf("  \"hrl_rescue_attempts\": %" PRIu64 ",\n", st->hrl_rescue_attempts);
+  printf("  \"hrl_rescue_hits\": %" PRIu64 ",\n", st->hrl_rescue_hits);
+  printf("  \"hrl_rescue_evicts\": %" PRIu64 ",\n", st->hrl_rescue_evicts);
+  printf("  \"hrl_rescue_hit_rate\": %.6f,\n", report->hrl_rescue_hit_rate);
+  printf("  \"lock_inode_acquire\": %" PRIu64 ",\n", st->lock_inode_acquire);
+  printf("  \"lock_inode_contended\": %" PRIu64 ",\n", st->lock_inode_contended);
+  printf("  \"lock_inode_wait_ns\": %" PRIu64 ",\n", st->lock_inode_wait_ns);
+  printf("  \"lock_inode_contended_rate\": %.6f,\n", report->lock_inode_cont_rate);
+  printf("  \"lock_inode_wait_ms\": %.3f,\n", report->lock_inode_wait_ms);
+  printf("  \"lock_inode_alloc_acquire\": %" PRIu64 ",\n", st->lock_inode_alloc_acquire);
+  printf("  \"lock_inode_alloc_contended\": %" PRIu64 ",\n", st->lock_inode_alloc_contended);
+  printf("  \"lock_inode_alloc_wait_ns\": %" PRIu64 ",\n", st->lock_inode_alloc_wait_ns);
+  printf("  \"lock_inode_alloc_contended_rate\": %.6f,\n", report->lock_inode_alloc_cont_rate);
+  printf("  \"lock_inode_alloc_wait_ms\": %.3f,\n", report->lock_inode_alloc_wait_ms);
+  printf("  \"lock_bitmap_acquire\": %" PRIu64 ",\n", st->lock_bitmap_acquire);
+  printf("  \"lock_bitmap_contended\": %" PRIu64 ",\n", st->lock_bitmap_contended);
+  printf("  \"lock_bitmap_wait_ns\": %" PRIu64 ",\n", st->lock_bitmap_wait_ns);
+  printf("  \"lock_bitmap_contended_rate\": %.6f,\n", report->lock_bitmap_cont_rate);
+  printf("  \"lock_bitmap_wait_ms\": %.3f,\n", report->lock_bitmap_wait_ms);
+  printf("  \"lock_hrl_bucket_acquire\": %" PRIu64 ",\n", st->lock_hrl_bucket_acquire);
+  printf("  \"lock_hrl_bucket_contended\": %" PRIu64 ",\n", st->lock_hrl_bucket_contended);
+  printf("  \"lock_hrl_bucket_wait_ns\": %" PRIu64 ",\n", st->lock_hrl_bucket_wait_ns);
+  printf("  \"lock_hrl_bucket_contended_rate\": %.6f,\n", report->lock_hrl_bucket_cont_rate);
+  printf("  \"lock_hrl_bucket_wait_ms\": %.3f,\n", report->lock_hrl_bucket_wait_ms);
+  printf("  \"lock_hrl_global_acquire\": %" PRIu64 ",\n", st->lock_hrl_global_acquire);
+  printf("  \"lock_hrl_global_contended\": %" PRIu64 ",\n", st->lock_hrl_global_contended);
+  printf("  \"lock_hrl_global_wait_ns\": %" PRIu64 ",\n", st->lock_hrl_global_wait_ns);
+  printf("  \"lock_hrl_global_contended_rate\": %.6f,\n", report->lock_hrl_global_cont_rate);
+  printf("  \"lock_hrl_global_wait_ms\": %.3f,\n", report->lock_hrl_global_wait_ms);
+  printf("  \"access_calls\": %" PRIu64 ",\n", st->access_calls);
+  printf("  \"access_path_walk_calls\": %" PRIu64 ",\n", st->access_path_walk_calls);
+  printf("  \"access_fh_fastpath_hits\": %" PRIu64 ",\n", st->access_fh_fastpath_hits);
+  printf("  \"access_path_components\": %" PRIu64 ",\n", st->access_path_components);
+  printf("  \"access_fh_fastpath_rate\": %.6f,\n", report->access_fh_fastpath_rate);
+  printf("  \"access_avg_components\": %.6f,\n", report->access_avg_components);
+  printf("  \"dir_snapshot_calls\": %" PRIu64 ",\n", st->dir_snapshot_calls);
+  printf("  \"dir_snapshot_bytes\": %" PRIu64 ",\n", st->dir_snapshot_bytes);
+  printf("  \"dir_snapshot_avg_bytes\": %.3f,\n", report->dir_snapshot_avg_bytes);
+  printf("  \"dir_snapshot_meta_load_calls\": %" PRIu64 ",\n", st->dir_snapshot_meta_load_calls);
+  printf("  \"dirent_view_next_calls\": %" PRIu64 ",\n", st->dirent_view_next_calls);
+  printf("  \"pwrite_calls\": %" PRIu64 ",\n", st->pwrite_calls);
+  printf("  \"pwrite_bytes\": %" PRIu64 ",\n", st->pwrite_bytes);
+  printf("  \"pwrite_ns_iblk_read\": %" PRIu64 ",\n", st->pwrite_ns_iblk_read);
+  printf("  \"pwrite_ns_iblk_write\": %" PRIu64 ",\n", st->pwrite_ns_iblk_write);
+  printf("  \"pwrite_iblk_write_sample_count\": %" PRIu64 ",\n",
+         st->pwrite_iblk_write_sample_count);
+  printf("  \"pwrite_iblk_write_sample_cap\": %" PRIu64 ",\n", st->pwrite_iblk_write_sample_cap);
+  printf("  \"pwrite_iblk_write_p50_ns\": %" PRIu64 ",\n", st->pwrite_iblk_write_p50_ns);
+  printf("  \"pwrite_iblk_write_p95_ns\": %" PRIu64 ",\n", st->pwrite_iblk_write_p95_ns);
+  printf("  \"pwrite_iblk_write_p99_ns\": %" PRIu64 ",\n", st->pwrite_iblk_write_p99_ns);
+  printf("  \"iblk_write_ns_hrl_put\": %" PRIu64 ",\n", st->iblk_write_ns_hrl_put);
+  printf("  \"iblk_write_ns_legacy_blk_write\": %" PRIu64 ",\n",
+         st->iblk_write_ns_legacy_blk_write);
+  printf("  \"iblk_write_ns_dec_ref\": %" PRIu64 ",\n", st->iblk_write_ns_dec_ref);
+  printf("  \"blk_alloc_calls\": %" PRIu64 ",\n", st->blk_alloc_calls);
+  printf("  \"blk_alloc_claim_retries\": %" PRIu64 ",\n", st->blk_alloc_claim_retries);
+  printf("  \"blk_alloc_ns_scan\": %" PRIu64 ",\n", st->blk_alloc_ns_scan);
+  printf("  \"blk_alloc_ns_claim\": %" PRIu64 ",\n", st->blk_alloc_ns_claim);
+  printf("  \"blk_alloc_ns_set_usage\": %" PRIu64 ",\n", st->blk_alloc_ns_set_usage);
+  printf("  \"blk_set_usage_calls\": %" PRIu64 ",\n", st->blk_set_usage_calls);
+  printf("  \"blk_set_usage_alloc_calls\": %" PRIu64 ",\n", st->blk_set_usage_alloc_calls);
+  printf("  \"blk_set_usage_free_calls\": %" PRIu64 ",\n", st->blk_set_usage_free_calls);
+  printf("  \"blk_set_usage_ns_bit_update\": %" PRIu64 ",\n", st->blk_set_usage_ns_bit_update);
+  printf("  \"blk_set_usage_ns_freecnt_update\": %" PRIu64 ",\n",
+         st->blk_set_usage_ns_freecnt_update);
+  printf("  \"blk_set_usage_ns_wtime_update\": %" PRIu64 ",\n", st->blk_set_usage_ns_wtime_update);
+  printf("  \"copy_share_attempt_blocks\": %" PRIu64 ",\n", st->copy_share_attempt_blocks);
+  printf("  \"copy_share_done_blocks\": %" PRIu64 ",\n", st->copy_share_done_blocks);
+  printf("  \"copy_share_fallback_blocks\": %" PRIu64 ",\n", st->copy_share_fallback_blocks);
+  printf("  \"copy_share_skip_unaligned\": %" PRIu64 ",\n", st->copy_share_skip_unaligned);
+  printf("  \"copy_share_skip_dst_inline\": %" PRIu64 ",\n", st->copy_share_skip_dst_inline);
+  printf("  \"bg_dedup_replacements\": %" PRIu64 ",\n", st->bg_dedup_replacements);
+  printf("  \"bg_dedup_evicts\": %" PRIu64 ",\n", st->bg_dedup_evicts);
+  printf("  \"bg_dedup_retries\": %" PRIu64 ",\n", st->bg_dedup_retries);
+  printf("  \"bg_dedup_steps\": %" PRIu64 ",\n", st->bg_dedup_steps);
+  printf("  \"bg_dedup_scanned_blocks\": %" PRIu64 ",\n", st->bg_dedup_scanned_blocks);
+  printf("  \"bg_dedup_direct_candidates\": %" PRIu64 ",\n", st->bg_dedup_direct_candidates);
+  printf("  \"bg_dedup_direct_hits\": %" PRIu64 ",\n", st->bg_dedup_direct_hits);
+  printf("  \"bg_dedup_direct_hit_rate\": %.6f,\n", report->bg_dedup_direct_hit_rate);
+  printf("  \"bg_dedup_index_evicts\": %" PRIu64 ",\n", st->bg_dedup_index_evicts);
+  printf("  \"bg_dedup_cooldowns\": %" PRIu64 ",\n", st->bg_dedup_cooldowns);
+  printf("  \"bg_dedup_mode\": %" PRIu32 ",\n", st->bg_dedup_mode);
+  printf("  \"bg_dedup_mode_str\": \"%s\",\n", bg_dedup_mode_str(st->bg_dedup_mode));
+  printf("  \"bg_dedup_telemetry_valid\": %" PRIu32 ",\n", st->bg_dedup_telemetry_valid);
+  printf("  \"bg_dedup_last_scanned_blocks\": %" PRIu64 ",\n", st->bg_dedup_last_scanned_blocks);
+  printf("  \"bg_dedup_last_direct_candidates\": %" PRIu64 ",\n",
+         st->bg_dedup_last_direct_candidates);
+  printf("  \"bg_dedup_last_replacements\": %" PRIu64 ",\n", st->bg_dedup_last_replacements);
+  printf("  \"bg_dedup_idle_skip_streak\": %" PRIu64 ",\n", st->bg_dedup_idle_skip_streak);
+  printf("  \"bg_dedup_cold_start_due_ms\": %" PRIu64 ",\n", st->bg_dedup_cold_start_due_ms);
+  printf("  \"pending_queue_depth\": %" PRIu64 ",\n", st->pending_queue_depth);
+  printf("  \"pending_queue_capacity\": %" PRIu64 ",\n", st->pending_queue_capacity);
+  printf("  \"pending_queue_head\": %" PRIu64 ",\n", st->pending_queue_head);
+  printf("  \"pending_queue_tail\": %" PRIu64 ",\n", st->pending_queue_tail);
+  printf("  \"pending_worker_start_calls\": %" PRIu64 ",\n", st->pending_worker_start_calls);
+  printf("  \"pending_worker_start_failures\": %" PRIu64 ",\n", st->pending_worker_start_failures);
+  printf("  \"pending_worker_start_fail_rate\": %.6f,\n", report->pending_worker_start_fail_rate);
+  printf("  \"pending_worker_start_last_error\": %" PRId32 ",\n",
+         st->pending_worker_start_last_error);
+  printf("  \"pending_worker_lwp_tid\": %" PRId32 ",\n", st->pending_worker_lwp_tid);
+  printf("  \"pending_worker_running\": %" PRId32 ",\n", st->pending_worker_running);
+  printf("  \"pending_worker_stop_flag\": %" PRId32 ",\n", st->pending_worker_stop_flag);
+  printf("  \"pending_worker_main_entries\": %" PRIu64 ",\n", st->pending_worker_main_entries);
+  printf("  \"pending_worker_main_exits\": %" PRIu64 ",\n", st->pending_worker_main_exits);
+  printf("  \"pending_resolved\": %" PRIu64 ",\n", st->pending_resolved);
+  printf("  \"pending_old_block_freed\": %" PRIu64 ",\n", st->pending_old_block_freed);
+  printf("  \"bg_dedup_retry_rate\": %.6f,\n", report->bg_dedup_retry_rate);
+  printf("  \"copy_share_hit_rate\": %.6f,\n", report->copy_share_hit_rate);
+  printf("  \"pwrite_iblk_read_ms\": %.3f,\n", report->pwrite_iblk_read_ms);
+  printf("  \"pwrite_iblk_write_ms\": %.3f,\n", report->pwrite_iblk_write_ms);
+  printf("  \"pwrite_iblk_write_p50_ms\": %.3f,\n", report->pwrite_iblk_write_p50_ms);
+  printf("  \"pwrite_iblk_write_p95_ms\": %.3f,\n", report->pwrite_iblk_write_p95_ms);
+  printf("  \"pwrite_iblk_write_p99_ms\": %.3f,\n", report->pwrite_iblk_write_p99_ms);
+  printf("  \"iblk_write_hrl_put_ms\": %.3f,\n", report->iblk_write_hrl_put_ms);
+  printf("  \"iblk_write_legacy_blk_write_ms\": %.3f,\n", report->iblk_write_legacy_blk_write_ms);
+  printf("  \"iblk_write_dec_ref_ms\": %.3f,\n", report->iblk_write_dec_ref_ms);
+  printf("  \"blk_alloc_scan_ms\": %.3f,\n", report->blk_alloc_scan_ms);
+  printf("  \"blk_alloc_claim_ms\": %.3f,\n", report->blk_alloc_claim_ms);
+  printf("  \"blk_alloc_set_usage_ms\": %.3f,\n", report->blk_alloc_set_usage_ms);
+  printf("  \"blk_alloc_retry_rate\": %.6f,\n", report->blk_alloc_retry_rate);
+  printf("  \"blk_set_usage_bit_ms\": %.3f,\n", report->blk_set_usage_bit_ms);
+  printf("  \"blk_set_usage_freecnt_ms\": %.3f,\n", report->blk_set_usage_freecnt_ms);
+  printf("  \"blk_set_usage_wtime_ms\": %.3f\n", report->blk_set_usage_wtime_ms);
+  printf("}\n");
+  return 0;
+}
+
+static int kafsctl_stats_print_text(const kafs_stats_report_t *report, kafs_unit_t unit)
+{
+  const kafs_stats_t *st = &report->st;
+  printf("kafs fsstat v%" PRIu32 "\n", st->version);
+  printf("  mode: %s\n", report->have_verbose_scan ? "verbose" : "lightweight");
+  if (!report->have_verbose_scan)
+    printf("  note: tombstone/HRL full scans are skipped by default; rerun with -v for them.\n");
+  printf("  summary.capacity:\n");
+  printf("    fs_blocks: used=");
+  print_bytes(report->fs_blocks_used * (uint64_t)st->blksize, unit);
+  printf(" / total=");
+  print_bytes(st->fs_blocks_total * (uint64_t)st->blksize, unit);
+  printf(" (%.2f%%)\n", report->fs_blocks_used_pct);
+  printf("    fs_inodes: used=%" PRIu64 " / total=%" PRIu64 " (%.2f%%)\n", report->fs_inodes_used,
+         st->fs_inodes_total, report->fs_inodes_used_pct);
+  if (report->have_verbose_scan)
+    printf("    hrl_entries: used=%" PRIu64 " / total=%" PRIu64 " (%.2f%%)\n", st->hrl_entries_used,
+           st->hrl_entries_total, report->hrl_entries_used_pct);
+  else
+    printf("    hrl_entries: total=%" PRIu64 " (used count requires -v)\n", st->hrl_entries_total);
+
+  printf("  summary.ratios:\n");
+  if (report->have_verbose_scan)
+    printf("    dedup_ratio: %.3f (logical/unique)\n", report->dedup_ratio);
+  else
+    printf("    dedup_ratio: unavailable without -v\n");
+  printf("    write_path: hrl=%.2f%% legacy_direct=%.2f%% (hrl_calls=%" PRIu64
+         " fallback_legacy=%" PRIu64 ")\n",
+         report->hrl_path_rate, report->legacy_path_rate, st->hrl_put_calls,
+         st->hrl_put_fallback_legacy);
+  printf("    direct_to_hrl: %.6f (legacy_direct/hrl_calls)\n", report->direct_to_hrl_ratio);
+  printf("    hrl_hit_miss: hit=%.2f%% miss=%.2f%%\n", report->hrl_hit_rate_pct,
+         report->hrl_miss_rate_pct);
+  printf("    copy_share_hit: %.2f%% (done/attempt)\n", report->copy_share_hit_rate * 100.0);
+
+  printf("  blksize: ");
+  print_bytes(st->blksize, unit);
+  printf("\n");
+
+  printf("  fs: blocks total=%" PRIu64 " (", st->fs_blocks_total);
+  print_bytes(st->fs_blocks_total * (uint64_t)st->blksize, unit);
+  printf(") free=%" PRIu64 " (", st->fs_blocks_free);
+  print_bytes(st->fs_blocks_free * (uint64_t)st->blksize, unit);
+  printf(")\n");
+  printf("      inodes total=%" PRIu64 " free=%" PRIu64 "\n", st->fs_inodes_total,
+         st->fs_inodes_free);
+  if (!report->have_verbose_scan)
+    printf("      tombstones: omitted without -v\n");
+  else if (st->tombstone_inodes > 0)
+    printf("      tombstones count=%" PRIu64 " oldest_dtime=%s (%" PRIu64 ".%09" PRIu64 ")\n",
+           st->tombstone_inodes, report->tombstone_oldest_buf, st->tombstone_oldest_dtime_sec,
+           st->tombstone_oldest_dtime_nsec);
+  else
+    printf("      tombstones count=0 oldest_dtime=none\n");
+
+  if (report->have_verbose_scan)
+  {
+    printf("  hrl: entries used=%" PRIu64 "/%" PRIu64 " duplicated=%" PRIu64 " refsum=%" PRIu64
+           "\n",
+           st->hrl_entries_used, st->hrl_entries_total, st->hrl_entries_duplicated,
+           st->hrl_refcnt_sum);
+    printf("  dedup: logical=");
+    print_bytes(report->logical_bytes, unit);
+    printf(" unique=");
+    print_bytes(report->unique_bytes, unit);
+    printf(" saved=");
+    print_bytes(report->saved_bytes, unit);
+    printf(" ratio=%.3f\n", report->dedup_ratio);
+  }
+  else
+  {
+    printf("  hrl: total entries=%" PRIu64 " (used/dup/refsum require -v)\n",
+           st->hrl_entries_total);
+    printf("  dedup: unavailable without -v\n");
+  }
+
+  printf("  hrl_put: calls=%" PRIu64 " hits=%" PRIu64 " misses=%" PRIu64 " fallback_legacy=%" PRIu64
+         " hit_rate=%.3f\n",
+         st->hrl_put_calls, st->hrl_put_hits, st->hrl_put_misses, st->hrl_put_fallback_legacy,
+         report->hit_rate);
+  printf("  hrl_rescue: attempts=%" PRIu64 " hits=%" PRIu64 " evicts=%" PRIu64 " hit_rate=%.3f\n",
+         st->hrl_rescue_attempts, st->hrl_rescue_hits, st->hrl_rescue_evicts,
+         report->hrl_rescue_hit_rate);
+  printf("  hrl_put_decomp: hash_ms=%.3f find_ms=%.3f cmp_ms=%.3f slot_alloc_ms=%.3f "
+         "blk_alloc_ms=%.3f blk_write_ms=%.3f avg_chain_steps=%.3f avg_cmp_calls=%.3f\n",
+         report->hrl_put_hash_ms, report->hrl_put_find_ms, report->hrl_put_cmp_ms,
+         report->hrl_put_slot_alloc_ms, report->hrl_put_blk_alloc_ms, report->hrl_put_blk_write_ms,
+         report->hrl_put_avg_chain_steps, report->hrl_put_avg_cmp_calls);
+  printf("  lock[inode]: acquire=%" PRIu64 " contended=%" PRIu64 " rate=%.3f wait_ms=%.3f\n",
+         st->lock_inode_acquire, st->lock_inode_contended, report->lock_inode_cont_rate,
+         report->lock_inode_wait_ms);
+  printf("  lock[inode_alloc]: acquire=%" PRIu64 " contended=%" PRIu64 " rate=%.3f wait_ms=%.3f\n",
+         st->lock_inode_alloc_acquire, st->lock_inode_alloc_contended,
+         report->lock_inode_alloc_cont_rate, report->lock_inode_alloc_wait_ms);
+  printf("  lock[bitmap]: acquire=%" PRIu64 " contended=%" PRIu64 " rate=%.3f wait_ms=%.3f\n",
+         st->lock_bitmap_acquire, st->lock_bitmap_contended, report->lock_bitmap_cont_rate,
+         report->lock_bitmap_wait_ms);
+  printf("  lock[hrl_bucket]: acquire=%" PRIu64 " contended=%" PRIu64 " rate=%.3f wait_ms=%.3f\n",
+         st->lock_hrl_bucket_acquire, st->lock_hrl_bucket_contended,
+         report->lock_hrl_bucket_cont_rate, report->lock_hrl_bucket_wait_ms);
+  printf("  lock[hrl_global]: acquire=%" PRIu64 " contended=%" PRIu64 " rate=%.3f wait_ms=%.3f\n",
+         st->lock_hrl_global_acquire, st->lock_hrl_global_contended,
+         report->lock_hrl_global_cont_rate, report->lock_hrl_global_wait_ms);
+  printf("  metadata_lookup: access_calls=%" PRIu64 " path_walk_calls=%" PRIu64
+         " fh_fastpath_hits=%" PRIu64 " fh_fastpath_rate=%.3f avg_components=%.3f\n",
+         st->access_calls, st->access_path_walk_calls, st->access_fh_fastpath_hits,
+         report->access_fh_fastpath_rate, report->access_avg_components);
+  printf("                   dir_snapshot_calls=%" PRIu64 " snapshot_bytes=%" PRIu64
+         " avg_snapshot_bytes=%.3f meta_load_calls=%" PRIu64 " view_next_calls=%" PRIu64 "\n",
+         st->dir_snapshot_calls, st->dir_snapshot_bytes, report->dir_snapshot_avg_bytes,
+         st->dir_snapshot_meta_load_calls, st->dirent_view_next_calls);
+  printf("  pwrite: calls=%" PRIu64 " bytes=%" PRIu64 " iblk_read_ms=%.3f iblk_write_ms=%.3f\n",
+         st->pwrite_calls, st->pwrite_bytes, report->pwrite_iblk_read_ms,
+         report->pwrite_iblk_write_ms);
+  printf("          iblk_write_lat: samples=%" PRIu64 "/%" PRIu64
+         " p50_ms=%.3f p95_ms=%.3f p99_ms=%.3f\n",
+         st->pwrite_iblk_write_sample_count, st->pwrite_iblk_write_sample_cap,
+         report->pwrite_iblk_write_p50_ms, report->pwrite_iblk_write_p95_ms,
+         report->pwrite_iblk_write_p99_ms);
+  printf("  iblk_write: hrl_put_ms=%.3f legacy_blk_write_ms=%.3f dec_ref_ms=%.3f\n",
+         report->iblk_write_hrl_put_ms, report->iblk_write_legacy_blk_write_ms,
+         report->iblk_write_dec_ref_ms);
+  printf("  blk_alloc: calls=%" PRIu64 " retries=%" PRIu64 " retry_rate=%.3f scan_ms=%.3f "
+         "claim_ms=%.3f set_usage_ms=%.3f\n",
+         st->blk_alloc_calls, st->blk_alloc_claim_retries, report->blk_alloc_retry_rate,
+         report->blk_alloc_scan_ms, report->blk_alloc_claim_ms, report->blk_alloc_set_usage_ms);
+  printf("  blk_set_usage: calls=%" PRIu64 " alloc_calls=%" PRIu64 " free_calls=%" PRIu64
+         " bit_ms=%.3f freecnt_ms=%.3f wtime_ms=%.3f\n",
+         st->blk_set_usage_calls, st->blk_set_usage_alloc_calls, st->blk_set_usage_free_calls,
+         report->blk_set_usage_bit_ms, report->blk_set_usage_freecnt_ms,
+         report->blk_set_usage_wtime_ms);
+  printf("  copy_share: attempt_blocks=%" PRIu64 " done_blocks=%" PRIu64 " fallback_blocks=%" PRIu64
+         " skip_unaligned=%" PRIu64 " skip_dst_inline=%" PRIu64 " hit_rate=%.3f\n",
+         st->copy_share_attempt_blocks, st->copy_share_done_blocks, st->copy_share_fallback_blocks,
+         st->copy_share_skip_unaligned, st->copy_share_skip_dst_inline,
+         report->copy_share_hit_rate);
+  printf("  bg_dedup: replacements=%" PRIu64 " evicts=%" PRIu64 " retries=%" PRIu64
+         " retry_rate=%.3f\n",
+         st->bg_dedup_replacements, st->bg_dedup_evicts, st->bg_dedup_retries,
+         report->bg_dedup_retry_rate);
+  printf("            steps=%" PRIu64 " scanned_blocks=%" PRIu64 " direct_candidates=%" PRIu64
+         " direct_hits=%" PRIu64 " direct_hit_rate=%.3f index_evicts=%" PRIu64 " cooldowns=%" PRIu64
+         "\n",
+         st->bg_dedup_steps, st->bg_dedup_scanned_blocks, st->bg_dedup_direct_candidates,
+         st->bg_dedup_direct_hits, report->bg_dedup_direct_hit_rate, st->bg_dedup_index_evicts,
+         st->bg_dedup_cooldowns);
+  printf("            mode=%" PRIu32 " (%s) telemetry_valid=%" PRIu32 " last_scanned=%" PRIu64
+         " last_direct_candidates=%" PRIu64 " last_replacements=%" PRIu64
+         " idle_skip_streak=%" PRIu64 " cold_due_ms=%" PRIu64 "\n",
+         st->bg_dedup_mode, bg_dedup_mode_str(st->bg_dedup_mode), st->bg_dedup_telemetry_valid,
+         st->bg_dedup_last_scanned_blocks, st->bg_dedup_last_direct_candidates,
+         st->bg_dedup_last_replacements, st->bg_dedup_idle_skip_streak,
+         st->bg_dedup_cold_start_due_ms);
+  printf("  pending: depth=%" PRIu64 "/%" PRIu64 " head=%" PRIu64 " tail=%" PRIu64 "\n",
+         st->pending_queue_depth, st->pending_queue_capacity, st->pending_queue_head,
+         st->pending_queue_tail);
+  printf("           worker running=%" PRId32 " stop=%" PRId32 " start_calls=%" PRIu64
+         " start_failures=%" PRIu64 " fail_rate=%.3f last_error=%" PRId32 " lwp_tid=%" PRId32 "\n",
+         st->pending_worker_running, st->pending_worker_stop_flag, st->pending_worker_start_calls,
+         st->pending_worker_start_failures, report->pending_worker_start_fail_rate,
+         st->pending_worker_start_last_error, st->pending_worker_lwp_tid);
+  printf("           worker_main entries=%" PRIu64 " exits=%" PRIu64 "\n",
+         st->pending_worker_main_entries, st->pending_worker_main_exits);
+  printf("           pending_resolved=%" PRIu64 " old_block_freed=%" PRIu64 "\n",
+         st->pending_resolved, st->pending_old_block_freed);
+  return 0;
+}
+
 static int cmd_stats(const char *mnt, int json, int verbose, kafs_unit_t unit)
 {
   int fd = open(mnt, O_RDONLY | O_DIRECTORY);
@@ -1962,460 +2512,13 @@ static int cmd_stats(const char *mnt, int json, int verbose, kafs_unit_t unit)
     return 1;
   }
   close(fd);
-
-  int have_verbose_scan = ((st.result_flags & KAFS_STATS_R_VERBOSE_SCAN) != 0);
-
-  uint64_t logical_bytes = st.hrl_refcnt_sum * (uint64_t)st.blksize;
-  uint64_t unique_bytes = st.hrl_entries_used * (uint64_t)st.blksize;
-  uint64_t saved_bytes = (st.hrl_refcnt_sum > st.hrl_entries_used)
-                             ? (st.hrl_refcnt_sum - st.hrl_entries_used) * (uint64_t)st.blksize
-                             : 0;
-
-  double dedup_ratio = 1.0;
-  if (unique_bytes > 0)
-    dedup_ratio = (double)logical_bytes / (double)unique_bytes;
-
-  double hit_rate = 0.0;
-  if (st.hrl_put_calls > 0)
-  {
-    hit_rate = (double)st.hrl_put_hits / (double)st.hrl_put_calls;
-  }
-  double hrl_put_hash_ms = (double)st.hrl_put_ns_hash / 1000000.0;
-  double hrl_put_find_ms = (double)st.hrl_put_ns_find / 1000000.0;
-  double hrl_put_cmp_ms = (double)st.hrl_put_ns_cmp_content / 1000000.0;
-  double hrl_put_slot_alloc_ms = (double)st.hrl_put_ns_slot_alloc / 1000000.0;
-  double hrl_put_blk_alloc_ms = (double)st.hrl_put_ns_blk_alloc / 1000000.0;
-  double hrl_put_blk_write_ms = (double)st.hrl_put_ns_blk_write / 1000000.0;
-  double hrl_put_avg_chain_steps =
-      (st.hrl_put_calls > 0) ? (double)st.hrl_put_chain_steps / (double)st.hrl_put_calls : 0.0;
-  double hrl_put_avg_cmp_calls =
-      (st.hrl_put_calls > 0) ? (double)st.hrl_put_cmp_calls / (double)st.hrl_put_calls : 0.0;
-
-  double lock_inode_cont_rate =
-      (st.lock_inode_acquire > 0) ? (double)st.lock_inode_contended / (double)st.lock_inode_acquire
-                                  : 0.0;
-  double lock_inode_wait_ms = (double)st.lock_inode_wait_ns / 1000000.0;
-  double lock_inode_alloc_cont_rate =
-      (st.lock_inode_alloc_acquire > 0)
-          ? (double)st.lock_inode_alloc_contended / (double)st.lock_inode_alloc_acquire
-          : 0.0;
-  double lock_inode_alloc_wait_ms = (double)st.lock_inode_alloc_wait_ns / 1000000.0;
-  double lock_bitmap_cont_rate = (st.lock_bitmap_acquire > 0) ? (double)st.lock_bitmap_contended /
-                                                                    (double)st.lock_bitmap_acquire
-                                                              : 0.0;
-  double lock_bitmap_wait_ms = (double)st.lock_bitmap_wait_ns / 1000000.0;
-  double lock_hrl_bucket_cont_rate =
-      (st.lock_hrl_bucket_acquire > 0)
-          ? (double)st.lock_hrl_bucket_contended / (double)st.lock_hrl_bucket_acquire
-          : 0.0;
-  double lock_hrl_bucket_wait_ms = (double)st.lock_hrl_bucket_wait_ns / 1000000.0;
-  double lock_hrl_global_cont_rate =
-      (st.lock_hrl_global_acquire > 0)
-          ? (double)st.lock_hrl_global_contended / (double)st.lock_hrl_global_acquire
-          : 0.0;
-  double lock_hrl_global_wait_ms = (double)st.lock_hrl_global_wait_ns / 1000000.0;
-  double access_fh_fastpath_rate =
-      (st.access_calls > 0) ? (double)st.access_fh_fastpath_hits / (double)st.access_calls : 0.0;
-  double access_avg_components =
-      (st.access_path_walk_calls > 0)
-          ? (double)st.access_path_components / (double)st.access_path_walk_calls
-          : 0.0;
-  double dir_snapshot_avg_bytes =
-      (st.dir_snapshot_calls > 0) ? (double)st.dir_snapshot_bytes / (double)st.dir_snapshot_calls
-                                  : 0.0;
-  double pwrite_iblk_read_ms = (double)st.pwrite_ns_iblk_read / 1000000.0;
-  double pwrite_iblk_write_ms = (double)st.pwrite_ns_iblk_write / 1000000.0;
-  double pwrite_iblk_write_p50_ms = (double)st.pwrite_iblk_write_p50_ns / 1000000.0;
-  double pwrite_iblk_write_p95_ms = (double)st.pwrite_iblk_write_p95_ns / 1000000.0;
-  double pwrite_iblk_write_p99_ms = (double)st.pwrite_iblk_write_p99_ns / 1000000.0;
-  double iblk_write_hrl_put_ms = (double)st.iblk_write_ns_hrl_put / 1000000.0;
-  double iblk_write_legacy_blk_write_ms = (double)st.iblk_write_ns_legacy_blk_write / 1000000.0;
-  double iblk_write_dec_ref_ms = (double)st.iblk_write_ns_dec_ref / 1000000.0;
-  double blk_alloc_scan_ms = (double)st.blk_alloc_ns_scan / 1000000.0;
-  double blk_alloc_claim_ms = (double)st.blk_alloc_ns_claim / 1000000.0;
-  double blk_alloc_set_usage_ms = (double)st.blk_alloc_ns_set_usage / 1000000.0;
-  double blk_alloc_retry_rate =
-      (st.blk_alloc_calls > 0) ? (double)st.blk_alloc_claim_retries / (double)st.blk_alloc_calls
-                               : 0.0;
-  double blk_set_usage_bit_ms = (double)st.blk_set_usage_ns_bit_update / 1000000.0;
-  double blk_set_usage_freecnt_ms = (double)st.blk_set_usage_ns_freecnt_update / 1000000.0;
-  double blk_set_usage_wtime_ms = (double)st.blk_set_usage_ns_wtime_update / 1000000.0;
-  double copy_share_hit_rate =
-      (st.copy_share_attempt_blocks > 0)
-          ? (double)st.copy_share_done_blocks / (double)st.copy_share_attempt_blocks
-          : 0.0;
-  uint64_t bg_dedup_ops = st.bg_dedup_replacements + st.bg_dedup_retries;
-  double bg_dedup_retry_rate =
-      (bg_dedup_ops > 0) ? (double)st.bg_dedup_retries / (double)bg_dedup_ops : 0.0;
-  double bg_dedup_direct_hit_rate =
-      (st.bg_dedup_direct_candidates > 0)
-          ? (double)st.bg_dedup_direct_hits / (double)st.bg_dedup_direct_candidates
-          : 0.0;
-  double pending_worker_start_fail_rate =
-      (st.pending_worker_start_calls > 0)
-          ? (double)st.pending_worker_start_failures / (double)st.pending_worker_start_calls
-          : 0.0;
-  uint64_t fs_blocks_used =
-      (st.fs_blocks_total >= st.fs_blocks_free) ? (st.fs_blocks_total - st.fs_blocks_free) : 0;
-  uint64_t fs_inodes_used =
-      (st.fs_inodes_total >= st.fs_inodes_free) ? (st.fs_inodes_total - st.fs_inodes_free) : 0;
-
-  double fs_blocks_used_pct = pct_u64(fs_blocks_used, st.fs_blocks_total);
-  double fs_inodes_used_pct = pct_u64(fs_inodes_used, st.fs_inodes_total);
-  double hrl_entries_used_pct = pct_u64(st.hrl_entries_used, st.hrl_entries_total);
-
-  uint64_t hrl_or_legacy_total = st.hrl_put_calls + st.hrl_put_fallback_legacy;
-  double hrl_path_rate = pct_u64(st.hrl_put_calls, hrl_or_legacy_total);
-  double legacy_path_rate = pct_u64(st.hrl_put_fallback_legacy, hrl_or_legacy_total);
-  double direct_to_hrl_ratio =
-      (st.hrl_put_calls > 0) ? (double)st.hrl_put_fallback_legacy / (double)st.hrl_put_calls : 0.0;
-  double hrl_hit_rate_pct = pct_u64(st.hrl_put_hits, st.hrl_put_calls);
-  double hrl_miss_rate_pct = pct_u64(st.hrl_put_misses, st.hrl_put_calls);
-  double hrl_rescue_hit_rate = (st.hrl_rescue_attempts > 0)
-                                   ? (double)st.hrl_rescue_hits / (double)st.hrl_rescue_attempts
-                                   : 0.0;
-  struct timespec tombstone_oldest = {
-      .tv_sec = (time_t)st.tombstone_oldest_dtime_sec,
-      .tv_nsec = (long)st.tombstone_oldest_dtime_nsec,
-  };
-  char tombstone_oldest_buf[64] = "none";
-  if (st.tombstone_inodes > 0 &&
-      (st.tombstone_oldest_dtime_sec != 0 || st.tombstone_oldest_dtime_nsec != 0))
-    fmt_time(tombstone_oldest_buf, &tombstone_oldest);
+  kafs_stats_report_t report;
+  kafsctl_stats_report_init(&report, &st);
+  kafsctl_stats_compute_report(&report);
 
   if (json)
-  {
-    printf("{\n");
-    printf("  \"version\": %" PRIu32 ",\n", st.version);
-    printf("  \"request_flags\": %" PRIu32 ",\n", st.request_flags);
-    printf("  \"result_flags\": %" PRIu32 ",\n", st.result_flags);
-    printf("  \"verbose_scan\": %s,\n", have_verbose_scan ? "true" : "false");
-    printf("  \"blksize\": %" PRIu32 ",\n", st.blksize);
-    printf("  \"fs_blocks_total\": %" PRIu64 ",\n", st.fs_blocks_total);
-    printf("  \"fs_blocks_free\": %" PRIu64 ",\n", st.fs_blocks_free);
-    printf("  \"fs_inodes_total\": %" PRIu64 ",\n", st.fs_inodes_total);
-    printf("  \"fs_inodes_free\": %" PRIu64 ",\n", st.fs_inodes_free);
-    printf("  \"tombstone_inodes\": %" PRIu64 ",\n", st.tombstone_inodes);
-    printf("  \"tombstone_oldest_dtime_sec\": %" PRIu64 ",\n", st.tombstone_oldest_dtime_sec);
-    printf("  \"tombstone_oldest_dtime_nsec\": %" PRIu64 ",\n", st.tombstone_oldest_dtime_nsec);
-    printf("  \"hrl_entries_total\": %" PRIu64 ",\n", st.hrl_entries_total);
-    printf("  \"hrl_entries_used\": %" PRIu64 ",\n", st.hrl_entries_used);
-    printf("  \"hrl_entries_duplicated\": %" PRIu64 ",\n", st.hrl_entries_duplicated);
-    printf("  \"hrl_refcnt_sum\": %" PRIu64 ",\n", st.hrl_refcnt_sum);
-    printf("  \"logical_bytes\": %" PRIu64 ",\n", logical_bytes);
-    printf("  \"unique_bytes\": %" PRIu64 ",\n", unique_bytes);
-    printf("  \"saved_bytes\": %" PRIu64 ",\n", saved_bytes);
-    printf("  \"dedup_ratio\": %.6f,\n", dedup_ratio);
-    printf("  \"hrl_put_calls\": %" PRIu64 ",\n", st.hrl_put_calls);
-    printf("  \"hrl_put_hits\": %" PRIu64 ",\n", st.hrl_put_hits);
-    printf("  \"hrl_put_misses\": %" PRIu64 ",\n", st.hrl_put_misses);
-    printf("  \"hrl_put_fallback_legacy\": %" PRIu64 ",\n", st.hrl_put_fallback_legacy);
-    printf("  \"hrl_put_ns_hash\": %" PRIu64 ",\n", st.hrl_put_ns_hash);
-    printf("  \"hrl_put_ns_find\": %" PRIu64 ",\n", st.hrl_put_ns_find);
-    printf("  \"hrl_put_ns_cmp_content\": %" PRIu64 ",\n", st.hrl_put_ns_cmp_content);
-    printf("  \"hrl_put_ns_slot_alloc\": %" PRIu64 ",\n", st.hrl_put_ns_slot_alloc);
-    printf("  \"hrl_put_ns_blk_alloc\": %" PRIu64 ",\n", st.hrl_put_ns_blk_alloc);
-    printf("  \"hrl_put_ns_blk_write\": %" PRIu64 ",\n", st.hrl_put_ns_blk_write);
-    printf("  \"hrl_put_chain_steps\": %" PRIu64 ",\n", st.hrl_put_chain_steps);
-    printf("  \"hrl_put_cmp_calls\": %" PRIu64 ",\n", st.hrl_put_cmp_calls);
-    printf("  \"hrl_put_hash_ms\": %.3f,\n", hrl_put_hash_ms);
-    printf("  \"hrl_put_find_ms\": %.3f,\n", hrl_put_find_ms);
-    printf("  \"hrl_put_cmp_ms\": %.3f,\n", hrl_put_cmp_ms);
-    printf("  \"hrl_put_slot_alloc_ms\": %.3f,\n", hrl_put_slot_alloc_ms);
-    printf("  \"hrl_put_blk_alloc_ms\": %.3f,\n", hrl_put_blk_alloc_ms);
-    printf("  \"hrl_put_blk_write_ms\": %.3f,\n", hrl_put_blk_write_ms);
-    printf("  \"hrl_put_avg_chain_steps\": %.3f,\n", hrl_put_avg_chain_steps);
-    printf("  \"hrl_put_avg_cmp_calls\": %.3f,\n", hrl_put_avg_cmp_calls);
-    printf("  \"hrl_put_hit_rate\": %.6f,\n", hit_rate);
-    printf("  \"hrl_rescue_attempts\": %" PRIu64 ",\n", st.hrl_rescue_attempts);
-    printf("  \"hrl_rescue_hits\": %" PRIu64 ",\n", st.hrl_rescue_hits);
-    printf("  \"hrl_rescue_evicts\": %" PRIu64 ",\n", st.hrl_rescue_evicts);
-    printf("  \"hrl_rescue_hit_rate\": %.6f,\n", hrl_rescue_hit_rate);
-    printf("  \"lock_inode_acquire\": %" PRIu64 ",\n", st.lock_inode_acquire);
-    printf("  \"lock_inode_contended\": %" PRIu64 ",\n", st.lock_inode_contended);
-    printf("  \"lock_inode_wait_ns\": %" PRIu64 ",\n", st.lock_inode_wait_ns);
-    printf("  \"lock_inode_contended_rate\": %.6f,\n", lock_inode_cont_rate);
-    printf("  \"lock_inode_wait_ms\": %.3f,\n", lock_inode_wait_ms);
-    printf("  \"lock_inode_alloc_acquire\": %" PRIu64 ",\n", st.lock_inode_alloc_acquire);
-    printf("  \"lock_inode_alloc_contended\": %" PRIu64 ",\n", st.lock_inode_alloc_contended);
-    printf("  \"lock_inode_alloc_wait_ns\": %" PRIu64 ",\n", st.lock_inode_alloc_wait_ns);
-    printf("  \"lock_inode_alloc_contended_rate\": %.6f,\n", lock_inode_alloc_cont_rate);
-    printf("  \"lock_inode_alloc_wait_ms\": %.3f,\n", lock_inode_alloc_wait_ms);
-    printf("  \"lock_bitmap_acquire\": %" PRIu64 ",\n", st.lock_bitmap_acquire);
-    printf("  \"lock_bitmap_contended\": %" PRIu64 ",\n", st.lock_bitmap_contended);
-    printf("  \"lock_bitmap_wait_ns\": %" PRIu64 ",\n", st.lock_bitmap_wait_ns);
-    printf("  \"lock_bitmap_contended_rate\": %.6f,\n", lock_bitmap_cont_rate);
-    printf("  \"lock_bitmap_wait_ms\": %.3f,\n", lock_bitmap_wait_ms);
-    printf("  \"lock_hrl_bucket_acquire\": %" PRIu64 ",\n", st.lock_hrl_bucket_acquire);
-    printf("  \"lock_hrl_bucket_contended\": %" PRIu64 ",\n", st.lock_hrl_bucket_contended);
-    printf("  \"lock_hrl_bucket_wait_ns\": %" PRIu64 ",\n", st.lock_hrl_bucket_wait_ns);
-    printf("  \"lock_hrl_bucket_contended_rate\": %.6f,\n", lock_hrl_bucket_cont_rate);
-    printf("  \"lock_hrl_bucket_wait_ms\": %.3f,\n", lock_hrl_bucket_wait_ms);
-    printf("  \"lock_hrl_global_acquire\": %" PRIu64 ",\n", st.lock_hrl_global_acquire);
-    printf("  \"lock_hrl_global_contended\": %" PRIu64 ",\n", st.lock_hrl_global_contended);
-    printf("  \"lock_hrl_global_wait_ns\": %" PRIu64 ",\n", st.lock_hrl_global_wait_ns);
-    printf("  \"lock_hrl_global_contended_rate\": %.6f,\n", lock_hrl_global_cont_rate);
-    printf("  \"lock_hrl_global_wait_ms\": %.3f,\n", lock_hrl_global_wait_ms);
-    printf("  \"access_calls\": %" PRIu64 ",\n", st.access_calls);
-    printf("  \"access_path_walk_calls\": %" PRIu64 ",\n", st.access_path_walk_calls);
-    printf("  \"access_fh_fastpath_hits\": %" PRIu64 ",\n", st.access_fh_fastpath_hits);
-    printf("  \"access_path_components\": %" PRIu64 ",\n", st.access_path_components);
-    printf("  \"access_fh_fastpath_rate\": %.6f,\n", access_fh_fastpath_rate);
-    printf("  \"access_avg_components\": %.6f,\n", access_avg_components);
-    printf("  \"dir_snapshot_calls\": %" PRIu64 ",\n", st.dir_snapshot_calls);
-    printf("  \"dir_snapshot_bytes\": %" PRIu64 ",\n", st.dir_snapshot_bytes);
-    printf("  \"dir_snapshot_avg_bytes\": %.3f,\n", dir_snapshot_avg_bytes);
-    printf("  \"dir_snapshot_meta_load_calls\": %" PRIu64 ",\n", st.dir_snapshot_meta_load_calls);
-    printf("  \"dirent_view_next_calls\": %" PRIu64 ",\n", st.dirent_view_next_calls);
-    printf("  \"pwrite_calls\": %" PRIu64 ",\n", st.pwrite_calls);
-    printf("  \"pwrite_bytes\": %" PRIu64 ",\n", st.pwrite_bytes);
-    printf("  \"pwrite_ns_iblk_read\": %" PRIu64 ",\n", st.pwrite_ns_iblk_read);
-    printf("  \"pwrite_ns_iblk_write\": %" PRIu64 ",\n", st.pwrite_ns_iblk_write);
-    printf("  \"pwrite_iblk_write_sample_count\": %" PRIu64 ",\n",
-           st.pwrite_iblk_write_sample_count);
-    printf("  \"pwrite_iblk_write_sample_cap\": %" PRIu64 ",\n", st.pwrite_iblk_write_sample_cap);
-    printf("  \"pwrite_iblk_write_p50_ns\": %" PRIu64 ",\n", st.pwrite_iblk_write_p50_ns);
-    printf("  \"pwrite_iblk_write_p95_ns\": %" PRIu64 ",\n", st.pwrite_iblk_write_p95_ns);
-    printf("  \"pwrite_iblk_write_p99_ns\": %" PRIu64 ",\n", st.pwrite_iblk_write_p99_ns);
-    printf("  \"iblk_write_ns_hrl_put\": %" PRIu64 ",\n", st.iblk_write_ns_hrl_put);
-    printf("  \"iblk_write_ns_legacy_blk_write\": %" PRIu64 ",\n",
-           st.iblk_write_ns_legacy_blk_write);
-    printf("  \"iblk_write_ns_dec_ref\": %" PRIu64 ",\n", st.iblk_write_ns_dec_ref);
-    printf("  \"blk_alloc_calls\": %" PRIu64 ",\n", st.blk_alloc_calls);
-    printf("  \"blk_alloc_claim_retries\": %" PRIu64 ",\n", st.blk_alloc_claim_retries);
-    printf("  \"blk_alloc_ns_scan\": %" PRIu64 ",\n", st.blk_alloc_ns_scan);
-    printf("  \"blk_alloc_ns_claim\": %" PRIu64 ",\n", st.blk_alloc_ns_claim);
-    printf("  \"blk_alloc_ns_set_usage\": %" PRIu64 ",\n", st.blk_alloc_ns_set_usage);
-    printf("  \"blk_set_usage_calls\": %" PRIu64 ",\n", st.blk_set_usage_calls);
-    printf("  \"blk_set_usage_alloc_calls\": %" PRIu64 ",\n", st.blk_set_usage_alloc_calls);
-    printf("  \"blk_set_usage_free_calls\": %" PRIu64 ",\n", st.blk_set_usage_free_calls);
-    printf("  \"blk_set_usage_ns_bit_update\": %" PRIu64 ",\n", st.blk_set_usage_ns_bit_update);
-    printf("  \"blk_set_usage_ns_freecnt_update\": %" PRIu64 ",\n",
-           st.blk_set_usage_ns_freecnt_update);
-    printf("  \"blk_set_usage_ns_wtime_update\": %" PRIu64 ",\n", st.blk_set_usage_ns_wtime_update);
-    printf("  \"copy_share_attempt_blocks\": %" PRIu64 ",\n", st.copy_share_attempt_blocks);
-    printf("  \"copy_share_done_blocks\": %" PRIu64 ",\n", st.copy_share_done_blocks);
-    printf("  \"copy_share_fallback_blocks\": %" PRIu64 ",\n", st.copy_share_fallback_blocks);
-    printf("  \"copy_share_skip_unaligned\": %" PRIu64 ",\n", st.copy_share_skip_unaligned);
-    printf("  \"copy_share_skip_dst_inline\": %" PRIu64 ",\n", st.copy_share_skip_dst_inline);
-    printf("  \"bg_dedup_replacements\": %" PRIu64 ",\n", st.bg_dedup_replacements);
-    printf("  \"bg_dedup_evicts\": %" PRIu64 ",\n", st.bg_dedup_evicts);
-    printf("  \"bg_dedup_retries\": %" PRIu64 ",\n", st.bg_dedup_retries);
-    printf("  \"bg_dedup_steps\": %" PRIu64 ",\n", st.bg_dedup_steps);
-    printf("  \"bg_dedup_scanned_blocks\": %" PRIu64 ",\n", st.bg_dedup_scanned_blocks);
-    printf("  \"bg_dedup_direct_candidates\": %" PRIu64 ",\n", st.bg_dedup_direct_candidates);
-    printf("  \"bg_dedup_direct_hits\": %" PRIu64 ",\n", st.bg_dedup_direct_hits);
-    printf("  \"bg_dedup_direct_hit_rate\": %.6f,\n", bg_dedup_direct_hit_rate);
-    printf("  \"bg_dedup_index_evicts\": %" PRIu64 ",\n", st.bg_dedup_index_evicts);
-    printf("  \"bg_dedup_cooldowns\": %" PRIu64 ",\n", st.bg_dedup_cooldowns);
-    printf("  \"bg_dedup_mode\": %" PRIu32 ",\n", st.bg_dedup_mode);
-    printf("  \"bg_dedup_mode_str\": \"%s\",\n", bg_dedup_mode_str(st.bg_dedup_mode));
-    printf("  \"bg_dedup_telemetry_valid\": %" PRIu32 ",\n", st.bg_dedup_telemetry_valid);
-    printf("  \"bg_dedup_last_scanned_blocks\": %" PRIu64 ",\n", st.bg_dedup_last_scanned_blocks);
-    printf("  \"bg_dedup_last_direct_candidates\": %" PRIu64 ",\n",
-           st.bg_dedup_last_direct_candidates);
-    printf("  \"bg_dedup_last_replacements\": %" PRIu64 ",\n", st.bg_dedup_last_replacements);
-    printf("  \"bg_dedup_idle_skip_streak\": %" PRIu64 ",\n", st.bg_dedup_idle_skip_streak);
-    printf("  \"bg_dedup_cold_start_due_ms\": %" PRIu64 ",\n", st.bg_dedup_cold_start_due_ms);
-    printf("  \"pending_queue_depth\": %" PRIu64 ",\n", st.pending_queue_depth);
-    printf("  \"pending_queue_capacity\": %" PRIu64 ",\n", st.pending_queue_capacity);
-    printf("  \"pending_queue_head\": %" PRIu64 ",\n", st.pending_queue_head);
-    printf("  \"pending_queue_tail\": %" PRIu64 ",\n", st.pending_queue_tail);
-    printf("  \"pending_worker_start_calls\": %" PRIu64 ",\n", st.pending_worker_start_calls);
-    printf("  \"pending_worker_start_failures\": %" PRIu64 ",\n", st.pending_worker_start_failures);
-    printf("  \"pending_worker_start_fail_rate\": %.6f,\n", pending_worker_start_fail_rate);
-    printf("  \"pending_worker_start_last_error\": %" PRId32 ",\n",
-           st.pending_worker_start_last_error);
-    printf("  \"pending_worker_lwp_tid\": %" PRId32 ",\n", st.pending_worker_lwp_tid);
-    printf("  \"pending_worker_running\": %" PRId32 ",\n", st.pending_worker_running);
-    printf("  \"pending_worker_stop_flag\": %" PRId32 ",\n", st.pending_worker_stop_flag);
-    printf("  \"pending_worker_main_entries\": %" PRIu64 ",\n", st.pending_worker_main_entries);
-    printf("  \"pending_worker_main_exits\": %" PRIu64 ",\n", st.pending_worker_main_exits);
-    printf("  \"pending_resolved\": %" PRIu64 ",\n", st.pending_resolved);
-    printf("  \"pending_old_block_freed\": %" PRIu64 ",\n", st.pending_old_block_freed);
-    printf("  \"bg_dedup_retry_rate\": %.6f,\n", bg_dedup_retry_rate);
-    printf("  \"copy_share_hit_rate\": %.6f,\n", copy_share_hit_rate);
-    printf("  \"pwrite_iblk_read_ms\": %.3f,\n", pwrite_iblk_read_ms);
-    printf("  \"pwrite_iblk_write_ms\": %.3f,\n", pwrite_iblk_write_ms);
-    printf("  \"pwrite_iblk_write_p50_ms\": %.3f,\n", pwrite_iblk_write_p50_ms);
-    printf("  \"pwrite_iblk_write_p95_ms\": %.3f,\n", pwrite_iblk_write_p95_ms);
-    printf("  \"pwrite_iblk_write_p99_ms\": %.3f,\n", pwrite_iblk_write_p99_ms);
-    printf("  \"iblk_write_hrl_put_ms\": %.3f,\n", iblk_write_hrl_put_ms);
-    printf("  \"iblk_write_legacy_blk_write_ms\": %.3f,\n", iblk_write_legacy_blk_write_ms);
-    printf("  \"iblk_write_dec_ref_ms\": %.3f,\n", iblk_write_dec_ref_ms);
-    printf("  \"blk_alloc_scan_ms\": %.3f,\n", blk_alloc_scan_ms);
-    printf("  \"blk_alloc_claim_ms\": %.3f,\n", blk_alloc_claim_ms);
-    printf("  \"blk_alloc_set_usage_ms\": %.3f,\n", blk_alloc_set_usage_ms);
-    printf("  \"blk_alloc_retry_rate\": %.6f,\n", blk_alloc_retry_rate);
-    printf("  \"blk_set_usage_bit_ms\": %.3f,\n", blk_set_usage_bit_ms);
-    printf("  \"blk_set_usage_freecnt_ms\": %.3f,\n", blk_set_usage_freecnt_ms);
-    printf("  \"blk_set_usage_wtime_ms\": %.3f\n", blk_set_usage_wtime_ms);
-    printf("}\n");
-    return 0;
-  }
-
-  printf("kafs fsstat v%" PRIu32 "\n", st.version);
-  printf("  mode: %s\n", have_verbose_scan ? "verbose" : "lightweight");
-  if (!have_verbose_scan)
-    printf("  note: tombstone/HRL full scans are skipped by default; rerun with -v for them.\n");
-  printf("  summary.capacity:\n");
-  printf("    fs_blocks: used=");
-  print_bytes(fs_blocks_used * (uint64_t)st.blksize, unit);
-  printf(" / total=");
-  print_bytes(st.fs_blocks_total * (uint64_t)st.blksize, unit);
-  printf(" (%.2f%%)\n", fs_blocks_used_pct);
-  printf("    fs_inodes: used=%" PRIu64 " / total=%" PRIu64 " (%.2f%%)\n", fs_inodes_used,
-         st.fs_inodes_total, fs_inodes_used_pct);
-  if (have_verbose_scan)
-  {
-    printf("    hrl_entries: used=%" PRIu64 " / total=%" PRIu64 " (%.2f%%)\n", st.hrl_entries_used,
-           st.hrl_entries_total, hrl_entries_used_pct);
-  }
-  else
-  {
-    printf("    hrl_entries: total=%" PRIu64 " (used count requires -v)\n", st.hrl_entries_total);
-  }
-
-  printf("  summary.ratios:\n");
-  if (have_verbose_scan)
-    printf("    dedup_ratio: %.3f (logical/unique)\n", dedup_ratio);
-  else
-    printf("    dedup_ratio: unavailable without -v\n");
-  printf("    write_path: hrl=%.2f%% legacy_direct=%.2f%% (hrl_calls=%" PRIu64
-         " fallback_legacy=%" PRIu64 ")\n",
-         hrl_path_rate, legacy_path_rate, st.hrl_put_calls, st.hrl_put_fallback_legacy);
-  printf("    direct_to_hrl: %.6f (legacy_direct/hrl_calls)\n", direct_to_hrl_ratio);
-  printf("    hrl_hit_miss: hit=%.2f%% miss=%.2f%%\n", hrl_hit_rate_pct, hrl_miss_rate_pct);
-  printf("    copy_share_hit: %.2f%% (done/attempt)\n", copy_share_hit_rate * 100.0);
-
-  printf("  blksize: ");
-  print_bytes(st.blksize, unit);
-  printf("\n");
-
-  printf("  fs: blocks total=%" PRIu64 " (", st.fs_blocks_total);
-  print_bytes(st.fs_blocks_total * (uint64_t)st.blksize, unit);
-  printf(") free=%" PRIu64 " (", st.fs_blocks_free);
-  print_bytes(st.fs_blocks_free * (uint64_t)st.blksize, unit);
-  printf(")\n");
-  printf("      inodes total=%" PRIu64 " free=%" PRIu64 "\n", st.fs_inodes_total,
-         st.fs_inodes_free);
-  if (!have_verbose_scan)
-  {
-    printf("      tombstones: omitted without -v\n");
-  }
-  else if (st.tombstone_inodes > 0)
-  {
-    printf("      tombstones count=%" PRIu64 " oldest_dtime=%s (%" PRIu64 ".%09" PRIu64 ")\n",
-           st.tombstone_inodes, tombstone_oldest_buf, st.tombstone_oldest_dtime_sec,
-           st.tombstone_oldest_dtime_nsec);
-  }
-  else
-  {
-    printf("      tombstones count=0 oldest_dtime=none\n");
-  }
-
-  if (have_verbose_scan)
-  {
-    printf("  hrl: entries used=%" PRIu64 "/%" PRIu64 " duplicated=%" PRIu64 " refsum=%" PRIu64
-           "\n",
-           st.hrl_entries_used, st.hrl_entries_total, st.hrl_entries_duplicated, st.hrl_refcnt_sum);
-
-    printf("  dedup: logical=");
-    print_bytes(logical_bytes, unit);
-    printf(" unique=");
-    print_bytes(unique_bytes, unit);
-    printf(" saved=");
-    print_bytes(saved_bytes, unit);
-    printf(" ratio=%.3f\n", dedup_ratio);
-  }
-  else
-  {
-    printf("  hrl: total entries=%" PRIu64 " (used/dup/refsum require -v)\n", st.hrl_entries_total);
-    printf("  dedup: unavailable without -v\n");
-  }
-
-  printf("  hrl_put: calls=%" PRIu64 " hits=%" PRIu64 " misses=%" PRIu64 " fallback_legacy=%" PRIu64
-         " hit_rate=%.3f\n",
-         st.hrl_put_calls, st.hrl_put_hits, st.hrl_put_misses, st.hrl_put_fallback_legacy,
-         hit_rate);
-  printf("  hrl_rescue: attempts=%" PRIu64 " hits=%" PRIu64 " evicts=%" PRIu64 " hit_rate=%.3f\n",
-         st.hrl_rescue_attempts, st.hrl_rescue_hits, st.hrl_rescue_evicts, hrl_rescue_hit_rate);
-  printf("  hrl_put_decomp: hash_ms=%.3f find_ms=%.3f cmp_ms=%.3f slot_alloc_ms=%.3f "
-         "blk_alloc_ms=%.3f blk_write_ms=%.3f avg_chain_steps=%.3f avg_cmp_calls=%.3f\n",
-         hrl_put_hash_ms, hrl_put_find_ms, hrl_put_cmp_ms, hrl_put_slot_alloc_ms,
-         hrl_put_blk_alloc_ms, hrl_put_blk_write_ms, hrl_put_avg_chain_steps,
-         hrl_put_avg_cmp_calls);
-  printf("  lock[inode]: acquire=%" PRIu64 " contended=%" PRIu64 " rate=%.3f wait_ms=%.3f\n",
-         st.lock_inode_acquire, st.lock_inode_contended, lock_inode_cont_rate, lock_inode_wait_ms);
-  printf("  lock[inode_alloc]: acquire=%" PRIu64 " contended=%" PRIu64 " rate=%.3f wait_ms=%.3f\n",
-         st.lock_inode_alloc_acquire, st.lock_inode_alloc_contended, lock_inode_alloc_cont_rate,
-         lock_inode_alloc_wait_ms);
-  printf("  lock[bitmap]: acquire=%" PRIu64 " contended=%" PRIu64 " rate=%.3f wait_ms=%.3f\n",
-         st.lock_bitmap_acquire, st.lock_bitmap_contended, lock_bitmap_cont_rate,
-         lock_bitmap_wait_ms);
-  printf("  lock[hrl_bucket]: acquire=%" PRIu64 " contended=%" PRIu64 " rate=%.3f wait_ms=%.3f\n",
-         st.lock_hrl_bucket_acquire, st.lock_hrl_bucket_contended, lock_hrl_bucket_cont_rate,
-         lock_hrl_bucket_wait_ms);
-  printf("  lock[hrl_global]: acquire=%" PRIu64 " contended=%" PRIu64 " rate=%.3f wait_ms=%.3f\n",
-         st.lock_hrl_global_acquire, st.lock_hrl_global_contended, lock_hrl_global_cont_rate,
-         lock_hrl_global_wait_ms);
-  printf("  metadata_lookup: access_calls=%" PRIu64 " path_walk_calls=%" PRIu64
-         " fh_fastpath_hits=%" PRIu64 " fh_fastpath_rate=%.3f avg_components=%.3f\n",
-         st.access_calls, st.access_path_walk_calls, st.access_fh_fastpath_hits,
-         access_fh_fastpath_rate, access_avg_components);
-  printf("                   dir_snapshot_calls=%" PRIu64 " snapshot_bytes=%" PRIu64
-         " avg_snapshot_bytes=%.3f meta_load_calls=%" PRIu64 " view_next_calls=%" PRIu64 "\n",
-         st.dir_snapshot_calls, st.dir_snapshot_bytes, dir_snapshot_avg_bytes,
-         st.dir_snapshot_meta_load_calls, st.dirent_view_next_calls);
-  printf("  pwrite: calls=%" PRIu64 " bytes=%" PRIu64 " iblk_read_ms=%.3f iblk_write_ms=%.3f\n",
-         st.pwrite_calls, st.pwrite_bytes, pwrite_iblk_read_ms, pwrite_iblk_write_ms);
-  printf("          iblk_write_lat: samples=%" PRIu64 "/%" PRIu64
-         " p50_ms=%.3f p95_ms=%.3f p99_ms=%.3f\n",
-         st.pwrite_iblk_write_sample_count, st.pwrite_iblk_write_sample_cap,
-         pwrite_iblk_write_p50_ms, pwrite_iblk_write_p95_ms, pwrite_iblk_write_p99_ms);
-  printf("  iblk_write: hrl_put_ms=%.3f legacy_blk_write_ms=%.3f dec_ref_ms=%.3f\n",
-         iblk_write_hrl_put_ms, iblk_write_legacy_blk_write_ms, iblk_write_dec_ref_ms);
-  printf("  blk_alloc: calls=%" PRIu64 " retries=%" PRIu64 " retry_rate=%.3f scan_ms=%.3f "
-         "claim_ms=%.3f set_usage_ms=%.3f\n",
-         st.blk_alloc_calls, st.blk_alloc_claim_retries, blk_alloc_retry_rate, blk_alloc_scan_ms,
-         blk_alloc_claim_ms, blk_alloc_set_usage_ms);
-  printf("  blk_set_usage: calls=%" PRIu64 " alloc_calls=%" PRIu64 " free_calls=%" PRIu64
-         " bit_ms=%.3f freecnt_ms=%.3f wtime_ms=%.3f\n",
-         st.blk_set_usage_calls, st.blk_set_usage_alloc_calls, st.blk_set_usage_free_calls,
-         blk_set_usage_bit_ms, blk_set_usage_freecnt_ms, blk_set_usage_wtime_ms);
-  printf("  copy_share: attempt_blocks=%" PRIu64 " done_blocks=%" PRIu64 " fallback_blocks=%" PRIu64
-         " skip_unaligned=%" PRIu64 " skip_dst_inline=%" PRIu64 " hit_rate=%.3f\n",
-         st.copy_share_attempt_blocks, st.copy_share_done_blocks, st.copy_share_fallback_blocks,
-         st.copy_share_skip_unaligned, st.copy_share_skip_dst_inline, copy_share_hit_rate);
-  printf("  bg_dedup: replacements=%" PRIu64 " evicts=%" PRIu64 " retries=%" PRIu64
-         " retry_rate=%.3f\n",
-         st.bg_dedup_replacements, st.bg_dedup_evicts, st.bg_dedup_retries, bg_dedup_retry_rate);
-  printf("            steps=%" PRIu64 " scanned_blocks=%" PRIu64 " direct_candidates=%" PRIu64
-         " direct_hits=%" PRIu64 " direct_hit_rate=%.3f index_evicts=%" PRIu64 " cooldowns=%" PRIu64
-         "\n",
-         st.bg_dedup_steps, st.bg_dedup_scanned_blocks, st.bg_dedup_direct_candidates,
-         st.bg_dedup_direct_hits, bg_dedup_direct_hit_rate, st.bg_dedup_index_evicts,
-         st.bg_dedup_cooldowns);
-  printf("            mode=%" PRIu32 " (%s) telemetry_valid=%" PRIu32 " last_scanned=%" PRIu64
-         " last_direct_candidates=%" PRIu64 " last_replacements=%" PRIu64
-         " idle_skip_streak=%" PRIu64 " cold_due_ms=%" PRIu64 "\n",
-         st.bg_dedup_mode, bg_dedup_mode_str(st.bg_dedup_mode), st.bg_dedup_telemetry_valid,
-         st.bg_dedup_last_scanned_blocks, st.bg_dedup_last_direct_candidates,
-         st.bg_dedup_last_replacements, st.bg_dedup_idle_skip_streak,
-         st.bg_dedup_cold_start_due_ms);
-  printf("  pending: depth=%" PRIu64 "/%" PRIu64 " head=%" PRIu64 " tail=%" PRIu64 "\n",
-         st.pending_queue_depth, st.pending_queue_capacity, st.pending_queue_head,
-         st.pending_queue_tail);
-  printf("           worker running=%" PRId32 " stop=%" PRId32 " start_calls=%" PRIu64
-         " start_failures=%" PRIu64 " fail_rate=%.3f last_error=%" PRId32 " lwp_tid=%" PRId32 "\n",
-         st.pending_worker_running, st.pending_worker_stop_flag, st.pending_worker_start_calls,
-         st.pending_worker_start_failures, pending_worker_start_fail_rate,
-         st.pending_worker_start_last_error, st.pending_worker_lwp_tid);
-  printf("           worker_main entries=%" PRIu64 " exits=%" PRIu64 "\n",
-         st.pending_worker_main_entries, st.pending_worker_main_exits);
-  printf("           pending_resolved=%" PRIu64 " old_block_freed=%" PRIu64 "\n",
-         st.pending_resolved, st.pending_old_block_freed);
-  return 0;
+    return kafsctl_stats_print_json(&report);
+  return kafsctl_stats_print_text(&report, unit);
 }
 
 static void fmt_time(char out[64], const struct timespec *ts)

--- a/src/kafsctl.c
+++ b/src/kafsctl.c
@@ -1618,6 +1618,74 @@ static int find_kafs_mount_root(const char *dir_path, char mount[KAFS_IOCTL_PATH
   return 0;
 }
 
+static const char *skip_leading_slashes(const char *path)
+{
+  while (*path == '/')
+    ++path;
+  return path;
+}
+
+static int resolve_auto_path_build_abs(const char *existing, const char *suffix,
+                                       char resolved_abs[KAFS_IOCTL_PATH_MAX])
+{
+  const char *rel_suffix = suffix ? skip_leading_slashes(suffix) : "";
+  if (*rel_suffix == '\0')
+  {
+    if (snprintf(resolved_abs, KAFS_IOCTL_PATH_MAX, "%s", existing) >= KAFS_IOCTL_PATH_MAX)
+      return -ENAMETOOLONG;
+    return 0;
+  }
+  return path_join_components(resolved_abs, existing, rel_suffix);
+}
+
+static int resolve_auto_path_existing_dir(const char *existing, int existing_is_dir,
+                                          char existing_dir[KAFS_IOCTL_PATH_MAX])
+{
+  if (snprintf(existing_dir, KAFS_IOCTL_PATH_MAX, "%s", existing) >= KAFS_IOCTL_PATH_MAX)
+    return -ENAMETOOLONG;
+  if (existing_is_dir)
+    return 0;
+
+  char *slash = strrchr(existing_dir, '/');
+  if (!slash)
+    return -EINVAL;
+  if (slash == existing_dir)
+    slash[1] = '\0';
+  else
+    *slash = '\0';
+  return 0;
+}
+
+static int resolve_auto_path_rel_to_mount(const char *mount, const char *resolved_abs,
+                                          const char **rel_out)
+{
+  size_t mount_len = strlen(mount);
+  if (strncmp(resolved_abs, mount, mount_len) != 0 ||
+      (resolved_abs[mount_len] != '\0' && resolved_abs[mount_len] != '/'))
+    return -EINVAL;
+
+  *rel_out = skip_leading_slashes(resolved_abs + mount_len);
+  return 0;
+}
+
+static int resolve_auto_path_fill_ref(kafs_path_ref_t *out, const char *mount,
+                                      const char *resolved_abs, const char *rel)
+{
+  out->dfd = open(mount, O_RDONLY | O_DIRECTORY);
+  if (out->dfd < 0)
+    return -errno;
+  if (snprintf(out->mount, sizeof(out->mount), "%s", mount) >= (int)sizeof(out->mount) ||
+      snprintf(out->abs_path, sizeof(out->abs_path), "%s", resolved_abs) >=
+          (int)sizeof(out->abs_path) ||
+      snprintf(out->rel, sizeof(out->rel), "%s", (*rel != '\0') ? rel : ".") >=
+          (int)sizeof(out->rel))
+  {
+    close_path_ref(out);
+    return -ENAMETOOLONG;
+  }
+  return 0;
+}
+
 static int resolve_auto_path(const char *path, kafs_path_ref_t *out)
 {
   char normalized[KAFS_IOCTL_PATH_MAX];
@@ -1633,67 +1701,26 @@ static int resolve_auto_path(const char *path, kafs_path_ref_t *out)
     return rc;
 
   char resolved_abs[KAFS_IOCTL_PATH_MAX];
-  if (!suffix || *suffix == '\0')
-  {
-    if (snprintf(resolved_abs, sizeof(resolved_abs), "%s", existing) >= (int)sizeof(resolved_abs))
-      return -ENAMETOOLONG;
-  }
-  else
-  {
-    const char *rel_suffix = suffix;
-    while (*rel_suffix == '/')
-      ++rel_suffix;
-    rc = path_join_components(resolved_abs, existing, rel_suffix);
-    if (rc != 0)
-      return rc;
-  }
+  rc = resolve_auto_path_build_abs(existing, suffix, resolved_abs);
+  if (rc != 0)
+    return rc;
 
   char existing_dir[KAFS_IOCTL_PATH_MAX];
-  if (existing_is_dir)
-  {
-    if (snprintf(existing_dir, sizeof(existing_dir), "%s", existing) >= (int)sizeof(existing_dir))
-      return -ENAMETOOLONG;
-  }
-  else
-  {
-    if (snprintf(existing_dir, sizeof(existing_dir), "%s", existing) >= (int)sizeof(existing_dir))
-      return -ENAMETOOLONG;
-    char *slash = strrchr(existing_dir, '/');
-    if (!slash)
-      return -EINVAL;
-    if (slash == existing_dir)
-      slash[1] = '\0';
-    else
-      *slash = '\0';
-  }
+  rc = resolve_auto_path_existing_dir(existing, existing_is_dir, existing_dir);
+  if (rc != 0)
+    return rc;
 
   char mount[KAFS_IOCTL_PATH_MAX];
   rc = find_kafs_mount_root(existing_dir, mount);
   if (rc != 0)
     return rc;
 
-  size_t mount_len = strlen(mount);
-  if (strncmp(resolved_abs, mount, mount_len) != 0 ||
-      (resolved_abs[mount_len] != '\0' && resolved_abs[mount_len] != '/'))
-    return -EINVAL;
+  const char *rel = NULL;
+  rc = resolve_auto_path_rel_to_mount(mount, resolved_abs, &rel);
+  if (rc != 0)
+    return rc;
 
-  const char *rel = resolved_abs + mount_len;
-  while (*rel == '/')
-    ++rel;
-
-  out->dfd = open(mount, O_RDONLY | O_DIRECTORY);
-  if (out->dfd < 0)
-    return -errno;
-  if (snprintf(out->mount, sizeof(out->mount), "%s", mount) >= (int)sizeof(out->mount) ||
-      snprintf(out->abs_path, sizeof(out->abs_path), "%s", resolved_abs) >=
-          (int)sizeof(out->abs_path) ||
-      snprintf(out->rel, sizeof(out->rel), "%s", (*rel != '\0') ? rel : ".") >=
-          (int)sizeof(out->rel))
-  {
-    close_path_ref(out);
-    return -ENAMETOOLONG;
-  }
-  return 0;
+  return resolve_auto_path_fill_ref(out, mount, resolved_abs, rel);
 }
 
 static int resolve_mount_path(const char *mnt, const char *path, kafs_path_ref_t *out)

--- a/src/kafsctl.c
+++ b/src/kafsctl.c
@@ -2,7 +2,6 @@
 #include "kafs_cli_opts.h"
 #include "kafs_core.h"
 #include "kafs_rpc.h"
-#include "kafs_superblock.h"
 
 #include <errno.h>
 #include <inttypes.h>
@@ -645,6 +644,205 @@ static int cmd_hotplug_set_runtime(const char *mnt, int argc, char **argv)
     return 1;
   }
   return 0;
+}
+
+static int cmd_hotplug_status(const char *mnt, int json);
+static int cmd_hotplug_restart(const char *mnt);
+static int cmd_hotplug_compat(const char *mnt, int json);
+static int cmd_hotplug_set_timeout(const char *mnt, const char *timeout_str);
+static int cmd_hotplug_set_dedup_priority(const char *mnt, const char *mode_str,
+                                          const char *nice_str);
+static int cmd_hotplug_env_list(const char *mnt);
+static int cmd_hotplug_env_set(const char *mnt, const char *kv);
+static int cmd_hotplug_env_unset(const char *mnt, const char *key);
+static int cmd_stats(const char *mnt, int json, int verbose, kafs_unit_t unit);
+static int cmd_chmod(const char *mnt, const char *mode_str, const char *path);
+
+typedef int (*kafsctl_path_cmd_fn)(const char *mountpoint, const char *path);
+
+static int kafsctl_dispatch_path_cmd(int argc, char **argv, kafsctl_path_cmd_fn fn)
+{
+  if (argc == 3)
+    return fn(NULL, argv[2]);
+  if (argc != 4)
+  {
+    usage(argv[0]);
+    return 2;
+  }
+  return fn(argv[2], argv[3]);
+}
+
+static int kafsctl_dispatch_chmod_cmd(int argc, char **argv)
+{
+  if (argc == 4)
+    return cmd_chmod(NULL, argv[2], argv[3]);
+  if (argc != 5)
+  {
+    usage(argv[0]);
+    return 2;
+  }
+  return cmd_chmod(argv[2], argv[3], argv[4]);
+}
+
+static int kafsctl_handle_migrate_command(int argc, char **argv)
+{
+  int assume_yes = 0;
+  for (int i = 3; i < argc; ++i)
+  {
+    if (strcmp(argv[i], "--yes") == 0)
+      assume_yes = 1;
+    else
+    {
+      usage(argv[0]);
+      return 2;
+    }
+  }
+  return cmd_migrate(argv[2], assume_yes);
+}
+
+static int kafsctl_handle_fsstat_command(int argc, char **argv)
+{
+  int json = 0;
+  int verbose = 0;
+  kafs_unit_t unit = KAFS_UNIT_KIB;
+
+  for (int i = 3; i < argc; ++i)
+  {
+    if (strcmp(argv[i], "--json") == 0)
+      json = 1;
+    else if (strcmp(argv[i], "-v") == 0 || strcmp(argv[i], "--verbose") == 0)
+      verbose = 1;
+    else if (strcmp(argv[i], "--bytes") == 0)
+      unit = KAFS_UNIT_BYTES;
+    else if (strcmp(argv[i], "--mib") == 0)
+      unit = KAFS_UNIT_MIB;
+    else if (strcmp(argv[i], "--gib") == 0)
+      unit = KAFS_UNIT_GIB;
+    else
+    {
+      usage(argv[0]);
+      return 2;
+    }
+  }
+
+  return cmd_stats(argv[2], json, verbose, unit);
+}
+
+static int kafsctl_handle_hotplug_env_command(int argc, char **argv)
+{
+  if (argc < 5)
+  {
+    usage(argv[0]);
+    return 2;
+  }
+  if (strcmp(argv[3], "list") == 0)
+  {
+    if (argc != 5)
+    {
+      usage(argv[0]);
+      return 2;
+    }
+    return cmd_hotplug_env_list(argv[4]);
+  }
+  if (strcmp(argv[3], "set") == 0)
+  {
+    if (argc != 6)
+    {
+      usage(argv[0]);
+      return 2;
+    }
+    return cmd_hotplug_env_set(argv[4], argv[5]);
+  }
+  if (strcmp(argv[3], "unset") == 0)
+  {
+    if (argc != 6)
+    {
+      usage(argv[0]);
+      return 2;
+    }
+    return cmd_hotplug_env_unset(argv[4], argv[5]);
+  }
+  usage(argv[0]);
+  return 2;
+}
+
+static int kafsctl_parse_json_flag_args(int argc, char **argv, int start_index, int *json_out)
+{
+  for (int i = start_index; i < argc; ++i)
+  {
+    if (strcmp(argv[i], "--json") == 0)
+      *json_out = 1;
+    else
+    {
+      usage(argv[0]);
+      return 2;
+    }
+  }
+  return 0;
+}
+
+static int kafsctl_handle_hotplug_command(int argc, char **argv)
+{
+  if (argc < 4)
+  {
+    usage(argv[0]);
+    return 2;
+  }
+  if (strcmp(argv[2], "status") == 0)
+  {
+    int json = 0;
+    if (kafsctl_parse_json_flag_args(argc, argv, 4, &json) != 0)
+      return 2;
+    return cmd_hotplug_status(argv[3], json);
+  }
+  if (strcmp(argv[2], "restart-back") == 0)
+  {
+    if (argc != 4)
+    {
+      usage(argv[0]);
+      return 2;
+    }
+    return cmd_hotplug_restart(argv[3]);
+  }
+  if (strcmp(argv[2], "compat") == 0)
+  {
+    int json = 0;
+    if (kafsctl_parse_json_flag_args(argc, argv, 4, &json) != 0)
+      return 2;
+    return cmd_hotplug_compat(argv[3], json);
+  }
+  if (strcmp(argv[2], "set-timeout") == 0)
+  {
+    if (argc != 5)
+    {
+      usage(argv[0]);
+      return 2;
+    }
+    return cmd_hotplug_set_timeout(argv[3], argv[4]);
+  }
+  if (strcmp(argv[2], "set-dedup-priority") == 0)
+  {
+    if (argc != 5 && argc != 6)
+    {
+      usage(argv[0]);
+      return 2;
+    }
+    return cmd_hotplug_set_dedup_priority(argv[3], argv[4], argc == 6 ? argv[5] : NULL);
+  }
+  if (strcmp(argv[2], "set-runtime") == 0)
+  {
+    if (argc < 5)
+    {
+      usage(argv[0]);
+      return 2;
+    }
+    return cmd_hotplug_set_runtime(argv[3], argc - 4, &argv[4]);
+  }
+  if (strcmp(argv[2], "env") == 0)
+    return kafsctl_handle_hotplug_env_command(argc, argv);
+
+  usage(argv[0]);
+  return 2;
 }
 
 #define KAFS_CTL_REL ".kafs.sock"
@@ -3213,196 +3411,22 @@ int main(int argc, char **argv)
   }
 
   if (strcmp(argv[1], "migrate") == 0)
-  {
-    int assume_yes = 0;
-    for (int i = 3; i < argc; ++i)
-    {
-      if (strcmp(argv[i], "--yes") == 0)
-        assume_yes = 1;
-      else
-      {
-        usage(argv[0]);
-        return 2;
-      }
-    }
-    return cmd_migrate(argv[2], assume_yes);
-  }
+    return kafsctl_handle_migrate_command(argc, argv);
 
   if (strcmp(argv[1], "fsstat") == 0 || strcmp(argv[1], "stats") == 0)
-  {
-    int json = 0;
-    int verbose = 0;
-    kafs_unit_t unit = KAFS_UNIT_KIB;
-    for (int i = 3; i < argc; ++i)
-    {
-      if (strcmp(argv[i], "--json") == 0)
-        json = 1;
-      else if (strcmp(argv[i], "-v") == 0 || strcmp(argv[i], "--verbose") == 0)
-        verbose = 1;
-      else if (strcmp(argv[i], "--bytes") == 0)
-        unit = KAFS_UNIT_BYTES;
-      else if (strcmp(argv[i], "--mib") == 0)
-        unit = KAFS_UNIT_MIB;
-      else if (strcmp(argv[i], "--gib") == 0)
-        unit = KAFS_UNIT_GIB;
-      else
-      {
-        usage(argv[0]);
-        return 2;
-      }
-    }
-    return cmd_stats(argv[2], json, verbose, unit);
-  }
+    return kafsctl_handle_fsstat_command(argc, argv);
 
   if (strcmp(argv[1], "hotplug") == 0)
-  {
-    if (argc < 4)
-    {
-      usage(argv[0]);
-      return 2;
-    }
-    if (strcmp(argv[2], "status") == 0)
-    {
-      int json = 0;
-      for (int i = 4; i < argc; ++i)
-      {
-        if (strcmp(argv[i], "--json") == 0)
-          json = 1;
-        else
-        {
-          usage(argv[0]);
-          return 2;
-        }
-      }
-      return cmd_hotplug_status(argv[3], json);
-    }
-    if (strcmp(argv[2], "restart-back") == 0)
-    {
-      if (argc != 4)
-      {
-        usage(argv[0]);
-        return 2;
-      }
-      return cmd_hotplug_restart(argv[3]);
-    }
-    if (strcmp(argv[2], "compat") == 0)
-    {
-      int json = 0;
-      for (int i = 4; i < argc; ++i)
-      {
-        if (strcmp(argv[i], "--json") == 0)
-          json = 1;
-        else
-        {
-          usage(argv[0]);
-          return 2;
-        }
-      }
-      return cmd_hotplug_compat(argv[3], json);
-    }
-    if (strcmp(argv[2], "set-timeout") == 0)
-    {
-      if (argc != 5)
-      {
-        usage(argv[0]);
-        return 2;
-      }
-      return cmd_hotplug_set_timeout(argv[3], argv[4]);
-    }
-    if (strcmp(argv[2], "set-dedup-priority") == 0)
-    {
-      if (argc != 5 && argc != 6)
-      {
-        usage(argv[0]);
-        return 2;
-      }
-      return cmd_hotplug_set_dedup_priority(argv[3], argv[4], argc == 6 ? argv[5] : NULL);
-    }
-    if (strcmp(argv[2], "set-runtime") == 0)
-    {
-      if (argc < 5)
-      {
-        usage(argv[0]);
-        return 2;
-      }
-      return cmd_hotplug_set_runtime(argv[3], argc - 4, &argv[4]);
-    }
-    if (strcmp(argv[2], "env") == 0)
-    {
-      if (argc < 5)
-      {
-        usage(argv[0]);
-        return 2;
-      }
-      if (strcmp(argv[3], "list") == 0)
-      {
-        if (argc != 5)
-        {
-          usage(argv[0]);
-          return 2;
-        }
-        return cmd_hotplug_env_list(argv[4]);
-      }
-      if (strcmp(argv[3], "set") == 0)
-      {
-        if (argc != 6)
-        {
-          usage(argv[0]);
-          return 2;
-        }
-        return cmd_hotplug_env_set(argv[4], argv[5]);
-      }
-      if (strcmp(argv[3], "unset") == 0)
-      {
-        if (argc != 6)
-        {
-          usage(argv[0]);
-          return 2;
-        }
-        return cmd_hotplug_env_unset(argv[4], argv[5]);
-      }
-      usage(argv[0]);
-      return 2;
-    }
-    usage(argv[0]);
-    return 2;
-  }
+    return kafsctl_handle_hotplug_command(argc, argv);
 
   if (strcmp(argv[1], "stat") == 0)
-  {
-    if (argc == 3)
-      return cmd_stat(NULL, argv[2]);
-    if (argc != 4)
-    {
-      usage(argv[0]);
-      return 2;
-    }
-    return cmd_stat(argv[2], argv[3]);
-  }
+    return kafsctl_dispatch_path_cmd(argc, argv, cmd_stat);
 
   if (strcmp(argv[1], "cat") == 0)
-  {
-    if (argc == 3)
-      return cmd_cat(NULL, argv[2]);
-    if (argc != 4)
-    {
-      usage(argv[0]);
-      return 2;
-    }
-    return cmd_cat(argv[2], argv[3]);
-  }
+    return kafsctl_dispatch_path_cmd(argc, argv, cmd_cat);
 
   if (strcmp(argv[1], "write") == 0)
-  {
-    if (argc == 3)
-      return cmd_write(NULL, argv[2]);
-    if (argc != 4)
-    {
-      usage(argv[0]);
-      return 2;
-    }
-    return cmd_write(argv[2], argv[3]);
-  }
+    return kafsctl_dispatch_path_cmd(argc, argv, cmd_write);
 
   if (strcmp(argv[1], "cp") == 0)
   {
@@ -3442,40 +3466,13 @@ int main(int argc, char **argv)
   }
 
   if (strcmp(argv[1], "rm") == 0)
-  {
-    if (argc == 3)
-      return cmd_rm(NULL, argv[2]);
-    if (argc != 4)
-    {
-      usage(argv[0]);
-      return 2;
-    }
-    return cmd_rm(argv[2], argv[3]);
-  }
+    return kafsctl_dispatch_path_cmd(argc, argv, cmd_rm);
 
   if (strcmp(argv[1], "mkdir") == 0)
-  {
-    if (argc == 3)
-      return cmd_mkdir(NULL, argv[2]);
-    if (argc != 4)
-    {
-      usage(argv[0]);
-      return 2;
-    }
-    return cmd_mkdir(argv[2], argv[3]);
-  }
+    return kafsctl_dispatch_path_cmd(argc, argv, cmd_mkdir);
 
   if (strcmp(argv[1], "rmdir") == 0)
-  {
-    if (argc == 3)
-      return cmd_rmdir(NULL, argv[2]);
-    if (argc != 4)
-    {
-      usage(argv[0]);
-      return 2;
-    }
-    return cmd_rmdir(argv[2], argv[3]);
-  }
+    return kafsctl_dispatch_path_cmd(argc, argv, cmd_rmdir);
 
   if (strcmp(argv[1], "ln") == 0)
     return cmd_ln_dispatch(argc, argv);
@@ -3503,40 +3500,13 @@ int main(int argc, char **argv)
   }
 
   if (strcmp(argv[1], "readlink") == 0)
-  {
-    if (argc == 3)
-      return cmd_readlink(NULL, argv[2]);
-    if (argc != 4)
-    {
-      usage(argv[0]);
-      return 2;
-    }
-    return cmd_readlink(argv[2], argv[3]);
-  }
+    return kafsctl_dispatch_path_cmd(argc, argv, cmd_readlink);
 
   if (strcmp(argv[1], "chmod") == 0)
-  {
-    if (argc == 4)
-      return cmd_chmod(NULL, argv[2], argv[3]);
-    if (argc != 5)
-    {
-      usage(argv[0]);
-      return 2;
-    }
-    return cmd_chmod(argv[2], argv[3], argv[4]);
-  }
+    return kafsctl_dispatch_chmod_cmd(argc, argv);
 
   if (strcmp(argv[1], "touch") == 0)
-  {
-    if (argc == 3)
-      return cmd_touch(NULL, argv[2]);
-    if (argc != 4)
-    {
-      usage(argv[0]);
-      return 2;
-    }
-    return cmd_touch(argv[2], argv[3]);
-  }
+    return kafsctl_dispatch_path_cmd(argc, argv, cmd_touch);
 
   usage(argv[0]);
   return 2;

--- a/src/kafsctl.c
+++ b/src/kafsctl.c
@@ -1415,25 +1415,75 @@ static int path_join_components(char out[KAFS_IOCTL_PATH_MAX], const char *base,
   return 0;
 }
 
+static int normalize_path_raw_input(const char *input, char raw[KAFS_IOCTL_PATH_MAX])
+{
+  if (input[0] == '/')
+  {
+    if (snprintf(raw, KAFS_IOCTL_PATH_MAX, "%s", input) >= KAFS_IOCTL_PATH_MAX)
+      return -ENAMETOOLONG;
+    return 0;
+  }
+
+  char cwd[KAFS_IOCTL_PATH_MAX];
+  if (!getcwd(cwd, sizeof(cwd)))
+    return -errno;
+  if (snprintf(raw, KAFS_IOCTL_PATH_MAX, "%s/%s", cwd, input) >= KAFS_IOCTL_PATH_MAX)
+    return -ENAMETOOLONG;
+  return 0;
+}
+
+static void normalize_path_pop_component(char normalized[KAFS_IOCTL_PATH_MAX], size_t *norm_len)
+{
+  if (*norm_len <= 1)
+    return;
+
+  if (normalized[*norm_len - 1] == '/')
+    --(*norm_len);
+  while (*norm_len > 1 && normalized[*norm_len - 1] != '/')
+    --(*norm_len);
+  normalized[*norm_len] = '\0';
+}
+
+static int normalize_path_append_component(char normalized[KAFS_IOCTL_PATH_MAX], size_t *norm_len,
+                                           const char *start, size_t len)
+{
+  if (*norm_len > 1)
+  {
+    if (*norm_len + 1 >= KAFS_IOCTL_PATH_MAX)
+      return -ENAMETOOLONG;
+    normalized[(*norm_len)++] = '/';
+  }
+  if (*norm_len + len >= KAFS_IOCTL_PATH_MAX)
+    return -ENAMETOOLONG;
+
+  memcpy(normalized + *norm_len, start, len);
+  *norm_len += len;
+  normalized[*norm_len] = '\0';
+  return 0;
+}
+
+static int normalize_path_handle_segment(char normalized[KAFS_IOCTL_PATH_MAX], size_t *norm_len,
+                                         const char *start, size_t len)
+{
+  if (len == 1 && start[0] == '.')
+    return 0;
+  if (len == 2 && start[0] == '.' && start[1] == '.')
+  {
+    normalize_path_pop_component(normalized, norm_len);
+    return 0;
+  }
+  return normalize_path_append_component(normalized, norm_len, start, len);
+}
+
 static int normalize_path_input(const char *input, char out[KAFS_IOCTL_PATH_MAX])
 {
   if (!input || !*input)
     return -EINVAL;
 
   char raw[KAFS_IOCTL_PATH_MAX];
-  if (input[0] == '/')
-  {
-    if (snprintf(raw, sizeof(raw), "%s", input) >= (int)sizeof(raw))
-      return -ENAMETOOLONG;
-  }
-  else
-  {
-    char cwd[KAFS_IOCTL_PATH_MAX];
-    if (!getcwd(cwd, sizeof(cwd)))
-      return -errno;
-    if (snprintf(raw, sizeof(raw), "%s/%s", cwd, input) >= (int)sizeof(raw))
-      return -ENAMETOOLONG;
-  }
+  int rc = normalize_path_raw_input(input, raw);
+  if (rc != 0)
+    return rc;
 
   char normalized[KAFS_IOCTL_PATH_MAX];
   size_t norm_len = 1;
@@ -1452,32 +1502,9 @@ static int normalize_path_input(const char *input, char out[KAFS_IOCTL_PATH_MAX]
     while (*cursor && *cursor != '/')
       ++cursor;
     size_t len = (size_t)(cursor - start);
-    if (len == 1 && start[0] == '.')
-      continue;
-    if (len == 2 && start[0] == '.' && start[1] == '.')
-    {
-      if (norm_len > 1)
-      {
-        if (normalized[norm_len - 1] == '/')
-          --norm_len;
-        while (norm_len > 1 && normalized[norm_len - 1] != '/')
-          --norm_len;
-        normalized[norm_len] = '\0';
-      }
-      continue;
-    }
-
-    if (norm_len > 1)
-    {
-      if (norm_len + 1 >= sizeof(normalized))
-        return -ENAMETOOLONG;
-      normalized[norm_len++] = '/';
-    }
-    if (norm_len + len >= sizeof(normalized))
-      return -ENAMETOOLONG;
-    memcpy(normalized + norm_len, start, len);
-    norm_len += len;
-    normalized[norm_len] = '\0';
+    rc = normalize_path_handle_segment(normalized, &norm_len, start, len);
+    if (rc != 0)
+      return rc;
   }
 
   if (snprintf(out, KAFS_IOCTL_PATH_MAX, "%s", normalized) >= KAFS_IOCTL_PATH_MAX)

--- a/src/kafsctl.c
+++ b/src/kafsctl.c
@@ -256,6 +256,113 @@ static void usage_chmod_cmd(const char *prog)
   usage_cmd(prog, "chmod <octal_mode> <path>\n       chmod <mountpoint> <octal_mode> <path>", NULL);
 }
 
+static void usage_primary_cmd(const char *prog, const char *cmd)
+{
+  if (strcmp(cmd, "migrate") == 0)
+    usage_migrate_cmd(prog);
+  else if (strcmp(cmd, "fsstat") == 0 || strcmp(cmd, "stats") == 0)
+    usage_fsstat_cmd(prog);
+  else if (strcmp(cmd, "hotplug") == 0)
+    usage_hotplug_cmd(prog);
+  else if (strcmp(cmd, "stat") == 0)
+    usage_single_path_cmd(prog, "stat");
+  else if (strcmp(cmd, "cat") == 0)
+    usage_single_path_cmd(prog, "cat");
+  else if (strcmp(cmd, "write") == 0)
+    usage_single_path_cmd(prog, "write");
+  else if (strcmp(cmd, "cp") == 0)
+    usage_cp_cmd(prog);
+  else if (strcmp(cmd, "mv") == 0)
+    usage_mv_cmd(prog);
+  else if (strcmp(cmd, "rm") == 0)
+    usage_single_path_cmd(prog, "rm");
+  else if (strcmp(cmd, "mkdir") == 0)
+    usage_single_path_cmd(prog, "mkdir");
+  else if (strcmp(cmd, "rmdir") == 0)
+    usage_single_path_cmd(prog, "rmdir");
+  else if (strcmp(cmd, "ln") == 0)
+    usage_ln_cmd(prog);
+  else if (strcmp(cmd, "symlink") == 0)
+    usage_symlink_cmd(prog);
+  else if (strcmp(cmd, "rsync") == 0)
+    usage_rsync_cmd(prog);
+  else if (strcmp(cmd, "readlink") == 0)
+    usage_single_path_cmd(prog, "readlink");
+  else if (strcmp(cmd, "chmod") == 0)
+    usage_chmod_cmd(prog);
+  else if (strcmp(cmd, "touch") == 0)
+    usage_single_path_cmd(prog, "touch");
+  else
+    usage(prog);
+}
+
+static void usage_hotplug_subcommand(const char *prog, const char *cmd)
+{
+  if (strcmp(cmd, "status") == 0)
+    usage_hotplug_status_cmd(prog);
+  else if (strcmp(cmd, "restart-back") == 0)
+    usage_hotplug_restart_cmd(prog);
+  else if (strcmp(cmd, "compat") == 0)
+    usage_hotplug_compat_cmd(prog);
+  else if (strcmp(cmd, "set-timeout") == 0)
+    usage_hotplug_timeout_cmd(prog);
+  else if (strcmp(cmd, "set-dedup-priority") == 0)
+    usage_hotplug_dedup_priority_cmd(prog);
+  else if (strcmp(cmd, "set-runtime") == 0)
+    usage_hotplug_set_runtime_cmd(prog);
+  else if (strcmp(cmd, "env") == 0)
+    usage_hotplug_env_cmd(prog);
+  else
+    usage_hotplug_cmd(prog);
+}
+
+static void usage_hotplug_env_subcommand(const char *prog, const char *cmd)
+{
+  if (strcmp(cmd, "list") == 0)
+    usage_hotplug_env_list_cmd(prog);
+  else if (strcmp(cmd, "set") == 0)
+    usage_hotplug_env_set_cmd(prog);
+  else if (strcmp(cmd, "unset") == 0)
+    usage_hotplug_env_unset_cmd(prog);
+  else
+    usage_hotplug_env_cmd(prog);
+}
+
+static void usage_help_target(const char *prog, int argc, char **argv)
+{
+  if (argc == 2)
+  {
+    usage(prog);
+    return;
+  }
+
+  if (strcmp(argv[2], "hotplug") != 0)
+  {
+    usage_primary_cmd(prog, argv[2]);
+    return;
+  }
+
+  if (argc == 3)
+  {
+    usage_hotplug_cmd(prog);
+    return;
+  }
+
+  if (strcmp(argv[3], "env") != 0)
+  {
+    usage_hotplug_subcommand(prog, argv[3]);
+    return;
+  }
+
+  if (argc == 4)
+  {
+    usage_hotplug_env_cmd(prog);
+    return;
+  }
+
+  usage_hotplug_env_subcommand(prog, argv[4]);
+}
+
 static int try_subcommand_help(int argc, char **argv)
 {
   if (argc < 2)
@@ -269,235 +376,26 @@ static int try_subcommand_help(int argc, char **argv)
 
   if (strcmp(argv[1], "help") == 0)
   {
-    if (argc == 2)
-    {
-      usage(argv[0]);
-      return 0;
-    }
-    if (argc >= 3)
-    {
-      if (strcmp(argv[2], "migrate") == 0)
-      {
-        usage_migrate_cmd(argv[0]);
-        return 0;
-      }
-      if (strcmp(argv[2], "fsstat") == 0 || strcmp(argv[2], "stats") == 0)
-      {
-        usage_fsstat_cmd(argv[0]);
-        return 0;
-      }
-      if (strcmp(argv[2], "hotplug") == 0)
-      {
-        if (argc == 3)
-        {
-          usage_hotplug_cmd(argv[0]);
-          return 0;
-        }
-        if (strcmp(argv[3], "status") == 0)
-        {
-          usage_hotplug_status_cmd(argv[0]);
-          return 0;
-        }
-        if (strcmp(argv[3], "restart-back") == 0)
-        {
-          usage_hotplug_restart_cmd(argv[0]);
-          return 0;
-        }
-        if (strcmp(argv[3], "compat") == 0)
-        {
-          usage_hotplug_compat_cmd(argv[0]);
-          return 0;
-        }
-        if (strcmp(argv[3], "set-timeout") == 0)
-        {
-          usage_hotplug_timeout_cmd(argv[0]);
-          return 0;
-        }
-        if (strcmp(argv[3], "set-dedup-priority") == 0)
-        {
-          usage_hotplug_dedup_priority_cmd(argv[0]);
-          return 0;
-        }
-        if (strcmp(argv[3], "set-runtime") == 0)
-        {
-          usage_hotplug_set_runtime_cmd(argv[0]);
-          return 0;
-        }
-        if (strcmp(argv[3], "env") == 0)
-        {
-          if (argc == 4)
-          {
-            usage_hotplug_env_cmd(argv[0]);
-            return 0;
-          }
-          if (strcmp(argv[4], "list") == 0)
-          {
-            usage_hotplug_env_list_cmd(argv[0]);
-            return 0;
-          }
-          if (strcmp(argv[4], "set") == 0)
-          {
-            usage_hotplug_env_set_cmd(argv[0]);
-            return 0;
-          }
-          if (strcmp(argv[4], "unset") == 0)
-          {
-            usage_hotplug_env_unset_cmd(argv[0]);
-            return 0;
-          }
-        }
-        usage_hotplug_cmd(argv[0]);
-        return 0;
-      }
-      if (strcmp(argv[2], "stat") == 0)
-      {
-        usage_single_path_cmd(argv[0], "stat");
-        return 0;
-      }
-      if (strcmp(argv[2], "cat") == 0)
-      {
-        usage_single_path_cmd(argv[0], "cat");
-        return 0;
-      }
-      if (strcmp(argv[2], "write") == 0)
-      {
-        usage_single_path_cmd(argv[0], "write");
-        return 0;
-      }
-      if (strcmp(argv[2], "cp") == 0)
-      {
-        usage_cp_cmd(argv[0]);
-        return 0;
-      }
-      if (strcmp(argv[2], "mv") == 0)
-      {
-        usage_mv_cmd(argv[0]);
-        return 0;
-      }
-      if (strcmp(argv[2], "rm") == 0)
-      {
-        usage_single_path_cmd(argv[0], "rm");
-        return 0;
-      }
-      if (strcmp(argv[2], "mkdir") == 0)
-      {
-        usage_single_path_cmd(argv[0], "mkdir");
-        return 0;
-      }
-      if (strcmp(argv[2], "rmdir") == 0)
-      {
-        usage_single_path_cmd(argv[0], "rmdir");
-        return 0;
-      }
-      if (strcmp(argv[2], "ln") == 0)
-      {
-        usage_ln_cmd(argv[0]);
-        return 0;
-      }
-      if (strcmp(argv[2], "symlink") == 0)
-      {
-        usage_symlink_cmd(argv[0]);
-        return 0;
-      }
-      if (strcmp(argv[2], "rsync") == 0)
-      {
-        usage_rsync_cmd(argv[0]);
-        return 0;
-      }
-      if (strcmp(argv[2], "readlink") == 0)
-      {
-        usage_single_path_cmd(argv[0], "readlink");
-        return 0;
-      }
-      if (strcmp(argv[2], "chmod") == 0)
-      {
-        usage_chmod_cmd(argv[0]);
-        return 0;
-      }
-      if (strcmp(argv[2], "touch") == 0)
-      {
-        usage_single_path_cmd(argv[0], "touch");
-        return 0;
-      }
-    }
-
-    usage(argv[0]);
+    usage_help_target(argv[0], argc, argv);
     return 0;
   }
 
   if (argc >= 3 && kafs_cli_is_help_arg(argv[2]))
   {
-    if (strcmp(argv[1], "migrate") == 0)
-      usage_migrate_cmd(argv[0]);
-    else if (strcmp(argv[1], "fsstat") == 0 || strcmp(argv[1], "stats") == 0)
-      usage_fsstat_cmd(argv[0]);
-    else if (strcmp(argv[1], "hotplug") == 0)
-      usage_hotplug_cmd(argv[0]);
-    else if (strcmp(argv[1], "stat") == 0)
-      usage_single_path_cmd(argv[0], "stat");
-    else if (strcmp(argv[1], "cat") == 0)
-      usage_single_path_cmd(argv[0], "cat");
-    else if (strcmp(argv[1], "write") == 0)
-      usage_single_path_cmd(argv[0], "write");
-    else if (strcmp(argv[1], "cp") == 0)
-      usage_cp_cmd(argv[0]);
-    else if (strcmp(argv[1], "mv") == 0)
-      usage_mv_cmd(argv[0]);
-    else if (strcmp(argv[1], "rm") == 0)
-      usage_single_path_cmd(argv[0], "rm");
-    else if (strcmp(argv[1], "mkdir") == 0)
-      usage_single_path_cmd(argv[0], "mkdir");
-    else if (strcmp(argv[1], "rmdir") == 0)
-      usage_single_path_cmd(argv[0], "rmdir");
-    else if (strcmp(argv[1], "ln") == 0)
-      usage_ln_cmd(argv[0]);
-    else if (strcmp(argv[1], "symlink") == 0)
-      usage_symlink_cmd(argv[0]);
-    else if (strcmp(argv[1], "rsync") == 0)
-      usage_rsync_cmd(argv[0]);
-    else if (strcmp(argv[1], "readlink") == 0)
-      usage_single_path_cmd(argv[0], "readlink");
-    else if (strcmp(argv[1], "chmod") == 0)
-      usage_chmod_cmd(argv[0]);
-    else if (strcmp(argv[1], "touch") == 0)
-      usage_single_path_cmd(argv[0], "touch");
-    else
-      usage(argv[0]);
+    usage_primary_cmd(argv[0], argv[1]);
     return 0;
   }
 
   if (argc >= 4 && strcmp(argv[1], "hotplug") == 0 && kafs_cli_is_help_arg(argv[3]))
   {
-    if (strcmp(argv[2], "status") == 0)
-      usage_hotplug_status_cmd(argv[0]);
-    else if (strcmp(argv[2], "restart-back") == 0)
-      usage_hotplug_restart_cmd(argv[0]);
-    else if (strcmp(argv[2], "compat") == 0)
-      usage_hotplug_compat_cmd(argv[0]);
-    else if (strcmp(argv[2], "set-timeout") == 0)
-      usage_hotplug_timeout_cmd(argv[0]);
-    else if (strcmp(argv[2], "set-dedup-priority") == 0)
-      usage_hotplug_dedup_priority_cmd(argv[0]);
-    else if (strcmp(argv[2], "set-runtime") == 0)
-      usage_hotplug_set_runtime_cmd(argv[0]);
-    else if (strcmp(argv[2], "env") == 0)
-      usage_hotplug_env_cmd(argv[0]);
-    else
-      usage_hotplug_cmd(argv[0]);
+    usage_hotplug_subcommand(argv[0], argv[2]);
     return 0;
   }
 
   if (argc >= 5 && strcmp(argv[1], "hotplug") == 0 && strcmp(argv[2], "env") == 0 &&
       kafs_cli_is_help_arg(argv[4]))
   {
-    if (strcmp(argv[3], "list") == 0)
-      usage_hotplug_env_list_cmd(argv[0]);
-    else if (strcmp(argv[3], "set") == 0)
-      usage_hotplug_env_set_cmd(argv[0]);
-    else if (strcmp(argv[3], "unset") == 0)
-      usage_hotplug_env_unset_cmd(argv[0]);
-    else
-      usage_hotplug_env_cmd(argv[0]);
+    usage_hotplug_env_subcommand(argv[0], argv[3]);
     return 0;
   }
 

--- a/src/kafsctl.c
+++ b/src/kafsctl.c
@@ -255,7 +255,7 @@ static void usage_chmod_cmd(const char *prog)
   usage_cmd(prog, "chmod <octal_mode> <path>\n       chmod <mountpoint> <octal_mode> <path>", NULL);
 }
 
-static void usage_primary_cmd(const char *prog, const char *cmd)
+static int usage_primary_direct_cmd(const char *prog, const char *cmd)
 {
   if (strcmp(cmd, "migrate") == 0)
     usage_migrate_cmd(prog);
@@ -263,35 +263,43 @@ static void usage_primary_cmd(const char *prog, const char *cmd)
     usage_fsstat_cmd(prog);
   else if (strcmp(cmd, "hotplug") == 0)
     usage_hotplug_cmd(prog);
-  else if (strcmp(cmd, "stat") == 0)
-    usage_single_path_cmd(prog, "stat");
-  else if (strcmp(cmd, "cat") == 0)
-    usage_single_path_cmd(prog, "cat");
-  else if (strcmp(cmd, "write") == 0)
-    usage_single_path_cmd(prog, "write");
   else if (strcmp(cmd, "cp") == 0)
     usage_cp_cmd(prog);
   else if (strcmp(cmd, "mv") == 0)
     usage_mv_cmd(prog);
-  else if (strcmp(cmd, "rm") == 0)
-    usage_single_path_cmd(prog, "rm");
-  else if (strcmp(cmd, "mkdir") == 0)
-    usage_single_path_cmd(prog, "mkdir");
-  else if (strcmp(cmd, "rmdir") == 0)
-    usage_single_path_cmd(prog, "rmdir");
   else if (strcmp(cmd, "ln") == 0)
     usage_ln_cmd(prog);
   else if (strcmp(cmd, "symlink") == 0)
     usage_symlink_cmd(prog);
   else if (strcmp(cmd, "rsync") == 0)
     usage_rsync_cmd(prog);
-  else if (strcmp(cmd, "readlink") == 0)
-    usage_single_path_cmd(prog, "readlink");
   else if (strcmp(cmd, "chmod") == 0)
     usage_chmod_cmd(prog);
-  else if (strcmp(cmd, "touch") == 0)
-    usage_single_path_cmd(prog, "touch");
   else
+    return 0;
+
+  return 1;
+}
+
+static int usage_primary_single_path(const char *prog, const char *cmd)
+{
+  static const char *const names[] = {"stat",  "cat",   "write",    "rm",
+                                      "mkdir", "rmdir", "readlink", "touch"};
+  for (size_t index = 0; index < sizeof(names) / sizeof(names[0]); ++index)
+  {
+    if (strcmp(cmd, names[index]) == 0)
+    {
+      usage_single_path_cmd(prog, names[index]);
+      return 1;
+    }
+  }
+
+  return 0;
+}
+
+static void usage_primary_cmd(const char *prog, const char *cmd)
+{
+  if (!usage_primary_direct_cmd(prog, cmd) && !usage_primary_single_path(prog, cmd))
     usage(prog);
 }
 

--- a/src/kafsctl.c
+++ b/src/kafsctl.c
@@ -3397,23 +3397,110 @@ static int parse_ln_options(int argc, char **argv, kafs_ln_opts_t *opts, int *op
   return 0;
 }
 
-static int cmd_ln_dispatch(int argc, char **argv)
+static int cmd_ln_dispatch_parse(int argc, char **argv, kafs_ln_opts_t *opts, int *operand_index)
 {
-  kafs_ln_opts_t opts;
-  int operand_index = 0;
-  int parse_rc = parse_ln_options(argc, argv, &opts, &operand_index);
+  int parse_rc = parse_ln_options(argc, argv, opts, operand_index);
   if (parse_rc == 1)
   {
     usage_ln_cmd(argv[0]);
     return 0;
   }
   if (parse_rc != 0)
-  {
     usage_ln_cmd(argv[0]);
-    return parse_rc;
+  return parse_rc;
+}
+
+static int cmd_ln_dispatch_target_dir(int argc, char **argv, int operand_index,
+                                      const kafs_ln_opts_t *opts, const char **mnt_out,
+                                      const char **src_out, const char **dst_out,
+                                      char dst_buf[KAFS_IOCTL_PATH_MAX])
+{
+  int remaining = argc - operand_index;
+  if (remaining == 1)
+  {
+    *src_out = argv[operand_index];
+  }
+  else if (remaining == 2)
+  {
+    *mnt_out = argv[operand_index];
+    *src_out = argv[operand_index + 1];
+  }
+  else
+  {
+    return 2;
   }
 
+  if (build_link_path(dst_buf, opts->target_dir, *src_out) != 0)
+  {
+    fprintf(stderr, "invalid target directory or source name\n");
+    return 2;
+  }
+
+  *dst_out = dst_buf;
+  return 0;
+}
+
+static int cmd_ln_dispatch_direct(int argc, char **argv, int operand_index, const char **mnt_out,
+                                  const char **src_out, const char **dst_out)
+{
   int remaining = argc - operand_index;
+  if (remaining == 2)
+  {
+    *src_out = argv[operand_index];
+    *dst_out = argv[operand_index + 1];
+    return 0;
+  }
+  if (remaining == 3)
+  {
+    *mnt_out = argv[operand_index];
+    *src_out = argv[operand_index + 1];
+    *dst_out = argv[operand_index + 2];
+    return 0;
+  }
+  return 2;
+}
+
+static int cmd_ln_dispatch_dir_destination(const char *mnt, const char *src, const char **dst_inout,
+                                           const kafs_ln_opts_t *opts,
+                                           char dst_buf[KAFS_IOCTL_PATH_MAX])
+{
+  if (opts->no_target_directory)
+    return 0;
+
+  int is_dir = path_ref_is_directory(mnt, *dst_inout, opts->no_deref);
+  if (is_dir != 0 && is_dir != 1)
+    return is_dir;
+  if (is_dir == 0)
+    return 0;
+
+  if (build_link_path(dst_buf, *dst_inout, src) != 0)
+  {
+    fprintf(stderr, "invalid destination path\n");
+    return 2;
+  }
+
+  *dst_inout = dst_buf;
+  return 0;
+}
+
+static int cmd_ln_dispatch_exec(const char *mnt, const char *src, const char *dst,
+                                const kafs_ln_opts_t *opts)
+{
+  if (opts->symbolic)
+    return mnt ? cmd_symlink_with_opts(mnt, src, dst, opts)
+               : cmd_symlink_auto_with_opts(src, dst, opts);
+
+  return mnt ? cmd_ln_with_opts(mnt, src, dst, opts) : cmd_ln_auto_with_opts(src, dst, opts);
+}
+
+static int cmd_ln_dispatch(int argc, char **argv)
+{
+  kafs_ln_opts_t opts;
+  int operand_index = 0;
+  int parse_rc = cmd_ln_dispatch_parse(argc, argv, &opts, &operand_index);
+  if (parse_rc != 0)
+    return parse_rc;
+
   const char *mnt = NULL;
   const char *src = NULL;
   const char *dst = NULL;
@@ -3421,69 +3508,29 @@ static int cmd_ln_dispatch(int argc, char **argv)
 
   if (opts.target_dir)
   {
-    if (remaining == 1)
-    {
-      src = argv[operand_index];
-    }
-    else if (remaining == 2)
-    {
-      mnt = argv[operand_index];
-      src = argv[operand_index + 1];
-    }
-    else
+    int rc =
+        cmd_ln_dispatch_target_dir(argc, argv, operand_index, &opts, &mnt, &src, &dst, dst_buf);
+    if (rc != 0)
     {
       usage_ln_cmd(argv[0]);
-      return 2;
+      return rc;
     }
-
-    if (build_link_path(dst_buf, opts.target_dir, src) != 0)
-    {
-      fprintf(stderr, "invalid target directory or source name\n");
-      return 2;
-    }
-    dst = dst_buf;
   }
   else
   {
-    if (remaining == 2)
-    {
-      src = argv[operand_index];
-      dst = argv[operand_index + 1];
-    }
-    else if (remaining == 3)
-    {
-      mnt = argv[operand_index];
-      src = argv[operand_index + 1];
-      dst = argv[operand_index + 2];
-    }
-    else
+    int rc = cmd_ln_dispatch_direct(argc, argv, operand_index, &mnt, &src, &dst);
+    if (rc != 0)
     {
       usage_ln_cmd(argv[0]);
-      return 2;
+      return rc;
     }
 
-    if (!opts.no_target_directory)
-    {
-      int is_dir = path_ref_is_directory(mnt, dst, opts.no_deref);
-      if (is_dir != 0 && is_dir != 1)
-        return is_dir;
-      if (is_dir > 0)
-      {
-        if (build_link_path(dst_buf, dst, src) != 0)
-        {
-          fprintf(stderr, "invalid destination path\n");
-          return 2;
-        }
-        dst = dst_buf;
-      }
-    }
+    rc = cmd_ln_dispatch_dir_destination(mnt, src, &dst, &opts, dst_buf);
+    if (rc != 0)
+      return rc;
   }
 
-  if (opts.symbolic)
-    return mnt ? cmd_symlink_with_opts(mnt, src, dst, &opts)
-               : cmd_symlink_auto_with_opts(src, dst, &opts);
-
-  return mnt ? cmd_ln_with_opts(mnt, src, dst, &opts) : cmd_ln_auto_with_opts(src, dst, &opts);
+  return cmd_ln_dispatch_exec(mnt, src, dst, &opts);
 }
 
 static int cmd_readlink(const char *mnt, const char *path)

--- a/src/kafsresize.c
+++ b/src/kafsresize.c
@@ -493,158 +493,228 @@ static int cmd_migrate_create(const char *dst_image, uint64_t size_bytes, uint32
   return 0;
 }
 
-int main(int argc, char **argv)
+typedef struct kafsresize_options
 {
-  int do_grow = 0;
-  int do_migrate_create = 0;
-  int assume_yes = 0;
-  int force = 0;
-  uint64_t target_bytes = 0;
-  uint32_t format_version = 0;
-  uint64_t journal_bytes = 0;
-  int blksize_log = 0;
-  double hrl_entry_ratio = 0.0;
-  uint32_t inodes = 0;
-  const char *image = NULL;
-  const char *dst_image = NULL;
-  const char *src_mount = NULL;
-  const char *dst_mount = NULL;
+  int do_grow;
+  int do_migrate_create;
+  int assume_yes;
+  int force;
+  uint64_t target_bytes;
+  uint32_t format_version;
+  uint64_t journal_bytes;
+  int blksize_log;
+  double hrl_entry_ratio;
+  uint32_t inodes;
+  const char *image;
+  const char *dst_image;
+  const char *src_mount;
+  const char *dst_mount;
+} kafsresize_options_t;
 
-  if (kafs_cli_exit_if_help(argc, argv, usage, argv[0]) == 0)
-    return 0;
+static int kafsresize_parse_u32_arg(const char *name, const char *value, uint32_t *out)
+{
+  unsigned long long parsed = strtoull(value, NULL, 0);
+  if (parsed == 0 || parsed > UINT32_MAX)
+  {
+    fprintf(stderr, "invalid %s: %s\n", name, value);
+    return 2;
+  }
+  *out = (uint32_t)parsed;
+  return 0;
+}
 
+static int kafsresize_parse_flag_arg(const char *arg, kafsresize_options_t *opts)
+{
+  if (strcmp(arg, "--grow") == 0)
+  {
+    opts->do_grow = 1;
+    return 1;
+  }
+  if (strcmp(arg, "--migrate-create") == 0)
+  {
+    opts->do_migrate_create = 1;
+    return 1;
+  }
+  if (strcmp(arg, "--yes") == 0)
+  {
+    opts->assume_yes = 1;
+    return 1;
+  }
+  if (strcmp(arg, "--force") == 0)
+  {
+    opts->force = 1;
+    return 1;
+  }
+  return 0;
+}
+
+static int kafsresize_parse_size_value_arg(int argc, char **argv, int *index,
+                                           kafsresize_options_t *opts)
+{
+  const char *arg = argv[*index];
+  if (strcmp(arg, "--size-bytes") == 0 && *index + 1 < argc)
+  {
+    if (kafs_parse_size_bytes_u64(argv[++(*index)], &opts->target_bytes) != 0)
+    {
+      fprintf(stderr, "invalid size-bytes: %s\n", argv[*index]);
+      return 2;
+    }
+    return 1;
+  }
+  if (strcmp(arg, "--journal-size-bytes") == 0 && *index + 1 < argc)
+  {
+    if (kafs_parse_size_bytes_u64(argv[++(*index)], &opts->journal_bytes) != 0)
+    {
+      fprintf(stderr, "invalid journal-size-bytes: %s\n", argv[*index]);
+      return 2;
+    }
+    return 1;
+  }
+  return 0;
+}
+
+static int kafsresize_parse_setting_value_arg(int argc, char **argv, int *index,
+                                              kafsresize_options_t *opts)
+{
+  const char *arg = argv[*index];
+  if (strcmp(arg, "--format-version") == 0 && *index + 1 < argc)
+  {
+    if (kafsresize_parse_u32_arg("format-version", argv[++(*index)], &opts->format_version) != 0)
+      return 2;
+    return 1;
+  }
+  if (strcmp(arg, "--blksize-log") == 0 && *index + 1 < argc)
+  {
+    opts->blksize_log = atoi(argv[++(*index)]);
+    if (opts->blksize_log <= 0)
+    {
+      fprintf(stderr, "invalid blksize-log: %s\n", argv[*index]);
+      return 2;
+    }
+    return 1;
+  }
+  if (strcmp(arg, "--hrl-entry-ratio") == 0 && *index + 1 < argc)
+  {
+    if (kafs_parse_ratio_0_to_1(argv[++(*index)], &opts->hrl_entry_ratio) != 0)
+    {
+      fprintf(stderr, "invalid hrl-entry-ratio (expected 0<R<=1): %s\n", argv[*index]);
+      return 2;
+    }
+    return 1;
+  }
+  if (strcmp(arg, "--inodes") == 0 && *index + 1 < argc)
+  {
+    if (kafsresize_parse_u32_arg("inodes", argv[++(*index)], &opts->inodes) != 0)
+      return 2;
+    return 1;
+  }
+  return 0;
+}
+
+static int kafsresize_parse_path_value_arg(int argc, char **argv, int *index,
+                                           kafsresize_options_t *opts)
+{
+  const char *arg = argv[*index];
+  if (strcmp(arg, "--dst-image") == 0 && *index + 1 < argc)
+  {
+    opts->dst_image = argv[++(*index)];
+    return 1;
+  }
+  if (strcmp(arg, "--src-mount") == 0 && *index + 1 < argc)
+  {
+    opts->src_mount = argv[++(*index)];
+    return 1;
+  }
+  if (strcmp(arg, "--dst-mount") == 0 && *index + 1 < argc)
+  {
+    opts->dst_mount = argv[++(*index)];
+    return 1;
+  }
+  return 0;
+}
+
+static int kafsresize_parse_value_arg(int argc, char **argv, int *index, kafsresize_options_t *opts)
+{
+  int rc = kafsresize_parse_size_value_arg(argc, argv, index, opts);
+  if (rc != 0)
+    return rc;
+
+  rc = kafsresize_parse_setting_value_arg(argc, argv, index, opts);
+  if (rc != 0)
+    return rc;
+
+  return kafsresize_parse_path_value_arg(argc, argv, index, opts);
+}
+
+static int kafsresize_parse_args(int argc, char **argv, kafsresize_options_t *opts)
+{
   for (int i = 1; i < argc; ++i)
   {
-    if (strcmp(argv[i], "--grow") == 0)
-    {
-      do_grow = 1;
+    const char *arg = argv[i];
+    if (kafsresize_parse_flag_arg(arg, opts) != 0)
       continue;
-    }
-    if (strcmp(argv[i], "--migrate-create") == 0)
-    {
-      do_migrate_create = 1;
+
+    int rc = kafsresize_parse_value_arg(argc, argv, &i, opts);
+    if (rc == 2)
+      return 2;
+    if (rc == 1)
       continue;
-    }
-    if (strcmp(argv[i], "--size-bytes") == 0 && i + 1 < argc)
-    {
-      if (kafs_parse_size_bytes_u64(argv[++i], &target_bytes) != 0)
-      {
-        fprintf(stderr, "invalid size-bytes: %s\n", argv[i]);
-        return 2;
-      }
-      continue;
-    }
-    if (strcmp(argv[i], "--journal-size-bytes") == 0 && i + 1 < argc)
-    {
-      if (kafs_parse_size_bytes_u64(argv[++i], &journal_bytes) != 0)
-      {
-        fprintf(stderr, "invalid journal-size-bytes: %s\n", argv[i]);
-        return 2;
-      }
-      continue;
-    }
-    if (strcmp(argv[i], "--format-version") == 0 && i + 1 < argc)
-    {
-      unsigned long long v = strtoull(argv[++i], NULL, 0);
-      if (v == 0 || v > UINT32_MAX)
-      {
-        fprintf(stderr, "invalid format-version: %s\n", argv[i]);
-        return 2;
-      }
-      format_version = (uint32_t)v;
-      continue;
-    }
-    if (strcmp(argv[i], "--blksize-log") == 0 && i + 1 < argc)
-    {
-      blksize_log = atoi(argv[++i]);
-      if (blksize_log <= 0)
-      {
-        fprintf(stderr, "invalid blksize-log: %s\n", argv[i]);
-        return 2;
-      }
-      continue;
-    }
-    if (strcmp(argv[i], "--hrl-entry-ratio") == 0 && i + 1 < argc)
-    {
-      if (kafs_parse_ratio_0_to_1(argv[++i], &hrl_entry_ratio) != 0)
-      {
-        fprintf(stderr, "invalid hrl-entry-ratio (expected 0<R<=1): %s\n", argv[i]);
-        return 2;
-      }
-      continue;
-    }
-    if (strcmp(argv[i], "--inodes") == 0 && i + 1 < argc)
-    {
-      unsigned long long v = strtoull(argv[++i], NULL, 0);
-      if (v == 0 || v > UINT32_MAX)
-      {
-        fprintf(stderr, "invalid inodes: %s\n", argv[i]);
-        return 2;
-      }
-      inodes = (uint32_t)v;
-      continue;
-    }
-    if (strcmp(argv[i], "--dst-image") == 0 && i + 1 < argc)
-    {
-      dst_image = argv[++i];
-      continue;
-    }
-    if (strcmp(argv[i], "--src-mount") == 0 && i + 1 < argc)
-    {
-      src_mount = argv[++i];
-      continue;
-    }
-    if (strcmp(argv[i], "--dst-mount") == 0 && i + 1 < argc)
-    {
-      dst_mount = argv[++i];
-      continue;
-    }
-    if (strcmp(argv[i], "--yes") == 0)
-    {
-      assume_yes = 1;
-      continue;
-    }
-    if (strcmp(argv[i], "--force") == 0)
-    {
-      force = 1;
-      continue;
-    }
-    if (argv[i][0] == '-')
+
+    if (arg[0] == '-')
     {
       usage(argv[0]);
       return 2;
     }
-    image = argv[i];
+    opts->image = arg;
   }
 
-  if (do_grow && do_migrate_create)
+  return 0;
+}
+
+static int kafsresize_run(const char *prog, const kafsresize_options_t *opts)
+{
+  if (opts->do_grow && opts->do_migrate_create)
   {
     fprintf(stderr, "--grow and --migrate-create are mutually exclusive\n");
     return 2;
   }
 
-  if (do_grow)
+  if (opts->do_grow)
   {
-    if (target_bytes == 0 || !image)
+    if (opts->target_bytes == 0 || !opts->image)
     {
-      usage(argv[0]);
+      usage(prog);
       return 2;
     }
-    return cmd_grow(image, target_bytes);
+    return cmd_grow(opts->image, opts->target_bytes);
   }
 
-  if (do_migrate_create)
+  if (opts->do_migrate_create)
   {
-    if (inodes == 0 || !dst_image)
+    if (opts->inodes == 0 || !opts->dst_image)
     {
-      usage(argv[0]);
+      usage(prog);
       return 2;
     }
-    return cmd_migrate_create(dst_image, target_bytes, inodes, format_version, journal_bytes,
-                              blksize_log, hrl_entry_ratio, src_mount, dst_mount, assume_yes,
-                              force);
+    return cmd_migrate_create(opts->dst_image, opts->target_bytes, opts->inodes,
+                              opts->format_version, opts->journal_bytes, opts->blksize_log,
+                              opts->hrl_entry_ratio, opts->src_mount, opts->dst_mount,
+                              opts->assume_yes, opts->force);
   }
 
-  usage(argv[0]);
+  usage(prog);
   return 2;
+}
+
+int main(int argc, char **argv)
+{
+  kafsresize_options_t opts = {0};
+
+  if (kafs_cli_exit_if_help(argc, argv, usage, argv[0]) == 0)
+    return 0;
+
+  if (kafsresize_parse_args(argc, argv, &opts) != 0)
+    return 2;
+
+  return kafsresize_run(argv[0], &opts);
 }

--- a/src/mkfs_kafs.c
+++ b/src/mkfs_kafs.c
@@ -436,6 +436,124 @@ static int mkfs_collect_args(int argc, char **argv, mkfs_options_t *opts)
   return 0;
 }
 
+static int mkfs_open_target(kafs_context_t *ctx, const char *img, struct stat *st, int *have_stat)
+{
+  *have_stat = (stat(img, st) == 0);
+  if (!*have_stat && errno != ENOENT)
+  {
+    perror("stat");
+    return 1;
+  }
+
+  memset(ctx, 0, sizeof(*ctx));
+  ctx->c_fd = open(img, O_RDWR | (*have_stat ? 0 : O_CREAT), 0666);
+  if (ctx->c_fd < 0)
+  {
+    perror("open");
+    return 1;
+  }
+  ctx->c_blo_search = 0;
+  ctx->c_ino_search = 0;
+
+  if (fstat(ctx->c_fd, st) != 0)
+  {
+    perror("fstat");
+    close(ctx->c_fd);
+    return 1;
+  }
+  return 0;
+}
+
+static int mkfs_resolve_total_bytes(kafs_context_t *ctx, const struct stat *st,
+                                    int size_arg_provided, off_t *total_bytes)
+{
+  if (S_ISREG(st->st_mode) && st->st_size > 0)
+  {
+    if (size_arg_provided)
+      fprintf(stderr, "warning: size overridden by existing file size\n");
+    *total_bytes = st->st_size;
+    return 0;
+  }
+  if (!S_ISBLK(st->st_mode))
+    return 0;
+
+#ifdef __linux__
+  uint64_t dev_bytes = 0;
+  if (ioctl(ctx->c_fd, BLKGETSIZE64, &dev_bytes) != 0)
+  {
+    perror("ioctl(BLKGETSIZE64)");
+    close(ctx->c_fd);
+    return 1;
+  }
+  if (dev_bytes == 0)
+  {
+    fprintf(stderr, "invalid block device size: 0\n");
+    close(ctx->c_fd);
+    return 1;
+  }
+  if (size_arg_provided)
+    fprintf(stderr, "warning: size overridden by block device size\n");
+  *total_bytes = (off_t)dev_bytes;
+  return 0;
+#else
+  fprintf(stderr, "block devices are not supported on this platform\n");
+  close(ctx->c_fd);
+  return 1;
+#endif
+}
+
+static int mkfs_prepare_target(kafs_context_t *ctx, const char *img, uint32_t format_version,
+                               kafs_logblksize_t log_blksize, kafs_blksize_t blksizemask,
+                               kafs_blksize_t blksize, kafs_inocnt_t *inocnt,
+                               int inocnt_arg_provided, size_t journal_bytes,
+                               double hrl_entry_ratio, int size_arg_provided, int assume_yes,
+                               off_t *total_bytes, struct stat *st, struct mkfs_layout *layout,
+                               kafs_blkcnt_t *blkcnt)
+{
+  int have_stat = 0;
+  if (mkfs_open_target(ctx, img, st, &have_stat) != 0)
+    return 1;
+  if (mkfs_resolve_total_bytes(ctx, st, size_arg_provided, total_bytes) != 0)
+    return 1;
+
+  if (!inocnt_arg_provided)
+    *inocnt = mkfs_default_inocnt_for_size(*total_bytes);
+
+  if (compute_blkcnt_for_total(format_version, *total_bytes, log_blksize, blksizemask, blksize,
+                               *inocnt, journal_bytes, hrl_entry_ratio, blkcnt, layout) != 0)
+  {
+    fprintf(stderr, "invalid total size: %lld\n", (long long)*total_bytes);
+    close(ctx->c_fd);
+    return 2;
+  }
+
+  if (*total_bytes >= (off_t)sizeof(kafs_ssuperblock_t))
+  {
+    kafs_ssuperblock_t sbcheck;
+    if (pread(ctx->c_fd, &sbcheck, sizeof(sbcheck), 0) == (ssize_t)sizeof(sbcheck) &&
+        kafs_sb_magic_get(&sbcheck) == KAFS_MAGIC &&
+        mkfs_format_version_is_supported(kafs_sb_format_version_get(&sbcheck)))
+    {
+      fprintf(stderr, "warning: image appears formatted and will be overwritten: %s\n", img);
+      if (!assume_yes && !mkfs_confirm_overwrite_stdin())
+      {
+        fprintf(stderr, "mkfs.kafs: aborted\n");
+        close(ctx->c_fd);
+        return 1;
+      }
+    }
+  }
+
+  if (S_ISREG(st->st_mode) && ftruncate(ctx->c_fd, *total_bytes) < 0)
+  {
+    perror("ftruncate");
+    close(ctx->c_fd);
+    return 1;
+  }
+
+  return 0;
+}
+
 int main(int argc, char **argv)
 {
   mkfs_options_t opts;
@@ -462,99 +580,15 @@ int main(int argc, char **argv)
   int assume_yes = opts.assume_yes;
 
   struct stat st;
-  int have_stat = (stat(img, &st) == 0);
-  if (!have_stat && errno != ENOENT)
-  {
-    perror("stat");
-    return 1;
-  }
-  kafs_context_t ctx = {0};
-  ctx.c_fd = open(img, O_RDWR | (have_stat ? 0 : O_CREAT), 0666);
-  if (ctx.c_fd < 0)
-  {
-    perror("open");
-    return 1;
-  }
-  ctx.c_blo_search = 0;
-  ctx.c_ino_search = 0;
-
-  if (fstat(ctx.c_fd, &st) != 0)
-  {
-    perror("fstat");
-    close(ctx.c_fd);
-    return 1;
-  }
-
-  if (S_ISREG(st.st_mode) && st.st_size > 0)
-  {
-    if (size_arg_provided)
-      fprintf(stderr, "warning: size overridden by existing file size\n");
-    total_bytes = st.st_size;
-  }
-  else if (S_ISBLK(st.st_mode))
-  {
-#ifdef __linux__
-    uint64_t dev_bytes = 0;
-    if (ioctl(ctx.c_fd, BLKGETSIZE64, &dev_bytes) != 0)
-    {
-      perror("ioctl(BLKGETSIZE64)");
-      close(ctx.c_fd);
-      return 1;
-    }
-    if (dev_bytes == 0)
-    {
-      fprintf(stderr, "invalid block device size: 0\n");
-      close(ctx.c_fd);
-      return 1;
-    }
-    if (size_arg_provided)
-      fprintf(stderr, "warning: size overridden by block device size\n");
-    total_bytes = (off_t)dev_bytes;
-#else
-    fprintf(stderr, "block devices are not supported on this platform\n");
-    close(ctx.c_fd);
-    return 1;
-#endif
-  }
-
-  if (!inocnt_arg_provided)
-    inocnt = mkfs_default_inocnt_for_size(total_bytes);
-
+  kafs_context_t ctx;
   struct mkfs_layout layout = {0};
   kafs_blkcnt_t blkcnt = 0;
-  if (compute_blkcnt_for_total(format_version, total_bytes, log_blksize, blksizemask, blksize,
-                               inocnt, journal_bytes, hrl_entry_ratio, &blkcnt, &layout) != 0)
-  {
-    fprintf(stderr, "invalid total size: %lld\n", (long long)total_bytes);
-    close(ctx.c_fd);
-    return 2;
-  }
-
-  if (total_bytes >= (off_t)sizeof(kafs_ssuperblock_t))
-  {
-    kafs_ssuperblock_t sbcheck;
-    if (pread(ctx.c_fd, &sbcheck, sizeof(sbcheck), 0) == (ssize_t)sizeof(sbcheck))
-    {
-      if (kafs_sb_magic_get(&sbcheck) == KAFS_MAGIC &&
-          mkfs_format_version_is_supported(kafs_sb_format_version_get(&sbcheck)))
-      {
-        fprintf(stderr, "warning: image appears formatted and will be overwritten: %s\n", img);
-        if (!assume_yes && !mkfs_confirm_overwrite_stdin())
-        {
-          fprintf(stderr, "mkfs.kafs: aborted\n");
-          close(ctx.c_fd);
-          return 1;
-        }
-      }
-    }
-  }
-
-  if (S_ISREG(st.st_mode) && ftruncate(ctx.c_fd, total_bytes) < 0)
-  {
-    perror("ftruncate");
-    close(ctx.c_fd);
-    return 1;
-  }
+  int prepare_rc =
+      mkfs_prepare_target(&ctx, img, format_version, log_blksize, blksizemask, blksize, &inocnt,
+                          inocnt_arg_provided, journal_bytes, hrl_entry_ratio, size_arg_provided,
+                          assume_yes, &total_bytes, &st, &layout, &blkcnt);
+  if (prepare_rc != 0)
+    return prepare_rc;
 
   off_t mapsize = layout.mapsize;
   ctx.c_superblock = NULL;

--- a/src/mkfs_kafs.c
+++ b/src/mkfs_kafs.c
@@ -554,6 +554,189 @@ static int mkfs_prepare_target(kafs_context_t *ctx, const char *img, uint32_t fo
   return 0;
 }
 
+static int mkfs_map_metadata(kafs_context_t *ctx, off_t mapsize, kafs_blkcnt_t blkcnt,
+                             uint32_t format_version, kafs_inocnt_t inocnt,
+                             const struct mkfs_layout *layout)
+{
+  ctx->c_superblock = mmap(NULL, mapsize, PROT_READ | PROT_WRITE, MAP_SHARED, ctx->c_fd, 0);
+  if (ctx->c_superblock == MAP_FAILED)
+  {
+    perror("mmap");
+    return 1;
+  }
+
+  memset(ctx->c_superblock, 0, (size_t)mapsize);
+  ctx->c_blkmasktbl = (kafs_blkmask_t *)((char *)ctx->c_superblock + (intptr_t)layout->blkmask_off);
+  ctx->c_inotbl = (kafs_sinode_t *)((char *)ctx->c_superblock + (intptr_t)layout->inotbl_off);
+
+  size_t blkmask_bytes = ((size_t)blkcnt + 7) >> 3;
+  size_t inotbl_bytes = (size_t)kafs_inode_table_bytes_for_format(format_version, inocnt);
+  char *base = (char *)ctx->c_superblock;
+  char *end = base + mapsize;
+  char *bm_ptr = (char *)ctx->c_blkmasktbl;
+  char *ino_ptr = (char *)ctx->c_inotbl;
+  assert(bm_ptr >= base && bm_ptr + blkmask_bytes <= end);
+  assert(ino_ptr >= base && ino_ptr + inotbl_bytes <= end);
+  memset(bm_ptr, 0, blkmask_bytes);
+  memset(ino_ptr, 0, inotbl_bytes);
+
+  if (layout->allocator_size > 0)
+  {
+    char *alloc_ptr = (char *)ctx->c_superblock + layout->allocator_off;
+    assert(alloc_ptr >= base && alloc_ptr + layout->allocator_size <= end);
+    memset(alloc_ptr, 0, layout->allocator_size);
+  }
+
+  return 0;
+}
+
+static void mkfs_init_superblock(kafs_context_t *ctx, uint32_t format_version,
+                                 kafs_logblksize_t log_blksize, kafs_inocnt_t inocnt,
+                                 kafs_blkcnt_t blkcnt, off_t mapsize, size_t journal_bytes,
+                                 const struct mkfs_layout *layout)
+{
+  kafs_sb_log_blksize_set(ctx->c_superblock, log_blksize);
+  kafs_sb_magic_set(ctx->c_superblock, KAFS_MAGIC);
+  kafs_sb_format_version_set(ctx->c_superblock, format_version);
+  kafs_sb_hash_fast_set(ctx->c_superblock, KAFS_HASH_FAST_XXH64);
+  kafs_sb_hash_strong_set(ctx->c_superblock, KAFS_HASH_STRONG_BLAKE3_256);
+  kafs_sb_hrl_index_offset_set(ctx->c_superblock, (uint64_t)layout->hrl_index_off);
+  kafs_sb_hrl_index_size_set(ctx->c_superblock, (uint64_t)layout->hrl_index_size);
+  kafs_sb_hrl_entry_offset_set(ctx->c_superblock, (uint64_t)layout->hrl_entry_off);
+  kafs_sb_hrl_entry_cnt_set(ctx->c_superblock, (uint32_t)layout->hrl_entry_cnt);
+  kafs_sb_journal_offset_set(ctx->c_superblock, (uint64_t)layout->journal_off);
+  kafs_sb_journal_size_set(ctx->c_superblock, (uint64_t)journal_bytes);
+  kafs_sb_journal_flags_set(ctx->c_superblock, 0);
+  kafs_sb_allocator_version_set(ctx->c_superblock, 2);
+  kafs_sb_allocator_offset_set(ctx->c_superblock, (uint64_t)layout->allocator_off);
+  kafs_sb_allocator_size_set(ctx->c_superblock, (uint64_t)layout->allocator_size);
+  kafs_sb_pendinglog_offset_set(ctx->c_superblock, (uint64_t)layout->pendinglog_off);
+  kafs_sb_pendinglog_size_set(ctx->c_superblock, (uint64_t)layout->pendinglog_size);
+  kafs_sb_checkpoint_seq_set(ctx->c_superblock, 0);
+  kafs_sb_commit_seq_set(ctx->c_superblock, 0);
+  kafs_sb_tailmeta_offset_set(ctx->c_superblock, (uint64_t)layout->tailmeta_off);
+  kafs_sb_tailmeta_size_set(ctx->c_superblock, (uint64_t)layout->tailmeta_size);
+  kafs_sb_feature_flags_set(ctx->c_superblock, mkfs_feature_flags_for_format(format_version));
+  kafs_sb_compat_flags_set(ctx->c_superblock, 0);
+
+  ctx->c_superblock->s_inocnt = kafs_inocnt_htos(inocnt);
+  kafs_sb_inocnt_free_set(ctx->c_superblock,
+                          (inocnt > (kafs_inocnt_t)KAFS_INO_ROOTDIR) ? (inocnt - 1) : 0);
+  ctx->c_superblock->s_blkcnt = kafs_blkcnt_htos(blkcnt);
+  ctx->c_superblock->s_r_blkcnt = kafs_blkcnt_htos(blkcnt);
+  kafs_blkcnt_t fdb = (kafs_blkcnt_t)(mapsize >> log_blksize);
+  ctx->c_superblock->s_first_data_block = kafs_blkcnt_htos(fdb);
+  kafs_sb_blkcnt_free_set(ctx->c_superblock, blkcnt - fdb);
+
+  for (kafs_blkcnt_t blo = 0; blo < fdb; ++blo)
+    kafs_blk_set_usage(ctx, blo, KAFS_TRUE);
+}
+
+static void mkfs_init_root_inode(kafs_context_t *ctx, uint32_t format_version, off_t mapsize)
+{
+  kafs_sinode_t *inoent_rootdir =
+      (kafs_sinode_t *)kafs_inode_ptr_in_table(ctx->c_inotbl, format_version, KAFS_INO_ROOTDIR);
+  {
+    char *ptr = (char *)inoent_rootdir;
+    char *base = (char *)ctx->c_superblock;
+    char *end = base + mapsize;
+    if (!(ptr >= base && ptr + sizeof(*inoent_rootdir) <= end))
+    {
+      fprintf(stderr, "inotbl/root inode out of range: ptr=%p base=%p end=%p mapsize=%lld\n",
+              (void *)ptr, (void *)base, (void *)end, (long long)mapsize);
+      abort();
+    }
+  }
+
+  kafs_ino_mode_set(inoent_rootdir, S_IFDIR | 0755);
+  kafs_ino_uid_set(inoent_rootdir, (kafs_uid_t)getuid());
+  kafs_ino_size_set(inoent_rootdir, 0);
+  kafs_time_t now = kafs_now();
+  kafs_time_t nulltime = (kafs_time_t){0, 0};
+  kafs_ino_atime_set(inoent_rootdir, now);
+  kafs_ino_ctime_set(inoent_rootdir, now);
+  kafs_ino_mtime_set(inoent_rootdir, now);
+  kafs_ino_dtime_set(inoent_rootdir, nulltime);
+  kafs_ino_gid_set(inoent_rootdir, (kafs_gid_t)getgid());
+  inoent_rootdir->i_linkcnt = kafs_linkcnt_htos(1);
+  kafs_ino_blocks_set(inoent_rootdir, 0);
+  kafs_ino_dev_set(inoent_rootdir, 0);
+
+  kafs_sdir_v4_hdr_t root_dir_hdr;
+  kafs_dir_v4_hdr_init(&root_dir_hdr);
+  memcpy(inoent_rootdir->i_blkreftbl, &root_dir_hdr, sizeof(root_dir_hdr));
+  kafs_ino_size_set(inoent_rootdir, (kafs_off_t)sizeof(root_dir_hdr));
+}
+
+static void mkfs_init_runtime_regions(kafs_context_t *ctx, const struct mkfs_layout *layout,
+                                      size_t journal_bytes, kafs_blksize_t blksize, off_t mapsize)
+{
+  ctx->c_hrl_index = (void *)((char *)ctx->c_superblock + layout->hrl_index_off);
+  ctx->c_hrl_bucket_cnt = layout->hrl_bucket_cnt;
+  (void)kafs_hrl_format(ctx);
+
+  if (journal_bytes > kj_header_size())
+  {
+    kj_header_t jh;
+    char *jhdr_ptr = (char *)ctx->c_superblock + layout->journal_off;
+    char *base = (char *)ctx->c_superblock;
+    char *end = base + mapsize;
+
+    memset(&jh, 0, sizeof(jh));
+    jh.magic = KJ_MAGIC;
+    jh.version = KJ_VER;
+    jh.flags = 0;
+    jh.area_size = (uint64_t)journal_bytes - (uint64_t)kj_header_size();
+    jh.write_off = 0;
+    jh.seq = 0;
+    jh.reserved0 = 0;
+    jh.header_crc = 0;
+    jh.header_crc = kj_crc32(&jh, sizeof(jh));
+
+    assert(jhdr_ptr >= base && jhdr_ptr + sizeof(jh) <= end);
+    memcpy(jhdr_ptr, &jh, sizeof(jh));
+  }
+
+  if (layout->tailmeta_size >= sizeof(kafs_tailmeta_region_hdr_t))
+  {
+    kafs_tailmeta_region_hdr_t region_hdr;
+    char *tailmeta_ptr = (char *)ctx->c_superblock + layout->tailmeta_off;
+    char *base = (char *)ctx->c_superblock;
+    char *end = base + mapsize;
+
+    assert(tailmeta_ptr >= base && tailmeta_ptr + layout->tailmeta_size <= end);
+    kafs_tailmeta_region_hdr_init(&region_hdr);
+    kafs_tailmeta_region_hdr_container_table_off_set(&region_hdr, (uint32_t)sizeof(region_hdr));
+    kafs_tailmeta_region_hdr_container_table_bytes_set(
+        &region_hdr,
+        (uint32_t)(KAFS_TAILMETA_DEFAULT_CLASS_COUNT * sizeof(kafs_tailmeta_container_hdr_t)));
+    kafs_tailmeta_region_hdr_container_count_set(&region_hdr, KAFS_TAILMETA_DEFAULT_CLASS_COUNT);
+    kafs_tailmeta_region_hdr_class_count_set(&region_hdr, KAFS_TAILMETA_DEFAULT_CLASS_COUNT);
+    memcpy(tailmeta_ptr, &region_hdr, sizeof(region_hdr));
+
+    kafs_tailmeta_container_hdr_t *containers =
+        (kafs_tailmeta_container_hdr_t *)(tailmeta_ptr + sizeof(region_hdr));
+    memset(containers, 0,
+           KAFS_TAILMETA_DEFAULT_CLASS_COUNT * sizeof(kafs_tailmeta_container_hdr_t));
+    for (uint16_t index = 0; index < KAFS_TAILMETA_DEFAULT_CLASS_COUNT; ++index)
+    {
+      uint16_t class_bytes = kafs_tailmeta_default_class_bytes(index);
+      uint16_t slot_count = kafs_tailmeta_default_slot_count_for_class(blksize, class_bytes);
+      uint32_t slot_table_off =
+          (uint32_t)((size_t)blksize * (size_t)(KAFS_TAILMETA_DEFAULT_REGION_META_BLOCKS + index));
+
+      kafs_tailmeta_container_hdr_init(&containers[index]);
+      kafs_tailmeta_container_hdr_class_bytes_set(&containers[index], class_bytes);
+      kafs_tailmeta_container_hdr_slot_count_set(&containers[index], slot_count);
+      kafs_tailmeta_container_hdr_free_bytes_set(&containers[index],
+                                                 (uint16_t)(slot_count * class_bytes));
+      kafs_tailmeta_container_hdr_slot_table_off_set(&containers[index], slot_table_off);
+      kafs_tailmeta_container_hdr_slot_table_bytes_set(
+          &containers[index], (uint32_t)(slot_count * sizeof(kafs_tailmeta_slot_desc_t)));
+    }
+  }
+}
+
 int main(int argc, char **argv)
 {
   mkfs_options_t opts;
@@ -591,191 +774,17 @@ int main(int argc, char **argv)
     return prepare_rc;
 
   off_t mapsize = layout.mapsize;
-  ctx.c_superblock = NULL;
-  ctx.c_blkmasktbl = (void *)layout.blkmask_off;
-  ctx.c_inotbl = (void *)layout.inotbl_off;
-
-  ctx.c_superblock = mmap(NULL, mapsize, PROT_READ | PROT_WRITE, MAP_SHARED, ctx.c_fd, 0);
-  if (ctx.c_superblock == MAP_FAILED)
-  {
-    perror("mmap");
+  if (mkfs_map_metadata(&ctx, mapsize, blkcnt, format_version, inocnt, &layout) != 0)
     return 1;
-  }
-  // Reformat safety: clear the full metadata mapping so stale pendinglog/journal/HRL
-  // state from previous formats cannot survive when the superblock shape remains valid.
-  memset(ctx.c_superblock, 0, (size_t)mapsize);
-  // 先頭アドレスにオフセットを加算（byte単位）
-  ctx.c_blkmasktbl = (kafs_blkmask_t *)((char *)ctx.c_superblock + (intptr_t)ctx.c_blkmasktbl);
-  ctx.c_inotbl = (kafs_sinode_t *)((char *)ctx.c_superblock + (intptr_t)ctx.c_inotbl);
 
-  // 境界チェックとゼロ初期化
-  size_t blkmask_bytes = ((size_t)blkcnt + 7) >> 3; // ビットマップの総バイト数
-  size_t inotbl_bytes = (size_t)kafs_inode_table_bytes_for_format(format_version, inocnt);
-  char *base = (char *)ctx.c_superblock;
-  char *end = base + mapsize;
-  char *bm_ptr = (char *)ctx.c_blkmasktbl;
-  char *ino_ptr = (char *)ctx.c_inotbl;
-  assert(bm_ptr >= base && bm_ptr + blkmask_bytes <= end);
-  assert(ino_ptr >= base && ino_ptr + inotbl_bytes <= end);
-  memset(bm_ptr, 0, blkmask_bytes);
-  memset(ino_ptr, 0, inotbl_bytes);
-  if (layout.allocator_size > 0)
-  {
-    char *alloc_ptr = (char *)ctx.c_superblock + layout.allocator_off;
-    assert(alloc_ptr >= base && alloc_ptr + layout.allocator_size <= end);
-    memset(alloc_ptr, 0, layout.allocator_size);
-  }
-
-  // スーパーブロック基本
-  kafs_sb_log_blksize_set(ctx.c_superblock, log_blksize);
-  kafs_sb_magic_set(ctx.c_superblock, KAFS_MAGIC);
-  kafs_sb_format_version_set(ctx.c_superblock, format_version);
-  kafs_sb_hash_fast_set(ctx.c_superblock, KAFS_HASH_FAST_XXH64);
-  kafs_sb_hash_strong_set(ctx.c_superblock, KAFS_HASH_STRONG_BLAKE3_256);
-  // HRL領域の割当
-  kafs_sb_hrl_index_offset_set(ctx.c_superblock, (uint64_t)layout.hrl_index_off);
-  kafs_sb_hrl_index_size_set(ctx.c_superblock, (uint64_t)layout.hrl_index_size);
-  kafs_sb_hrl_entry_offset_set(ctx.c_superblock, (uint64_t)layout.hrl_entry_off);
-  kafs_sb_hrl_entry_cnt_set(ctx.c_superblock, (uint32_t)layout.hrl_entry_cnt);
-  // Journal region metadata
-  kafs_sb_journal_offset_set(ctx.c_superblock, (uint64_t)layout.journal_off);
-  kafs_sb_journal_size_set(ctx.c_superblock, (uint64_t)journal_bytes);
-  kafs_sb_journal_flags_set(ctx.c_superblock, 0);
-  kafs_sb_allocator_version_set(ctx.c_superblock, 2);
-  kafs_sb_allocator_offset_set(ctx.c_superblock, (uint64_t)layout.allocator_off);
-  kafs_sb_allocator_size_set(ctx.c_superblock, (uint64_t)layout.allocator_size);
-  kafs_sb_pendinglog_offset_set(ctx.c_superblock, (uint64_t)layout.pendinglog_off);
-  kafs_sb_pendinglog_size_set(ctx.c_superblock, (uint64_t)layout.pendinglog_size);
-  kafs_sb_checkpoint_seq_set(ctx.c_superblock, 0);
-  kafs_sb_commit_seq_set(ctx.c_superblock, 0);
-  kafs_sb_tailmeta_offset_set(ctx.c_superblock, (uint64_t)layout.tailmeta_off);
-  kafs_sb_tailmeta_size_set(ctx.c_superblock, (uint64_t)layout.tailmeta_size);
-  kafs_sb_feature_flags_set(ctx.c_superblock, mkfs_feature_flags_for_format(format_version));
-  kafs_sb_compat_flags_set(ctx.c_superblock, 0);
-
-  // R/O items
-  ctx.c_superblock->s_inocnt = kafs_inocnt_htos(inocnt);
-  // root inode uses one entry
-  kafs_sb_inocnt_free_set(ctx.c_superblock,
-                          (inocnt > (kafs_inocnt_t)KAFS_INO_ROOTDIR) ? (inocnt - 1) : 0);
-  // 一般/ルートどちらも同一のブロック数で初期化（シンプル化）
-  ctx.c_superblock->s_blkcnt = kafs_blkcnt_htos(blkcnt);
-  ctx.c_superblock->s_r_blkcnt = kafs_blkcnt_htos(blkcnt);
-  kafs_blkcnt_t fdb = (kafs_blkcnt_t)(mapsize >> log_blksize);
-  ctx.c_superblock->s_first_data_block = kafs_blkcnt_htos(fdb);
-  kafs_sb_blkcnt_free_set(ctx.c_superblock, blkcnt - fdb);
-
-  for (kafs_blkcnt_t blo = 0; blo < fdb; ++blo)
-    kafs_blk_set_usage(&ctx, blo, KAFS_TRUE);
-
-  // root inode
-  // inotbl はゼロ初期化済み
-  kafs_sinode_t *inoent_rootdir = (kafs_sinode_t *)kafs_inode_ptr_in_table(
-      ctx.c_inotbl, kafs_sb_format_version_get(ctx.c_superblock), KAFS_INO_ROOTDIR);
-  // 安全性チェック
-  {
-    char *p = (char *)inoent_rootdir;
-    char *base2 = (char *)ctx.c_superblock;
-    char *end2 = base2 + mapsize;
-    if (!(p >= base2 && p + sizeof(*inoent_rootdir) <= end2))
-    {
-      fprintf(stderr, "inotbl/root inode out of range: ptr=%p base=%p end=%p mapsize=%lld\n",
-              (void *)p, (void *)base2, (void *)end2, (long long)mapsize);
-      abort();
-    }
-  }
-  kafs_ino_mode_set(inoent_rootdir, S_IFDIR | 0755);
-  // For unprivileged FUSE mounts, make the filesystem root owned by the image creator.
-  kafs_ino_uid_set(inoent_rootdir, (kafs_uid_t)getuid());
-  kafs_ino_size_set(inoent_rootdir, 0);
-  kafs_time_t now = kafs_now();
-  kafs_time_t nulltime = (kafs_time_t){0, 0};
-  kafs_ino_atime_set(inoent_rootdir, now);
-  kafs_ino_ctime_set(inoent_rootdir, now);
-  kafs_ino_mtime_set(inoent_rootdir, now);
-  kafs_ino_dtime_set(inoent_rootdir, nulltime);
-  kafs_ino_gid_set(inoent_rootdir, (kafs_gid_t)getgid());
-  // ログ呼び出しを避けて直接設定（デバッグ）
-  inoent_rootdir->i_linkcnt = kafs_linkcnt_htos(1);
-  kafs_ino_blocks_set(inoent_rootdir, 0);
-  kafs_ino_dev_set(inoent_rootdir, 0);
-  kafs_sdir_v4_hdr_t root_dir_hdr;
-  kafs_dir_v4_hdr_init(&root_dir_hdr);
-  memcpy(inoent_rootdir->i_blkreftbl, &root_dir_hdr, sizeof(root_dir_hdr));
-  kafs_ino_size_set(inoent_rootdir, (kafs_off_t)sizeof(root_dir_hdr));
-  // ルートディレクトリの実レコードは空開始（"." は readdir で注入、".." は保持しない）
-
-  // HRL 初期化（ゼロクリア）
-  ctx.c_hrl_index = (void *)((char *)ctx.c_superblock + layout.hrl_index_off);
-  ctx.c_hrl_bucket_cnt = layout.hrl_bucket_cnt;
-  (void)kafs_hrl_format(&ctx);
-
-  // Journal header 初期化（fresh image が fsck --fast-check を通る前提）
-  {
-    size_t hsz = kj_header_size();
-    if (journal_bytes > hsz)
-    {
-      kj_header_t jh;
-      memset(&jh, 0, sizeof(jh));
-      jh.magic = KJ_MAGIC;
-      jh.version = KJ_VER;
-      jh.flags = 0;
-      jh.area_size = (uint64_t)journal_bytes - (uint64_t)hsz;
-      jh.write_off = 0;
-      jh.seq = 0;
-      jh.reserved0 = 0;
-      jh.header_crc = 0;
-      jh.header_crc = kj_crc32(&jh, sizeof(jh));
-
-      char *jhdr_ptr = (char *)ctx.c_superblock + layout.journal_off;
-      char *base3 = (char *)ctx.c_superblock;
-      char *end3 = base3 + mapsize;
-      assert(jhdr_ptr >= base3 && jhdr_ptr + sizeof(jh) <= end3);
-      memcpy(jhdr_ptr, &jh, sizeof(jh));
-    }
-  }
-
-  if (layout.tailmeta_size >= sizeof(kafs_tailmeta_region_hdr_t))
-  {
-    kafs_tailmeta_region_hdr_t region_hdr;
-    char *tailmeta_ptr = (char *)ctx.c_superblock + layout.tailmeta_off;
-    char *base4 = (char *)ctx.c_superblock;
-    char *end4 = base4 + mapsize;
-
-    assert(tailmeta_ptr >= base4 && tailmeta_ptr + layout.tailmeta_size <= end4);
-    kafs_tailmeta_region_hdr_init(&region_hdr);
-    kafs_tailmeta_region_hdr_container_table_off_set(&region_hdr, (uint32_t)sizeof(region_hdr));
-    kafs_tailmeta_region_hdr_container_table_bytes_set(
-        &region_hdr,
-        (uint32_t)(KAFS_TAILMETA_DEFAULT_CLASS_COUNT * sizeof(kafs_tailmeta_container_hdr_t)));
-    kafs_tailmeta_region_hdr_container_count_set(&region_hdr, KAFS_TAILMETA_DEFAULT_CLASS_COUNT);
-    kafs_tailmeta_region_hdr_class_count_set(&region_hdr, KAFS_TAILMETA_DEFAULT_CLASS_COUNT);
-    memcpy(tailmeta_ptr, &region_hdr, sizeof(region_hdr));
-
-    kafs_tailmeta_container_hdr_t *containers =
-        (kafs_tailmeta_container_hdr_t *)(tailmeta_ptr + sizeof(region_hdr));
-    memset(containers, 0,
-           KAFS_TAILMETA_DEFAULT_CLASS_COUNT * sizeof(kafs_tailmeta_container_hdr_t));
-    for (uint16_t index = 0; index < KAFS_TAILMETA_DEFAULT_CLASS_COUNT; ++index)
-    {
-      uint16_t class_bytes = kafs_tailmeta_default_class_bytes(index);
-      uint16_t slot_count = kafs_tailmeta_default_slot_count_for_class(blksize, class_bytes);
-      uint32_t slot_table_off =
-          (uint32_t)((size_t)blksize * (size_t)(KAFS_TAILMETA_DEFAULT_REGION_META_BLOCKS + index));
-
-      kafs_tailmeta_container_hdr_init(&containers[index]);
-      kafs_tailmeta_container_hdr_class_bytes_set(&containers[index], class_bytes);
-      kafs_tailmeta_container_hdr_slot_count_set(&containers[index], slot_count);
-      kafs_tailmeta_container_hdr_free_bytes_set(&containers[index],
-                                                 (uint16_t)(slot_count * class_bytes));
-      kafs_tailmeta_container_hdr_slot_table_off_set(&containers[index], slot_table_off);
-      kafs_tailmeta_container_hdr_slot_table_bytes_set(
-          &containers[index], (uint32_t)(slot_count * sizeof(kafs_tailmeta_slot_desc_t)));
-    }
-  }
+  mkfs_init_superblock(&ctx, format_version, log_blksize, inocnt, blkcnt, mapsize, journal_bytes,
+                       &layout);
+  mkfs_init_root_inode(&ctx, format_version, mapsize);
+  mkfs_init_runtime_regions(&ctx, &layout, journal_bytes, blksize, mapsize);
 
   if (trim_data_area)
   {
+    kafs_blkcnt_t fdb = (kafs_blkcnt_t)(mapsize >> log_blksize);
     off_t data_off = (off_t)fdb << log_blksize;
     off_t data_len = ((off_t)blkcnt - (off_t)fdb) << log_blksize;
     int trc = mkfs_trim_range(ctx.c_fd, data_off, data_len);

--- a/src/mkfs_kafs.c
+++ b/src/mkfs_kafs.c
@@ -775,7 +775,10 @@ int main(int argc, char **argv)
 
   off_t mapsize = layout.mapsize;
   if (mkfs_map_metadata(&ctx, mapsize, blkcnt, format_version, inocnt, &layout) != 0)
+  {
+    close(ctx.c_fd);
     return 1;
+  }
 
   mkfs_init_superblock(&ctx, format_version, log_blksize, inocnt, blkcnt, mapsize, journal_bytes,
                        &layout);

--- a/src/mkfs_kafs.c
+++ b/src/mkfs_kafs.c
@@ -288,102 +288,178 @@ static int compute_blkcnt_for_total(uint32_t format_version, off_t total_bytes,
   return 0;
 }
 
-int main(int argc, char **argv)
+typedef struct mkfs_options
 {
-  const char *img = NULL;
-  uint32_t format_version = KAFS_FORMAT_VERSION_V5;
-  kafs_logblksize_t log_blksize = 12; // 4096B
-  kafs_blksize_t blksize = 1u << log_blksize;
-  kafs_blksize_t blksizemask = blksize - 1u;
-  off_t total_bytes = 1024ll * 1024ll * 1024ll; // 1GiB
-  kafs_inocnt_t inocnt = 0;                     // number of inodes
-  size_t journal_bytes = 1u << 20;              // 1MiB default journal region
-  double hrl_entry_ratio = 0.75;
-  int size_arg_provided = 0;
-  int inocnt_arg_provided = 0;
-  int trim_data_area = 0;
-  int assume_yes = 0;
+  const char *img;
+  uint32_t format_version;
+  kafs_logblksize_t log_blksize;
+  kafs_blksize_t blksize;
+  kafs_blksize_t blksizemask;
+  off_t total_bytes;
+  kafs_inocnt_t inocnt;
+  size_t journal_bytes;
+  double hrl_entry_ratio;
+  int size_arg_provided;
+  int inocnt_arg_provided;
+  int trim_data_area;
+  int assume_yes;
+} mkfs_options_t;
 
-  if (kafs_cli_exit_if_help(argc, argv, usage, argv[0]) == 0)
+static void mkfs_options_init(mkfs_options_t *opts)
+{
+  memset(opts, 0, sizeof(*opts));
+  opts->format_version = KAFS_FORMAT_VERSION_V5;
+  opts->log_blksize = 12;
+  opts->blksize = 1u << opts->log_blksize;
+  opts->blksizemask = opts->blksize - 1u;
+  opts->total_bytes = 1024ll * 1024ll * 1024ll;
+  opts->journal_bytes = 1u << 20;
+  opts->hrl_entry_ratio = 0.75;
+}
+
+static int mkfs_parse_size_option(const char *value, off_t *total_bytes)
+{
+  uint64_t tmp = 0;
+  if (kafs_parse_size_bytes_u64(value, &tmp) != 0)
+  {
+    fprintf(stderr, "invalid size: %s\n", value);
+    return 2;
+  }
+  *total_bytes = (off_t)tmp;
+  return 0;
+}
+
+static int mkfs_parse_journal_size_option(const char *value, size_t *journal_bytes)
+{
+  uint64_t tmp = 0;
+  if (kafs_parse_size_bytes_u64(value, &tmp) != 0)
+  {
+    fprintf(stderr, "invalid journal size: %s\n", value);
+    return 2;
+  }
+  *journal_bytes = (size_t)tmp;
+  if (*journal_bytes < 4096)
+    *journal_bytes = 4096;
+  return 0;
+}
+
+static int mkfs_parse_format_version_option(const char *value, uint32_t *format_version)
+{
+  *format_version = (uint32_t)strtoul(value, NULL, 0);
+  if (!mkfs_format_version_is_supported(*format_version))
+  {
+    fprintf(stderr, "unsupported format version: %u\n", *format_version);
+    return 2;
+  }
+  return 0;
+}
+
+static int mkfs_handle_arg(int argc, char **argv, int *index, mkfs_options_t *opts)
+{
+  const char *arg = argv[*index];
+
+  if ((strcmp(arg, "--size-bytes") == 0 || strcmp(arg, "-s") == 0) && *index + 1 < argc)
+  {
+    *index += 1;
+    if (mkfs_parse_size_option(argv[*index], &opts->total_bytes) != 0)
+      return 2;
+    opts->size_arg_provided = 1;
     return 0;
+  }
+  if ((strcmp(arg, "--blksize-log") == 0 || strcmp(arg, "-b") == 0) && *index + 1 < argc)
+  {
+    opts->log_blksize = (kafs_logblksize_t)strtoul(argv[++*index], NULL, 0);
+    opts->blksize = 1u << opts->log_blksize;
+    opts->blksizemask = opts->blksize - 1u;
+    return 0;
+  }
+  if (strcmp(arg, "--format-version") == 0 && *index + 1 < argc)
+  {
+    *index += 1;
+    return mkfs_parse_format_version_option(argv[*index], &opts->format_version);
+  }
+  if ((strcmp(arg, "--inodes") == 0 || strcmp(arg, "-i") == 0) && *index + 1 < argc)
+  {
+    opts->inocnt = (kafs_inocnt_t)strtoul(argv[++*index], NULL, 0);
+    opts->inocnt_arg_provided = 1;
+    return 0;
+  }
+  if ((strcmp(arg, "--journal-size-bytes") == 0 || strcmp(arg, "-J") == 0) && *index + 1 < argc)
+  {
+    *index += 1;
+    return mkfs_parse_journal_size_option(argv[*index], &opts->journal_bytes);
+  }
+  if (strcmp(arg, "--hrl-entry-ratio") == 0 && *index + 1 < argc)
+  {
+    *index += 1;
+    if (kafs_parse_ratio_0_to_1(argv[*index], &opts->hrl_entry_ratio) != 0)
+    {
+      fprintf(stderr, "invalid hrl-entry-ratio (expected 0<R<=1): %s\n", argv[*index]);
+      return 2;
+    }
+    return 0;
+  }
+  if (strcmp(arg, "--trim-data-area") == 0)
+  {
+    opts->trim_data_area = 1;
+    return 0;
+  }
+  if (strcmp(arg, "--yes") == 0)
+  {
+    opts->assume_yes = 1;
+    return 0;
+  }
+  if (arg[0] != '-' && opts->img == NULL)
+  {
+    opts->img = arg;
+    return 0;
+  }
 
+  return 2;
+}
+
+static int mkfs_collect_args(int argc, char **argv, mkfs_options_t *opts)
+{
   for (int i = 1; i < argc; ++i)
   {
-    if ((strcmp(argv[i], "--size-bytes") == 0 || strcmp(argv[i], "-s") == 0) && i + 1 < argc)
-    {
-      uint64_t tmp = 0;
-      if (kafs_parse_size_bytes_u64(argv[++i], &tmp) != 0)
-      {
-        fprintf(stderr, "invalid size: %s\n", argv[i]);
-        return 2;
-      }
-      total_bytes = (off_t)tmp;
-      size_arg_provided = 1;
-    }
-    else if ((strcmp(argv[i], "--blksize-log") == 0 || strcmp(argv[i], "-b") == 0) && i + 1 < argc)
-    {
-      log_blksize = (kafs_logblksize_t)strtoul(argv[++i], NULL, 0);
-      blksize = 1u << log_blksize;
-      blksizemask = blksize - 1u;
-    }
-    else if (strcmp(argv[i], "--format-version") == 0 && i + 1 < argc)
-    {
-      format_version = (uint32_t)strtoul(argv[++i], NULL, 0);
-      if (!mkfs_format_version_is_supported(format_version))
-      {
-        fprintf(stderr, "unsupported format version: %u\n", format_version);
-        return 2;
-      }
-    }
-    else if ((strcmp(argv[i], "--inodes") == 0 || strcmp(argv[i], "-i") == 0) && i + 1 < argc)
-    {
-      inocnt = (kafs_inocnt_t)strtoul(argv[++i], NULL, 0);
-      inocnt_arg_provided = 1;
-    }
-    else if ((strcmp(argv[i], "--journal-size-bytes") == 0 || strcmp(argv[i], "-J") == 0) &&
-             i + 1 < argc)
-    {
-      uint64_t tmp = 0;
-      if (kafs_parse_size_bytes_u64(argv[++i], &tmp) != 0)
-      {
-        fprintf(stderr, "invalid journal size: %s\n", argv[i]);
-        return 2;
-      }
-      journal_bytes = (size_t)tmp;
-      if (journal_bytes < 4096)
-        journal_bytes = 4096; // minimum
-    }
-    else if (strcmp(argv[i], "--hrl-entry-ratio") == 0 && i + 1 < argc)
-    {
-      if (kafs_parse_ratio_0_to_1(argv[++i], &hrl_entry_ratio) != 0)
-      {
-        fprintf(stderr, "invalid hrl-entry-ratio (expected 0<R<=1): %s\n", argv[i]);
-        return 2;
-      }
-    }
-    else if (strcmp(argv[i], "--trim-data-area") == 0)
-    {
-      trim_data_area = 1;
-    }
-    else if (strcmp(argv[i], "--yes") == 0)
-    {
-      assume_yes = 1;
-    }
-    else if (argv[i][0] != '-' && img == NULL)
-    {
-      img = argv[i];
-    }
-    else
+    if (mkfs_handle_arg(argc, argv, &i, opts) != 0)
     {
       usage(argv[0]);
       return 2;
     }
   }
-  if (!img)
+  if (!opts->img)
   {
     usage(argv[0]);
     return 2;
   }
+  return 0;
+}
+
+int main(int argc, char **argv)
+{
+  mkfs_options_t opts;
+
+  if (kafs_cli_exit_if_help(argc, argv, usage, argv[0]) == 0)
+    return 0;
+
+  mkfs_options_init(&opts);
+  if (mkfs_collect_args(argc, argv, &opts) != 0)
+    return 2;
+
+  const char *img = opts.img;
+  uint32_t format_version = opts.format_version;
+  kafs_logblksize_t log_blksize = opts.log_blksize;
+  kafs_blksize_t blksize = opts.blksize;
+  kafs_blksize_t blksizemask = opts.blksizemask;
+  off_t total_bytes = opts.total_bytes;
+  kafs_inocnt_t inocnt = opts.inocnt;
+  size_t journal_bytes = opts.journal_bytes;
+  double hrl_entry_ratio = opts.hrl_entry_ratio;
+  int size_arg_provided = opts.size_arg_provided;
+  int inocnt_arg_provided = opts.inocnt_arg_provided;
+  int trim_data_area = opts.trim_data_area;
+  int assume_yes = opts.assume_yes;
 
   struct stat st;
   int have_stat = (stat(img, &st) == 0);


### PR DESCRIPTION
## Summary
Refactor the first static-analysis wave across core CLI and filesystem paths to reduce complexity and improve maintainability without intentionally changing behavior.

## Changes
- simplify kafsctl path normalization and dispatch flow
- simplify kafs-info summary/reporting flow
- extract helper routines from complex kafs.c and fsck paths to reduce function complexity
- keep clone/static-analysis gates clean while preserving existing behavior

## Validation
- PASS: ./scripts/clones.sh
- PASS: ./scripts/static-checks.sh
- PASS: make -j4
- PASS: make check -j4

## Notes
- local merge check against master was clean with no conflicts
- worktree still has local untracked helper/artifact files, but they are not part of this PR