### PR TITLE
fix: resolve v5 tail smallfile write and validation regressions

### DIFF
--- a/src/kafs.c
+++ b/src/kafs.c
@@ -4184,8 +4184,8 @@ static int kafs_tailmeta_validate_slot_for_inode(struct kafs_context *ctx, kafs_
   kafs_off_t inode_size = kafs_ino_size_get(inoent);
   kafs_blksize_t blksize = kafs_sb_blksize_get(ctx->c_superblock);
   kafs_tailmeta_inode_desc_from_inode_taildesc(&desc, taildesc);
-  return kafs_tailmeta_inode_desc_matches_slot_for_inode(&desc, slot, class_bytes, ino, inode_size,
-                                                         blksize);
+  return kafs_tailmeta_inode_desc_matches_slot_for_inode(&desc, slot, class_bytes, ino,
+                                                         inode_size, blksize);
 }
 
 static int kafs_tailmeta_lookup_tail_slot(struct kafs_context *ctx, kafs_sinode_t *inoent,

--- a/src/kafs.c
+++ b/src/kafs.c
@@ -4081,6 +4081,28 @@ static int kafs_tailmeta_alloc_slot(struct kafs_context *ctx,
   return -ENOSPC;
 }
 
+static uint16_t kafs_tailmeta_max_tail_only_len(struct kafs_context *ctx)
+{
+  struct kafs_tailmeta_region_view view;
+  uint16_t max_len = 0;
+
+  if (ctx && kafs_tailmeta_region_view_get(ctx, &view) == 0)
+  {
+    uint32_t container_count = kafs_tailmeta_region_hdr_container_count_get(view.hdr);
+    for (uint32_t container_index = 0; container_index < container_count; ++container_index)
+    {
+      uint16_t class_bytes =
+          kafs_tailmeta_container_hdr_class_bytes_get(&view.containers[container_index]);
+      if (class_bytes > max_len)
+        max_len = class_bytes;
+    }
+  }
+
+  if (max_len == 0u)
+    max_len = kafs_tailmeta_default_class_bytes(KAFS_TAILMETA_DEFAULT_CLASS_COUNT - 1u);
+  return max_len;
+}
+
 static int kafs_tailmeta_release_slot(struct kafs_tailmeta_region_view *view,
                                       uint32_t container_index, uint16_t slot_index)
 {
@@ -4783,7 +4805,7 @@ static int kafs_pwrite_prepare_tail_layout(struct kafs_context *ctx, kafs_sinode
                                            kafs_off_t filesize, kafs_off_t filesize_new,
                                            int *completed_out)
 {
-  kafs_blksize_t blksize = kafs_sb_blksize_get(ctx->c_superblock);
+  uint16_t tail_only_max_len = kafs_tailmeta_max_tail_only_len(ctx);
   const kafs_sinode_taildesc_v5_t *taildesc = kafs_ctx_inode_taildesc_v5_const(ctx, inoent);
 
   *completed_out = 0;
@@ -4798,9 +4820,16 @@ static int kafs_pwrite_prepare_tail_layout(struct kafs_context *ctx, kafs_sinode
 
   if (taildesc && kafs_ino_taildesc_v5_layout_kind_get(taildesc) == KAFS_TAIL_LAYOUT_TAIL_ONLY)
   {
-    if (filesize_new < (kafs_off_t)blksize)
+    if (filesize_new <= (kafs_off_t)tail_only_max_len)
     {
       int rc = kafs_pwrite_try_tail_only_store(ctx, inoent, buf, size, offset, filesize_new);
+      if (rc == -ENOSPC)
+      {
+        rc = kafs_tailmeta_promote_tail_only_to_full_block(ctx, inoent);
+        if (rc < 0)
+          return rc;
+        return 0;
+      }
       if (rc < 0)
         return rc;
       *completed_out = 1;
@@ -4813,10 +4842,13 @@ static int kafs_pwrite_prepare_tail_layout(struct kafs_context *ctx, kafs_sinode
   }
 
   if (kafs_tailmeta_inode_is_regular_v5(ctx, inoent) &&
-      filesize_new > (kafs_off_t)KAFS_INODE_DIRECT_BYTES && filesize_new < (kafs_off_t)blksize &&
+      filesize_new > (kafs_off_t)KAFS_INODE_DIRECT_BYTES &&
+      filesize_new <= (kafs_off_t)tail_only_max_len &&
       filesize <= (kafs_off_t)KAFS_INODE_DIRECT_BYTES)
   {
     int rc = kafs_pwrite_try_tail_only_store(ctx, inoent, buf, size, offset, filesize_new);
+    if (rc == -ENOSPC)
+      return 0;
     if (rc < 0)
       return rc;
     *completed_out = 1;

--- a/src/kafs_tailmeta.h
+++ b/src/kafs_tailmeta.h
@@ -654,7 +654,7 @@ static inline int kafs_tailmeta_inode_desc_validate(const kafs_tailmeta_inode_de
     return -EPROTO;
   if (container_blo == (kafs_blkcnt_t)0)
     return -EPROTO;
-  if ((uint32_t)off + (uint32_t)len > (uint32_t)class_bytes)
+  if (off % class_bytes != 0u)
     return -EPROTO;
   return 0;
 }

--- a/tests/tests_tailmeta_parser.c
+++ b/tests/tests_tailmeta_parser.c
@@ -140,7 +140,7 @@ int main(void)
   kafs_tailmeta_inode_desc_flags_set(&desc, KAFS_TAILDESC_FLAG_PACKED_SMALL_FILE);
   kafs_tailmeta_inode_desc_fragment_len_set(&desc, 64);
   kafs_tailmeta_inode_desc_container_blo_set(&desc, 9);
-  kafs_tailmeta_inode_desc_fragment_off_set(&desc, 32);
+        kafs_tailmeta_inode_desc_fragment_off_set(&desc, 128);
   kafs_tailmeta_inode_desc_generation_set(&desc, 11);
   assert(kafs_tailmeta_inode_desc_validate(&desc, 128) == 0);
   assert(kafs_tailmeta_inode_desc_uses_tail_storage(&desc));
@@ -155,20 +155,20 @@ int main(void)
                 kafs_ino_taildesc_v5_flags_set(&inode_taildesc, KAFS_TAILDESC_FLAG_PACKED_SMALL_FILE);
                 kafs_ino_taildesc_v5_fragment_len_set(&inode_taildesc, 64);
                 kafs_ino_taildesc_v5_container_blo_set(&inode_taildesc, 9);
-                kafs_ino_taildesc_v5_fragment_off_set(&inode_taildesc, 32);
+                kafs_ino_taildesc_v5_fragment_off_set(&inode_taildesc, 128);
                 kafs_ino_taildesc_v5_generation_set(&inode_taildesc, 11);
                 assert(kafs_ino_taildesc_v5_uses_tail_storage(&inode_taildesc));
                 assert_inode_taildesc_fields(&inode_taildesc, KAFS_TAIL_LAYOUT_TAIL_ONLY,
-                                                                                                                                 KAFS_TAILDESC_FLAG_PACKED_SMALL_FILE, 64, 9, 32, 11);
+                                                                                                                                 KAFS_TAILDESC_FLAG_PACKED_SMALL_FILE, 64, 9, 128, 11);
 
                 kafs_tailmeta_inode_desc_from_inode_taildesc(&desc_from_inode, &inode_taildesc);
                 assert_tailmeta_inode_desc_fields(&desc_from_inode, KAFS_TAIL_LAYOUT_TAIL_ONLY,
-                                                                                                                                                        KAFS_TAILDESC_FLAG_PACKED_SMALL_FILE, 64, 9, 32, 11);
+                                                                                                                                                        KAFS_TAILDESC_FLAG_PACKED_SMALL_FILE, 64, 9, 128, 11);
 
                 kafs_ino_taildesc_v5_init(&inode_taildesc_roundtrip);
                 kafs_tailmeta_inode_desc_to_inode_taildesc(&inode_taildesc_roundtrip, &desc_from_inode);
                 assert_inode_taildesc_fields(&inode_taildesc_roundtrip, KAFS_TAIL_LAYOUT_TAIL_ONLY,
-                                                                                                                                 KAFS_TAILDESC_FLAG_PACKED_SMALL_FILE, 64, 9, 32, 11);
+                                                                                                                                 KAFS_TAILDESC_FLAG_PACKED_SMALL_FILE, 64, 9, 128, 11);
         }
 
   memset(&slot, 0, sizeof(slot));
@@ -209,9 +209,9 @@ int main(void)
           KAFS_TAILCHECK_OWNER_MISMATCH) != 0);
   kafs_tailmeta_slot_owner_ino_set(&slot, 7);
 
-  kafs_tailmeta_inode_desc_fragment_off_set(&desc, 96);
+        kafs_tailmeta_inode_desc_fragment_off_set(&desc, 96);
   assert(kafs_tailmeta_inode_desc_validate(&desc, 128) != 0);
-  kafs_tailmeta_inode_desc_fragment_off_set(&desc, 32);
+        kafs_tailmeta_inode_desc_fragment_off_set(&desc, 128);
 
   kafs_tailmeta_inode_desc_layout_kind_set(&desc, KAFS_TAIL_LAYOUT_MIXED_FULL_TAIL);
   kafs_tailmeta_inode_desc_flags_set(&desc, KAFS_TAILDESC_FLAG_FINAL_TAIL);

--- a/tests/tests_v5_tail_smallfile_smoketest.c
+++ b/tests/tests_v5_tail_smallfile_smoketest.c
@@ -433,6 +433,9 @@ int main(void)
   for (int index = 0; index < k_tail_class_fill_count; ++index)
   {
     char fill_verify[k_tail_class_fill_size];
+    ssize_t nread;
+    struct stat st_fill;
+    int saved_errno = 0;
 
     snprintf(path, sizeof(path), "%s/fill-%d", mnt, index);
     fd = open(path, O_RDONLY);
@@ -442,11 +445,18 @@ int main(void)
       kafs_test_stop_kafs(mnt, srv);
       return 1;
     }
-    if (read(fd, fill_verify, sizeof(fill_verify)) != (ssize_t)sizeof(fill_verify) ||
+    errno = 0;
+    nread = read(fd, fill_verify, sizeof(fill_verify));
+    saved_errno = errno;
+    if (fstat(fd, &st_fill) != 0)
+      memset(&st_fill, 0, sizeof(st_fill));
+    if (nread != (ssize_t)sizeof(fill_verify) ||
         memcmp(fill_verify, fill_payload, sizeof(fill_payload)) != 0)
     {
-      tlogf("readback mismatch on fill-%d", index);
+      tlogf("readback mismatch on fill-%d nread=%zd st_size=%lld errno=%d(%s)", index, nread,
+        (long long)st_fill.st_size, saved_errno, strerror(saved_errno));
       close(fd);
+      kafs_test_dump_log(k_mount_options.log_path, "fill readback mismatch");
       kafs_test_stop_kafs(mnt, srv);
       return 1;
     }
@@ -463,6 +473,7 @@ int main(void)
     }
   }
 
+  snprintf(path, sizeof(path), "%s/keep", mnt);
   if (unlink(path) != 0)
   {
     tlogf("unlink keep failed: %s", strerror(errno));

--- a/tests/tests_v5_tail_smallfile_smoketest.c
+++ b/tests/tests_v5_tail_smallfile_smoketest.c
@@ -297,6 +297,13 @@ static const kafs_test_mount_options_t k_mount_options = {
 
 int main(void)
 {
+  enum
+  {
+    k_oversized_small_size = 3073,
+    k_tail_class_fill_size = 544,
+    k_tail_class_fill_count = 4,
+  };
+
   if (kafs_test_enter_tmpdir("v5_tail_smallfile") != 0)
     return 77;
   if (access("/dev/fuse", R_OK | W_OK) != 0)
@@ -356,6 +363,105 @@ int main(void)
     return 1;
   }
   close(fd);
+
+  snprintf(path, sizeof(path), "%s/nearblk", mnt);
+  fd = open(path, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+  if (fd < 0)
+  {
+    tlogf("create nearblk failed: %s", strerror(errno));
+    kafs_test_stop_kafs(mnt, srv);
+    return 1;
+  }
+  char near_payload[k_oversized_small_size];
+  for (size_t i = 0; i < sizeof(near_payload); ++i)
+    near_payload[i] = (char)('A' + (i % 26));
+  if (write(fd, near_payload, sizeof(near_payload)) != (ssize_t)sizeof(near_payload))
+  {
+    tlogf("write nearblk failed: %s", strerror(errno));
+    close(fd);
+    kafs_test_stop_kafs(mnt, srv);
+    return 1;
+  }
+  close(fd);
+
+  fd = open(path, O_RDONLY);
+  if (fd < 0)
+  {
+    tlogf("open nearblk for read failed: %s", strerror(errno));
+    kafs_test_stop_kafs(mnt, srv);
+    return 1;
+  }
+  char near_verify[k_oversized_small_size];
+  if (read(fd, near_verify, sizeof(near_verify)) != (ssize_t)sizeof(near_verify) ||
+      memcmp(near_verify, near_payload, sizeof(near_payload)) != 0)
+  {
+    tlogf("readback mismatch on nearblk");
+    close(fd);
+    kafs_test_stop_kafs(mnt, srv);
+    return 1;
+  }
+  close(fd);
+  if (unlink(path) != 0)
+  {
+    tlogf("unlink nearblk failed: %s", strerror(errno));
+    kafs_test_stop_kafs(mnt, srv);
+    return 1;
+  }
+
+  char fill_payload[k_tail_class_fill_size];
+  for (size_t i = 0; i < sizeof(fill_payload); ++i)
+    fill_payload[i] = (char)('0' + (i % 10));
+  for (int index = 0; index < k_tail_class_fill_count; ++index)
+  {
+    snprintf(path, sizeof(path), "%s/fill-%d", mnt, index);
+    fd = open(path, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    if (fd < 0)
+    {
+      tlogf("create fill-%d failed: %s", index, strerror(errno));
+      kafs_test_stop_kafs(mnt, srv);
+      return 1;
+    }
+    if (write(fd, fill_payload, sizeof(fill_payload)) != (ssize_t)sizeof(fill_payload))
+    {
+      tlogf("write fill-%d failed: %s", index, strerror(errno));
+      close(fd);
+      kafs_test_stop_kafs(mnt, srv);
+      return 1;
+    }
+    close(fd);
+  }
+  for (int index = 0; index < k_tail_class_fill_count; ++index)
+  {
+    char fill_verify[k_tail_class_fill_size];
+
+    snprintf(path, sizeof(path), "%s/fill-%d", mnt, index);
+    fd = open(path, O_RDONLY);
+    if (fd < 0)
+    {
+      tlogf("open fill-%d for read failed: %s", index, strerror(errno));
+      kafs_test_stop_kafs(mnt, srv);
+      return 1;
+    }
+    if (read(fd, fill_verify, sizeof(fill_verify)) != (ssize_t)sizeof(fill_verify) ||
+        memcmp(fill_verify, fill_payload, sizeof(fill_payload)) != 0)
+    {
+      tlogf("readback mismatch on fill-%d", index);
+      close(fd);
+      kafs_test_stop_kafs(mnt, srv);
+      return 1;
+    }
+    close(fd);
+  }
+  for (int index = 0; index < k_tail_class_fill_count; ++index)
+  {
+    snprintf(path, sizeof(path), "%s/fill-%d", mnt, index);
+    if (unlink(path) != 0)
+    {
+      tlogf("unlink fill-%d failed: %s", index, strerror(errno));
+      kafs_test_stop_kafs(mnt, srv);
+      return 1;
+    }
+  }
 
   if (unlink(path) != 0)
   {


### PR DESCRIPTION
## Summary
- fix false ENOSPC on v5 tail writes for small files near the tail-only limit and when tail slots are exhausted
- fix the tail metadata validation mismatch that caused Protocol error on packed smallfile readback
- keep the v5 tail smallfile regression coverage and fix the test cleanup path bug

## Changes
- restrict tail-only placement to the runtime tail-only maximum length and fall back to full blocks when tail slot allocation returns ENOSPC
- align tail descriptor offset validation with the stored slot offset semantics in tail metadata
- extend the v5 tail smallfile smoke test with 3073B and repeated 544B cases
- fix the smoke test cleanup to unlink keep through the correct path

## Impact
- fixes rsync migration failures caused by false ENOSPC during v5 smallfile writes
- fixes a regression where packed smallfile readback could fail with Protocol error
- no format or migration procedure changes

## Validation
- PASS: make -C src kafs
- PASS: make -C tests v5_tail_smallfile_smoketest
- PASS: ./tests/v5_tail_smallfile_smoketest
- PASS: ./scripts/clones.sh
- PASS: ./scripts/static-checks.sh
- PASS: rsync -aH --delete --info=stats2,progress2 /home/katsumata-m/kscr_selfhost/ /home/katsumata-m/kscr_selfhost_v5/

Closes #176
